### PR TITLE
Specs should pass when autoloaded plugins installed in system

### DIFF
--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -90,6 +90,7 @@ describe YARD::Config do
     it "should load gem plugins if :load_plugins is true" do
       File.should_receive(:file?).with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).and_return(false)
       YARD::Config.stub!(:options).and_return(:load_plugins => true, :ignored_plugins => [], :autoload_plugins => [])
+      YARD::Config.stub!(:load_plugin)
       YARD::Config.should_receive(:require).with('rubygems')
       YARD::Config.load_plugins
     end


### PR DESCRIPTION
rake specs failed on my system when YARD plugins installed on my system.

It was reproduced by simply:

gem install yard-rspec
rake specs

  3) YARD::Config.load_plugins should load gem plugins if :load_plugins is true
     Failure/Error: YARD::Config.load_plugins
       <YARD::Config (class)> received :require with unexpected arguments
         expected: ("rubygems")
              got: ("yard-rspec")
     # ./lib/yard/config.rb:124:in `load_plugin'
     # ./lib/yard/config.rb:140:in`block in load_gem_plugins'
     # ./lib/yard/config.rb:137:in `each'
     # ./lib/yard/config.rb:137:in`load_gem_plugins'
     # ./lib/yard/config.rb:109:in `load_plugins'
     # ./spec/config_spec.rb:94:in`block (3 levels) in <top (required)>'
