### PR TITLE
Add Redcarpet to the list of Markdown providers

### DIFF
--- a/lib/yard/templates/helpers/markup_helper.rb
+++ b/lib/yard/templates/helpers/markup_helper.rb
@@ -23,20 +23,21 @@ module YARD
       MARKUP_PROVIDERS = {
         :markdown => [
           {:lib => :bluecloth, :const => 'BlueCloth'},
-          {:lib => :kramdown, :const => "Kramdown::Document"},
+          {:lib => :kramdown, :const => 'Kramdown::Document'},
           {:lib => :maruku, :const => 'Maruku'},
-          {:lib => :"rpeg-markdown", :const => "PEGMarkdown"},
-          {:lib => :rdiscount, :const => "RDiscount"}
+          {:lib => :'rpeg-markdown', :const => 'PEGMarkdown'},
+          {:lib => :redcarpet, :const => 'Redcarpet'},
+          {:lib => :rdiscount, :const => 'RDiscount'},
         ],
         :textile => [
-          {:lib => :redcloth, :const => 'RedCloth'}
+          {:lib => :redcloth, :const => 'RedCloth'},
         ],
         :rdoc => [
           {:lib => nil, :const => 'YARD::Templates::Helpers::Markup::RDocMarkup'},
         ],
         :text => [],
         :html => [],
-        :none => []
+        :none => [],
       }
       
       # Returns a list of extensions for various markup types. To register

--- a/spec/templates/helpers/markup_helper_spec.rb
+++ b/spec/templates/helpers/markup_helper_spec.rb
@@ -62,6 +62,7 @@ describe YARD::Templates::Helpers::MarkupHelper do
       @gen.should_receive(:require).with('kramdown').and_raise(LoadError)
       @gen.should_receive(:require).with('maruku').and_raise(LoadError)
       @gen.should_receive(:require).with('rpeg-markdown').and_raise(LoadError)
+      @gen.should_receive(:require).with('redcarpet').and_raise(LoadError)
       @gen.should_receive(:require).with('rdiscount').and_return(true)
       @gen.should_receive(:eval).with('::RDiscount').and_return(true)
       @gen.stub!(:options).and_return({:markup => :markdown})


### PR DESCRIPTION
For more information on Redcarpet see:
- https://github.com/tanoku/redcarpet
- https://github.com/blog/832-rolling-out-the-redcarpet
