### PR TITLE
Always pass IO objects to Marshal.load/Marshal.dump

### DIFF
--- a/lib/yard/registry_store.rb
+++ b/lib/yard/registry_store.rb
@@ -198,14 +198,14 @@ module YARD
     end
     
     def load_yardoc_old
-      @store, @proxy_types = *Marshal.load(File.read(@file))
+      @store, @proxy_types = *(File.open!(@file) { |f| Marshal.load(f) })
     end
     
     private
     
     def load_proxy_types
       return unless File.file?(proxy_types_path)
-      @proxy_types = Marshal.load(File.read(proxy_types_path))
+      @proxy_types = File.open!(proxy_types_path) { |f| Marshal.load(f) }
     end
     
     def load_checksums
@@ -227,7 +227,7 @@ module YARD
     end
     
     def write_proxy_types
-      File.open!(proxy_types_path, 'wb') {|f| f.write(Marshal.dump(@proxy_types)) }
+      File.open!(proxy_types_path, "w") {|f| Marshal.dump(@proxy_types, f) }
     end
     
     def write_checksums

--- a/lib/yard/serializers/yardoc_serializer.rb
+++ b/lib/yard/serializers/yardoc_serializer.rb
@@ -59,16 +59,21 @@ module YARD
         end
         File.join('objects', path)
       end
-      
+
+      # Serializes object with data to its serialized path (prefixed by the +#basepath+).
+      #
+      # @return [String] the written data (for chaining)
       def serialize(object)
-        super(object, dump(object))
+        path = File.join(basepath, *serialized_path(object))
+        log.debug "Serializing to #{path}"
+        File.open!(path, "w") {|f| Marshal.dump(object, f) }
       end
       
       def deserialize(path, is_path = false)
         path = File.join(basepath, serialized_path(path)) unless is_path
         if File.file?(path)
           log.debug "Deserializing #{path}..."
-          Marshal.load(File.read_binary(path))
+          File.open!(path) { |f| Marshal.load(f) }
         else
           log.debug "Could not find #{path}"
           nil
@@ -76,9 +81,9 @@ module YARD
       end
       
       private
-      
-      def dump(object)
-        Marshal.dump(internal_dump(object, true))
+
+      def dump(object, io)
+        Marshal.dump(internal_dump(object, true), io)
       end
       
       def internal_dump(object, first_object = false)

--- a/spec/registry_store_spec.rb
+++ b/spec/registry_store_spec.rb
@@ -7,8 +7,10 @@ describe YARD::RegistryStore do
     it "should load old yardoc format if .yardoc is a file" do
       File.should_receive(:directory?).with('foo').and_return(false)
       File.should_receive(:file?).with('foo').and_return(true)
-      File.should_receive(:read).with('foo').and_return('FOO')
-      Marshal.should_receive(:load).with('FOO')
+
+      io = StringIO.new('FOO')
+      File.should_receive(:open!).with('foo').and_yield(io)
+      Marshal.should_receive(:load).with(io)
 
       @store.load('foo')
     end
@@ -25,7 +27,10 @@ describe YARD::RegistryStore do
     it "should return true if .yardoc is loaded (file)" do
       File.should_receive(:directory?).with('myyardoc').and_return(false)
       File.should_receive(:file?).with('myyardoc').and_return(true)
-      File.should_receive(:read).with('myyardoc').and_return(Marshal.dump(''))
+
+      io = StringIO.new(Marshal.dump(''))
+      File.should_receive(:open!).with('myyardoc').and_yield(io)
+
       @store.load('myyardoc').should == true
     end
 
@@ -62,7 +67,10 @@ describe YARD::RegistryStore do
       File.should_receive(:file?).with('foo/checksums').and_return(false)
       File.should_receive(:file?).with('foo/proxy_types').and_return(true)
       File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
-      File.should_receive(:read).with('foo/proxy_types').and_return(Marshal.dump({'a' => 'b'}))
+
+      io = StringIO.new(Marshal.dump({'a' => 'b'}))
+      File.should_receive(:open!).with('foo/proxy_types').and_yield(io)
+
       @store.load('foo').should == true
       @store.proxy_types.should == {'a' => 'b'}
     end
@@ -72,7 +80,10 @@ describe YARD::RegistryStore do
       File.should_receive(:file?).with('foo/checksums').and_return(false)
       File.should_receive(:file?).with('foo/proxy_types').and_return(false)
       File.should_receive(:file?).with('foo/objects/root.dat').and_return(true)
-      File.should_receive(:read_binary).with('foo/objects/root.dat').and_return(Marshal.dump('foo'))
+
+      io = StringIO.new(Marshal.dump('foo'))
+      File.should_receive(:open!).with('foo/objects/root.dat').and_yield(io)
+
       @store.load('foo').should == true
       @store.root.should == 'foo'
     end


### PR DESCRIPTION
I changed all calls to Marshal.load/Marshal.dump to always make use of IO objects. This should make sure that we don't have any problems with non-binary writes of marshal data, as the marshal methods make sure that data is always written in binary mode.

Also, this should be a tad faster and use a tiny bit less memory, as the files don't have to be read into memory first on deserializing and objects don't get marshalled into a string first before they're written.

I'm not happy about the changes I had to make to YardocSerializer#serialize and YardocSerializer#dump, as YardocSerializer#serialize now duplicates FileSystemSerializer#serialize and YardocSerializer#dump now takes a second argument.
