### PR TITLE
Fix for --list-undoc

### DIFF
--- a/lib/yard/cli/stats.rb
+++ b/lib/yard/cli/stats.rb
@@ -67,7 +67,7 @@ module YARD
       
       # Prints list of undocumented objects
       def print_undocumented_objects
-        return unless @undoc_list
+        return if @undoc_list.empty?
         puts
         puts "Undocumented Objects:"
         


### PR DESCRIPTION
`yard stats --list-undoc` will raise an error if there is nothing undocumented:

```
/Library/Ruby/Gems/1.8/gems/yard-0.6.1/lib/yard/cli/stats.rb:75:in `print_undocumented_objects': undefined method `path' for nil:NilClass (NoMethodError)
  from /Library/Ruby/Gems/1.8/gems/yard-0.6.1/lib/yard/cli/stats.rb:46:in `run'
  from /Library/Ruby/Gems/1.8/gems/yard-0.6.1/lib/yard/cli/command.rb:13:in `run'
  from /Library/Ruby/Gems/1.8/gems/yard-0.6.1/lib/yard/cli/command_parser.rb:66:in `run'
  from /Library/Ruby/Gems/1.8/gems/yard-0.6.1/lib/yard/cli/command_parser.rb:48:in `run'
  from /Library/Ruby/Gems/1.8/gems/yard-0.6.1/bin/yard:4
  from /usr/bin/yard:19:in `load'
  from /usr/bin/yard:19
```

The attached commit includes a fix for this issue.
