### PR TITLE
This fixes RDoc warnings

### DIFF
--- a/lib/yard/core_ext/hash.rb
+++ b/lib/yard/core_ext/hash.rb
@@ -9,7 +9,7 @@ class Hash
         create_186(*args)
       end
     end
-    alias create_186 []
-    alias [] create
+    alias :create_186 :[]
+    alias :[] :create
   end
 end if RUBY_VERSION < "1.8.7"


### PR DESCRIPTION
This fixes warnings on 
gem install ripper yard

on fresh rvm REE 1.8.7 (2011-03) installation.
