### PR TITLE
Add Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-_Yardoc
-.DS_Store
-*.pdf
-.yardoc
 *.gem
-/pkg
-/doc
+*.pdf
+.DS_Store
+.yardoc
 /coverage
+/doc
+/pkg
+Gemfile.lock
+_Yardoc

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "http://rubygems.org"
+
+gemspec

--- a/yard.gemspec
+++ b/yard.gemspec
@@ -19,4 +19,9 @@ Gem::Specification.new do |s|
   s.executables   = ['yard', 'yardoc', 'yri']
   s.has_rdoc      = 'yard'
   s.rubyforge_project = 'yard'
+  s.add_development_dependency 'bluecloth', '~> 2.1'
+  s.add_development_dependency 'rake', '~> 0.8'
+  s.add_development_dependency 'rack', '~> 1.2'
+  s.add_development_dependency 'RedCloth', '~> 4.2'
+  s.add_development_dependency 'rspec', '~> 2.5'
 end


### PR DESCRIPTION
This patch will make it easier for developers to get up-and-running as fast as possible. By explicitly stating development dependencies in the gem specification, which is referenced in the Gemfile, they can be easily installed using Bundler. Note: Bundler is not required if you don't want to use it.
