### PR TITLE
Fix line through for deprecated methods

### DIFF
--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -23,7 +23,7 @@ h2 small { font-weight: normal; font-size: 0.7em; display: block; float: right; 
 .docstring h1 { font-size: 1.2em; }
 .docstring h2 { font-size: 1.1em; }
 .docstring h3, .docstring h4 { font-size: 1em; border-bottom: 0; padding-top: 10px; }
-.docstring .object_link { font-family: monospace; }
+.summary_desc .object_link, .docstring .object_link { font-family: monospace; }
 
 .note { 
   color: #222;
@@ -252,8 +252,8 @@ li.r2 { background: #fafafa; }
   -webkit-border-radius: 2px;
 }
 
-#content ul.summary li.deprecated a:link, 
-#content ul.summary li.deprecated a:visited { text-decoration: line-through; font-style: italic; }
+#content ul.summary li.deprecated .summary_signature a:link,
+#content ul.summary li.deprecated .summary_signature a:visited { text-decoration: line-through; font-style: italic; }
 
 #toc { 
   padding: 20px; padding-right: 30px; border: 1px solid #ddd; float: right; background: #fff; margin-left: 20px; margin-bottom: 20px;


### PR DESCRIPTION
For quite some time, alternatives specified in a @deprecated tag have been rendered struck through. This branch fixes that issue (and also renders the object references using a monospaced font.).

Example of such a tag:

```
# @deprecated See {OtherClass#other_method} instead
```
