### PR TITLE
Customizable JS, CSS, and menus

### DIFF
--- a/templates/default/fulldoc/html/css/full_list.css
+++ b/templates/default/fulldoc/html/css/full_list.css
@@ -51,3 +51,6 @@ li.collapsed.clicked a.toggle { background-position: top right; }
 #full_list.insearch li.found { display: list-item; padding-left: 10px; }
 #full_list.insearch li a.toggle { display: none; }
 #full_list.insearch li small.search_info { display: block; }
+
+#nav a:after { content: " | "; }
+#nav a:last-child:after { content: " "; }

--- a/templates/default/fulldoc/html/full_list.erb
+++ b/templates/default/fulldoc/html/full_list.erb
@@ -3,10 +3,14 @@
 <html>
   <head>
     <meta name="Content-Type" content="text/html; charset=<%= charset %>" />
-    <link rel="stylesheet" href="css/full_list.css" type="text/css" media="screen" charset="utf-8" />
-    <link rel="stylesheet" href="css/common.css" type="text/css" media="screen" charset="utf-8" />
-    <script type="text/javascript" charset="utf-8" src="js/jquery.js"></script>
-    <script type="text/javascript" charset="utf-8" src="js/full_list.js"></script>
+    <% stylesheets_full_list.each do |stylesheet| %>
+      <link rel="stylesheet" href="<%= url_for(stylesheet) %>" type="text/css" media="screen" charset="utf-8" />
+    <% end %>
+    
+    <% javascripts_full_list.each do |javascript| %>
+      <script type="text/javascript" charset="utf-8" src="<%= url_for(javascript) %>"></script>
+    <% end %>
+    
     <base id="base_target" target="_parent" />
   </head>
   <body>
@@ -19,16 +23,15 @@
     <div id="content">
       <h1 id="full_list_header"><%= @list_title %></h1>
       <div id="nav">
-        <a target="_self" href="class_list.html">Classes</a> | 
-        <a target="_self" href="method_list.html">Methods</a> |
-        <a target="_self" href="file_list.html">Files</a>
+        <% menu_lists.each do |list| %>
+          <a target="_self" href="<%= list[:type] %>_list.html"><%= list[:title] %></a>
+        <% end %>
       </div>
       <div id="search">Search: <input type="text" /></div>
 
-      <ul id="full_list" class="<%= @list_type %>">
+      <ul id="full_list" class="<%= @list_class || @list_type %>">
         <%= erb "full_list_#{@list_type}" %>
       </ul>
     </div>
   </body>
 </html>
-

--- a/templates/default/fulldoc/html/setup.rb
+++ b/templates/default/fulldoc/html/setup.rb
@@ -2,15 +2,18 @@ include Helpers::ModuleHelper
 
 def init
   options[:objects] = objects = run_verifier(options[:objects])
-  options[:files] = ([options[:readme]] + options[:files]).compact.map {|t| t.to_s }
+  options[:files] = ([options[:readme]] + options[:files]).compact
   options[:readme] = options[:files].first
-  options[:title] ||= "Documentation by YARD #{YARD::VERSION}"
+  
+  options[:stylesheets] = stylesheets
+  options[:javascripts] = javascripts
+  options[:search_fields] = menu_lists
   
   return serialize_onefile if options[:onefile]
   generate_assets
   serialize('_index.html')
   options[:files].each_with_index do |file, i| 
-    serialize_file(file, i == 0 ? options[:title] : nil) 
+    serialize_file(file, file.title) 
   end
 
   options.delete(:objects)
@@ -27,6 +30,36 @@ def init
   end
 end
 
+#
+# The core javascript files for the documentation template
+#
+def javascripts
+  [ 'js/jquery.js', 'js/app.js' ]
+end
+
+#
+# Javascript files that are additionally loaded for the searchable full lists
+# e.g. Class List, Method List, File List
+#
+def javascripts_full_list
+  [ 'js/jquery.js', 'js/full_list.js' ]
+end
+
+#
+# The core stylesheets for the documentation template
+#
+def stylesheets
+  [ 'css/style.css', 'css/common.css' ]
+end
+
+#
+# Stylesheet files that are additionally loaded for the searchable full lists
+# e.g. Class List, Method List, File List
+#
+def stylesheets_full_list
+  [ 'css/full_list.css', 'css/common.css' ]
+end
+
 def serialize(object)
   options[:object] = object
   serialize_index(options) if object == '_index.html' && options[:files].empty?
@@ -36,8 +69,8 @@ def serialize(object)
 end
 
 def serialize_onefile
-  options[:css_data] = file('css/style.css', true) + "\n" + file('css/common.css', true)
-  options[:js_data] = file('js/jquery.js', true) + file('js/app.js', true)
+  options[:css_data] = stylesheets.map{|sheet| file(sheet,true) }.join("\n")
+  options[:js_data] = javascripts.map{|script| file(script,true) }.join("")
   Templates::Engine.with_serializer('index.html', options[:serializer]) do
     T('onefile').run(options)
   end
@@ -52,32 +85,52 @@ end
 def serialize_file(file, title = nil)
   options[:object] = Registry.root
   options[:file] = file
-  options[:page_title] = title
-  options[:serialized_path] = 'file.' + File.basename(file.gsub(/\.[^.]+$/, '')) + '.html'
+  outfile = 'file.' + file.name + '.html'
 
   serialize_index(options) if file == options[:readme]
-  Templates::Engine.with_serializer(options[:serialized_path], options[:serializer]) do
+  Templates::Engine.with_serializer(outfile, options[:serializer]) do
     T('layout').run(options)
   end
   options.delete(:file)
-  options.delete(:serialized_path)
-  options.delete(:page_title)
 end
 
 def asset(path, content)
   options[:serializer].serialize(path, content) if options[:serializer]
 end
 
+#
+# The list of search links and drop-down menus
+#
+def menu_lists
+  [ { :type => 'class', :title => 'Classes', :search_title => 'Class List' },
+    { :type => 'method', :title => 'Methods', :search_title => 'Method List' }, 
+    { :type => 'file', :title => 'Files', :search_title => 'File List' } ]
+end
+
 def generate_assets
-  %w( js/jquery.js js/app.js js/full_list.js 
-      css/style.css css/full_list.css css/common.css ).each do |file|
+  
+  (javascripts + javascripts_full_list + 
+    stylesheets + stylesheets_full_list).uniq.each do |file|
     asset(file, file(file, true))
   end
   
+  #@javascripts = javascripts_full_list
+  #@stylesheets = stylesheets_full_list
+  
   @object = Registry.root
-  generate_method_list
-  generate_class_list
-  generate_file_list
+  
+  menu_lists.each do |list|
+    
+    list_generator_method = "generate_#{list[:type]}_list"
+    
+    if respond_to?(list_generator_method)
+      send(list_generator_method)
+    else
+      log.error "Unable to generate '#{list[:title]}' list because no method " + 
+        "'#{list_generator_method}' exists"
+    end
+  end
+  
   generate_frameset
 end
 
@@ -107,6 +160,8 @@ def generate_file_list
 end
 
 def generate_frameset
+  @javascripts = javascripts_full_list
+  @stylesheets = stylesheets_full_list
   asset('frames.html', erb(:frames))
 end
 

--- a/templates/default/layout/html/headers.erb
+++ b/templates/default/layout/html/headers.erb
@@ -1,13 +1,17 @@
 <meta http-equiv="Content-Type" content="text/html; charset=<%= charset %>" />
-<title><%= @page_title %></title>
-<link rel="stylesheet" href="<%= url_for("css/style.css") %>" type="text/css" media="screen" charset="utf-8" />
-<link rel="stylesheet" href="<%= url_for("css/common.css") %>" type="text/css" media="screen" charset="utf-8" />
-<% if @extra_css %>
-  <link rel="stylesheet" href="<%= url_for @extra_css %>" type="text/css" media="screen" charset="utf-8" />
+<title>
+  <%= h @page_title %>
+  <% if options[:title] && @page_title != options[:title] %>
+    &mdash; <%= h options[:title] %>
+  <% end %>
+</title>
+<% stylesheets.each do |stylesheet| %>
+  <link rel="stylesheet" href="<%= url_for(stylesheet) %>" type="text/css" media="screen" charset="utf-8" />
 <% end %>
 <script type="text/javascript" charset="utf-8">
   relpath = '<%= url_for('') %>';
   if (relpath != '') relpath += '/';
 </script>
-<script type="text/javascript" charset="utf-8" src="<%= url_for("js/jquery.js") %>"></script>
-<script type="text/javascript" charset="utf-8" src="<%= url_for("js/app.js") %>"></script>
+<% javascripts.each do |javascript| %>
+  <script type="text/javascript" charset="utf-8" src="<%= url_for(javascript) %>"></script>
+<% end %>

--- a/templates/default/layout/html/search.erb
+++ b/templates/default/layout/html/search.erb
@@ -1,5 +1,5 @@
 <div id="search">
-  <a id="class_list_link" href="#">Class List</a>
-  <a id="method_list_link" href="#">Method List</a>
-  <a id ="file_list_link" href="#">File List</a>
+  <% search_fields.each do |field| %>
+    <a id="<%= field[:type] %>_list_link" href="#"><%= field[:search_title] %></a>
+  <% end %>
 </div>

--- a/templates/default/layout/html/setup.rb
+++ b/templates/default/layout/html/setup.rb
@@ -1,14 +1,18 @@
 def init
   @breadcrumb = []
-
+  
+  @stylesheets = options[:stylesheets]
+  @javascripts = options[:javascripts]
+  @search_fields = options[:search_fields]
+  
   if @onefile
     sections :layout
   elsif @file
-    @contents = File.read(@file)
-    @file = File.basename(@file)
-    @fname = @file.gsub(/\.[^.]+$/, '')
-    @breadcrumb_title = "File: " + @fname
-    @page_title ||= @breadcrumb_title
+    if @file.attributes[:namespace]
+      @object = options[:object] = Registry.at(@file.attributes[:namespace]) || Registry.root 
+    end
+    @breadcrumb_title = "File: " + @file.title
+    @page_title = @breadcrumb_title
     sections :layout, [:diskfile]
   elsif object
     case object
@@ -46,6 +50,19 @@ def index
 end
 
 def diskfile
-  data = htmlify(markup_file_contents(@contents), markup_for_file(@contents, @file))
+  @file.attributes[:markup] ||= markup_for_file('', @file.filename)
+  data = htmlify(@file.contents, @file.attributes[:markup])
   "<div id='filecontents'>" + data + "</div>"
+end
+
+def stylesheets
+  @stylesheets
+end
+
+def javascripts
+  @javascripts
+end
+
+def search_fields
+  @search_fields
 end


### PR DESCRIPTION
 provided methods to override or add to Javascript, CSS, and the
 search fields.

User can override, add, or remove from the stylesheets and javascript by creating a `fulldoc/html/setup.rb` and overriding the methods:

```
def javascripts
 super + [ 'js/custom.js' ]
end

def stylesheets
 super + [ 'css/custom.css' ]
end
```

This is similar to menu lists:

```
def menu_lists
  [ { :type => 'feature', :title => 'Features', :search_title => 'Features' }, 
    { :type => 'tag', :title => 'Tags', :search_title => 'Tags' } 
  ] + super
end
```

Based on the type specified a method is called `generate_feature_list` and `generate_tag_list`. An example of `generate_feature_list`:

```
def generate_feature_list
  @features = Registry.all(:feature)
  generate_full_list @features.sort {|x,y| x.value.to_s <=> y.value.to_s }, :feature
end
```
