### PR TITLE
Remove Gem::Specification#has_rdoc=

### DIFF
--- a/yard.gemspec
+++ b/yard.gemspec
@@ -17,6 +17,5 @@ Gem::Specification.new do |s|
   s.files         = Dir.glob("{docs,bin,lib,spec,templates,benchmarks}/**/*") + ['ChangeLog', 'LICENSE', 'LEGAL', 'README.md', 'Rakefile', '.yardopts']
   s.require_paths = ['lib']
   s.executables   = ['yard', 'yardoc', 'yri']
-  s.has_rdoc      = 'yard'
   s.rubyforge_project = 'yard'
 end


### PR DESCRIPTION
This method has been deprecated with no replacement as of RubyGems 1.7.
It will be removed on or after 2011-10-01.
