### PR TITLE
Specs using yaml should require yaml

### DIFF
--- a/spec/cli/config_spec.rb
+++ b/spec/cli/config_spec.rb
@@ -1,5 +1,7 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
+require 'yaml'
+
 describe YARD::CLI::Config do
   before do
     @config = YARD::CLI::Config.new

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,5 +1,7 @@
 require File.join(File.dirname(__FILE__), "spec_helper")
 
+require 'yaml'
+
 describe YARD::Config do
   describe '.load' do
     before do


### PR DESCRIPTION
Config. specs fail with this error:

  1) YARD::CLI::Config Listing configuration should accept --list
     Failure/Error: YAML.should_receive(:dump).twice.and_return("--- foo\nbar\nbaz")
     NameError:
       uninitialized constant RSpec::Core::ExampleGroup::Nested_2::Nested_1::YAML
     # ./spec/cli/config_spec.rb:17:in `block (3 levels) in <top (required)>'

It's easy to reproduce on any mache by explicitly run

  rspec ./spec/cli/config_spec.rb

and

  rspec ./spec/config_spec.rb

These fail can be passed when other specs runned before that requires yaml. Or can be failed if ran earlier than yaml was loaded.
