### PR TITLE
Method Summary lists (when collapsed) have a wrapping issue in FF, and a clipping issue in Chrome

### DIFF
--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -168,7 +168,7 @@ ul.summary li { margin-bottom: 5px; }
   -moz-border-radius: 3px; -webkit-border-radius: 3px; 
 }
 .summary_signature:hover { background: #eeeeff; cursor: pointer; }
-ul.summary.compact li { display: inline-block; margin-right: 0px 5px 0px 0px; line-height: 2.6em;}
+ul.summary.compact li { display: inline-block; margin: 0px 5px 0px 0px; line-height: 2.6em;}
 ul.summary.compact .summary_signature { padding: 5px 7px; padding-right: 4px; }
 #content .summary_signature:hover a:link, 
 #content .summary_signature:hover a:visited {


### PR DESCRIPTION
At the top of class files, like [GMP::Z](http://rubydoc.info/gems/gmp/0.5.41/GMP/Z), there are two sections, Class Method Summary and Instance Method Summary. This bug applies the same to both. This bug is seen when a section is collapsed. In Firefox (3.6.+), there is a wrapping issue. In Chrome, there is a clipping issue. This commit fixes both.

I have tested the fix in both Firefox 3.6.12 and Chrome 7.0 (as if the Chrome version numbers meant anything). Spacing, padding, etc. is not altered; the number of method names that fit on a line is unchanged.

I have _not_ tested Safari, or IE. I'm not even sure if either issue exists on those.
