### PR TITLE
Keyboard Shortcuts

### DIFF
--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -93,8 +93,9 @@ function keyboardShortcuts() {
   if (window.top.frames.main) return;
   $(document).keypress(function(evt) {
     if (evt.altKey || evt.ctrlKey || evt.metaKey || evt.shiftKey) return;
-    if (evt.originalTarget.nodeName == "INPUT" || 
-        evt.originalTarget.nodeName == "TEXTAREA") return;
+    if(typeof evt.orignalTarget !== "undefined" &&  
+        (evt.originalTarget.nodeName == "INPUT" || 
+        evt.originalTarget.nodeName == "TEXTAREA")) return;
     switch (evt.charCode) {
       case 67: case 99:  $('#class_list_link').click(); break;  // 'c'
       case 77: case 109: $('#method_list_link').click(); break; // 'm'


### PR DESCRIPTION
After generating the HTML documentation I noticed that I was getting errors in Chrome.  I found that the shortcut keys to open the class, methods, and file view unavailable.  This was because of an error with the 'originalTarget' being undefined.

This simply adds a check before finding out of it is a input or textarea.
