### PR TITLE
Add Redcarpet to the list of Markdown providers

### DIFF
--- a/lib/yard/templates/helpers/markup_helper.rb
+++ b/lib/yard/templates/helpers/markup_helper.rb
@@ -22,21 +22,22 @@ module YARD
       # The default list of markup providers for each markup type
       MARKUP_PROVIDERS = {
         :markdown => [
-          {:lib => :rdiscount, :const => "RDiscount"},
-          {:lib => :kramdown, :const => "Kramdown::Document"},
+          {:lib => :rdiscount, :const => 'RDiscount'},
+          {:lib => :kramdown, :const => 'Kramdown::Document'},
           {:lib => :bluecloth, :const => 'BlueCloth'},
           {:lib => :maruku, :const => 'Maruku'},
-          {:lib => :"rpeg-markdown", :const => "PEGMarkdown"}
+          {:lib => :redcarpet, :const => 'RedcarpetCompat'},
+          {:lib => :'rpeg-markdown', :const => 'PEGMarkdown'},
         ],
         :textile => [
-          {:lib => :redcloth, :const => 'RedCloth'}
+          {:lib => :redcloth, :const => 'RedCloth'},
         ],
         :rdoc => [
           {:lib => nil, :const => 'YARD::Templates::Helpers::Markup::RDocMarkup'},
         ],
         :text => [],
         :html => [],
-        :none => []
+        :none => [],
       }
       
       # Returns a list of extensions for various markup types. To register

--- a/spec/templates/helpers/markup_helper_spec.rb
+++ b/spec/templates/helpers/markup_helper_spec.rb
@@ -62,6 +62,7 @@ describe YARD::Templates::Helpers::MarkupHelper do
       @gen.should_receive(:require).with('kramdown').and_raise(LoadError)
       @gen.should_receive(:require).with('bluecloth').and_raise(LoadError)
       @gen.should_receive(:require).with('maruku').and_raise(LoadError)
+      @gen.should_receive(:require).with('redcarpet').and_raise(LoadError)
       @gen.should_receive(:require).with('rpeg-markdown').and_return(true)
       @gen.should_receive(:eval).with('::PEGMarkdown').and_return(true)
       @gen.stub!(:options).and_return({:markup => :markdown})


### PR DESCRIPTION
For more information on Redcarpet see:
- https://github.com/tanoku/redcarpet
- https://github.com/blog/832-rolling-out-the-redcarpet
