### PR TITLE
yard server -m problem

### DIFF
--- a/lib/yard/server/commands/library_command.rb
+++ b/lib/yard/server/commands/library_command.rb
@@ -62,7 +62,7 @@ module YARD
                 yardoc.parse_arguments
               end
               yardoc.options.delete(:serializer)
-              yardoc.options[:files].unshift(*Dir.glob(library.source_path + '/README*'))
+              yardoc.options[:files].unshift(*Dir.glob('README*'))
               options.update(yardoc.options.to_hash)
             end
           end


### PR DESCRIPTION
Whenever I run yard "server -m lib1 yard1 lib2 yard2" I getting exceptions like:

Errno::ENOENT: No such file or directory - lib1

And the pages don't load

This lock fixes the threads from stepping all over each other.
