### PR TITLE
Config class lookup

### DIFF
--- a/lib/yard/cli/yri.rb
+++ b/lib/yard/cli/yri.rb
@@ -49,7 +49,7 @@ module YARD
       def run(*args)
         optparse(*args)
         
-        if Config::CONFIG['host_os'] =~ /mingw|win32/
+        if ::Config::CONFIG['host_os'] =~ /mingw|win32/
           @serializer ||= YARD::Serializers::StdoutSerializer.new
         else
           @serializer ||= YARD::Serializers::ProcessSerializer.new('less')


### PR DESCRIPTION
This fixes the `uninitialized constant YARD::CLI::Config::CONFIG (NameError)` exception
