### PR TITLE
ToC breaking on heading with quotes

### DIFF
--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -152,7 +152,7 @@ function generateTOC() {
     show = true;
     var thisTag = parseInt(this.tagName[1]);
     if (this.id.length == 0) {
-      var proposedId = $(this).text().replace(/[^a-z0-9:'"\.()=-]/ig, '_');
+      var proposedId = $(this).text().replace(/[^a-z0-9:\.()=-]/ig, '_');
       if ($('#' + proposedId).length > 0) proposedId += counter++;
       this.id = proposedId;
     }


### PR DESCRIPTION
Hi
Only a small thing - the javascript that generates the table of contents was breaking for headers that have quotes in.
I included quotes in the characters that get transformed into underscores when generating the id to link to and it seems to work.
Nice feature by the way. Keep up the great work!!
Mark
