### PR TITLE
Eliminate warnings that clutter gem installs on Ruby <= v1.8.7

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -21,7 +21,7 @@ unless defined? Gem::DocManager.load_yardoc
       @has_rdoc && @has_rdoc != 'yard'
     end
   
-    alias has_yardoc? has_yardoc
+    alias :has_yardoc? :has_yardoc
   end
 
   class Gem::DocManager
@@ -84,8 +84,8 @@ unless defined? Gem::DocManager.load_yardoc
       say "Building YARD (yri) index for #{@spec.full_name}..."
       run_yardoc '-c', '-n'
     end
-    alias install_ri_yard_orig install_ri
-    alias install_ri install_ri_yard
+    alias :install_ri_yard_orig :install_ri
+    alias :install_ri :install_ri_yard
 
     def install_rdoc_yard
       if @spec.has_rdoc?
@@ -94,7 +94,7 @@ unless defined? Gem::DocManager.load_yardoc
         install_yardoc
       end
     end
-    alias install_rdoc_yard_orig install_rdoc
-    alias install_rdoc install_rdoc_yard
+    alias :install_rdoc_yard_orig :install_rdoc
+    alias :install_rdoc :install_rdoc_yard
   end
 end

--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -276,8 +276,8 @@ module YARD
           super
         end
       end
-      alias == equal?
-      alias eql? equal?
+      alias :== :equal?
+      alias :eql? :equal?
       
       # @return [Integer] the object's hash value (for equality checking)
       def hash; path.hash end

--- a/lib/yard/code_objects/proxy.rb
+++ b/lib/yard/code_objects/proxy.rb
@@ -99,8 +99,8 @@ module YARD
           end
         end
       end
-      alias to_s path
-      alias to_str path
+      alias :to_s :path
+      alias :to_str :path
     
       # @return [Boolean] 
       def is_a?(klass)
@@ -137,7 +137,7 @@ module YARD
           false
         end
       end
-      alias == equal?
+      alias :== :equal?
       
       # @return [Integer] the object's hash value (for equality checking)
       def hash; path.hash end

--- a/lib/yard/core_ext/hash.rb
+++ b/lib/yard/core_ext/hash.rb
@@ -9,7 +9,7 @@ class Hash
         create_186(*args)
       end
     end
-    alias create_186 []
-    alias [] create
+    alias :create_186 :[]
+    alias :[] :create
   end
 end if RUBY_VERSION < "1.8.7"

--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -68,7 +68,7 @@ module YARD
       @all = content
       super parse_comments(content)
     end
-    alias all= replace
+    alias :all= :replace
 
     # @endgroup
     

--- a/lib/yard/parser/ruby/ast_node.rb
+++ b/lib/yard/parser/ruby/ast_node.rb
@@ -40,9 +40,9 @@ module YARD
       class AstNode < Array
         attr_accessor :docstring, :docstring_range, :source, :group
         attr_writer :source_range, :line_range, :file, :full_source
-        alias comments docstring
-        alias comments_range docstring_range
-        alias to_s source
+        alias :comments :docstring
+        alias :comments_range :docstring_range
+        alias :to_s :source
         
         # @return [Symbol] the node's unique symbolic type
         attr_accessor :type

--- a/lib/yard/parser/ruby/legacy/statement.rb
+++ b/lib/yard/parser/ruby/legacy/statement.rb
@@ -19,7 +19,7 @@ module YARD
           RubyToken::TkBlockContents === token ? (include_block ? block.to_s : '') : token.text
         end.join
       end
-      alias source to_s
+      alias :source :to_s
       
       def inspect
         l = line - 1

--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -18,7 +18,7 @@ module YARD
       # @since 0.5.6
       class RipperParser < Ripper
         attr_reader :ast, :charno, :comments, :file, :tokens
-        alias root ast
+        alias :root :ast
 
         def initialize(source, filename, *args)
           super
@@ -251,7 +251,7 @@ module YARD
         def on_body_stmt(*args)
           args.compact.size == 1 ? args.first : AstNode.new(:list, args)
         end
-        alias on_bodystmt on_body_stmt
+        alias :on_bodystmt :on_body_stmt
         
         def on_assoc_new(*args)
           AstNode.new(:assoc, args)

--- a/lib/yard/registry_store.rb
+++ b/lib/yard/registry_store.rb
@@ -55,8 +55,8 @@ module YARD
       end
     end
     
-    alias [] get
-    alias []= put
+    alias :[] :get
+    alias :[]= :put
     
     def delete(key) @store.delete(key.to_sym) end
     

--- a/lib/yard/server/library_version.rb
+++ b/lib/yard/server/library_version.rb
@@ -29,8 +29,8 @@ module YARD
         other.is_a?(LibraryVersion) && other.name == name && 
           other.version == version && other.yardoc_file == yardoc_file
       end
-      alias == eql?
-      alias equal? eql?
+      alias :== :eql?
+      alias :equal? :eql?
       
       def prepare!
         return if yardoc_file

--- a/lib/yard/server/rack_adapter.rb
+++ b/lib/yard/server/rack_adapter.rb
@@ -45,6 +45,6 @@ end
 
 # @private
 class Rack::Request
-  alias query params
+  alias :query :params
   def xhr?; (env['HTTP_X_REQUESTED_WITH'] || "").downcase == "xmlhttprequest" end
 end

--- a/lib/yard/tags/overload_tag.rb
+++ b/lib/yard/tags/overload_tag.rb
@@ -34,7 +34,7 @@ module YARD
       def is_a?(other)
         object.is_a?(other) || self.class >= other.class || false
       end
-      alias kind_of? is_a?
+      alias :kind_of? :is_a?
       
       private
 

--- a/lib/yard/templates/section.rb
+++ b/lib/yard/templates/section.rb
@@ -46,7 +46,7 @@ module YARD
       def push(*args)
         super(*parse_sections(args))
       end
-      alias << push
+      alias :<< :push
       
       def unshift(*args)
         super(*parse_sections(args))

--- a/lib/yard/verifier.rb
+++ b/lib/yard/verifier.rb
@@ -93,7 +93,7 @@ module YARD
     
     # @return [CodeObjects::Base] the current object being tested
     attr_reader :object
-    alias o object
+    alias :o :object
     
     private
     

--- a/spec/templates/method_spec.rb
+++ b/spec/templates/method_spec.rb
@@ -27,7 +27,7 @@ describe YARD::Templates::Engine.template(:default, :method) do
         # @raise [Exception] hi!
         # @deprecated for great justice
         def m(x) end
-        alias x m
+        alias :x :m
       eof
     end
     

--- a/spec/templates/module_spec.rb
+++ b/spec/templates/module_spec.rb
@@ -27,7 +27,7 @@ describe YARD::Templates::Engine.template(:default, :module) do
         
         def self.a; end
         def a; end
-        alias b a
+        alias :b :a
 
         # @overload test_overload(a)
         #   hello2


### PR DESCRIPTION
Thanks for a great documentation tool, Loren!

There are ‘alias’ statements in the YARD source that receive bare arguments rather than symbols:

```
alias foo bar
```

rather than

```
alias :foo :bar
```

This causes the RDoc parser in Ruby v1.8.7 and earlier to issue warnings. These warnings clutter stdout during gem installs. Because it happens during YARD gem installs, dependent gems are also affected.
