### PR TITLE
Use Bundler to simplify development process. ripper gem will be installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ _Yardoc
 /pkg
 /doc
 /coverage
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,6 @@
+source :rubygems
+
+gemspec
+
+gem 'ripper', :platforms => [:ruby_18, :mri_18]
+

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+require 'rubygems'
+
 require File.dirname(__FILE__) + '/lib/yard'
 require File.dirname(__FILE__) + '/lib/yard/rubygems/specification'
 require 'rbconfig'
@@ -6,18 +8,14 @@ YARD::VERSION.replace(ENV['YARD_VERSION']) if ENV['YARD_VERSION']
 WINDOWS = (Config::CONFIG['host_os'] =~ /mingw|win32|cygwin/ ? true : false) rescue false
 SUDO = WINDOWS ? '' : 'sudo'
 
+begin
+  require 'bundler'
+  Bundler::GemHelper.install_tasks
+rescue LoadError
+  $stderr.puts "Bundler not available. Install it with: gem install bundler"
+end
+
 task :default => :specs
-
-desc "Builds the gem"
-task :gem do
-  load 'yard.gemspec'
-  Gem::Builder.new(SPEC).build
-end
-
-desc "Installs the gem"
-task :install => :gem do 
-  sh "#{SUDO} gem install yard-#{YARD::VERSION}.gem --no-rdoc --no-ri"
-end
 
 desc 'Run spec suite'
 task :suite do
@@ -83,3 +81,4 @@ end
 YARD::Rake::YardocTask.new do |t|
   t.options += ['--title', "YARD #{YARD::VERSION} Documentation"]
 end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,4 @@
 require "rubygems"
-begin
-  require "rspec"
-rescue LoadError
-  require "spec"
-end
 
 require File.expand_path(File.join(File.dirname(__FILE__), '..', 'lib', 'yard'))
 

--- a/yard.gemspec
+++ b/yard.gemspec
@@ -1,5 +1,5 @@
 require File.expand_path(File.dirname(__FILE__) + '/lib/yard')
-SPEC = Gem::Specification.new do |s|
+Gem::Specification.new do |s|
   s.name          = "yard"
   s.summary       = "Documentation tool for consistent and usable documentation in Ruby." 
   s.description   = <<-eof
@@ -9,7 +9,6 @@ SPEC = Gem::Specification.new do |s|
     custom Ruby constructs such as custom class level definitions.
   eof
   s.version       = YARD::VERSION
-  s.date          = "2011-04-06"
   s.author        = "Loren Segal"
   s.email         = "lsegal@soen.ca"
   s.homepage      = "http://yardoc.org"
@@ -19,4 +18,10 @@ SPEC = Gem::Specification.new do |s|
   s.executables   = ['yard', 'yardoc', 'yri']
   s.has_rdoc      = 'yard'
   s.rubyforge_project = 'yard'
+  s.add_development_dependency('bundler', '>= 1.0')
+  s.add_development_dependency('rspec-core')
+  s.add_development_dependency('rspec-expectations')
+  s.add_development_dependency('rspec-mocks')
+  s.add_development_dependency('rake')
+
 end


### PR DESCRIPTION
Use Bundler to simplify development process. 

ripper gem will be installed automatically on 1.8 platforms.

Use have additional rake commands to release the software.
