### PR TITLE
Add default UTF-8 charset in response HTTP headers

### DIFF
--- a/lib/yard/server/commands/base.rb
+++ b/lib/yard/server/commands/base.rb
@@ -88,7 +88,7 @@ module YARD
         def call(request)
           self.request = request
           self.path ||= request.path[1..-1]
-          self.headers = {'Content-Type' => 'text/html'}
+          self.headers = {'Content-Type' => 'text/html; charset=UTF-8'}
           self.body = ''
           self.status = 200
           begin

--- a/spec/server/commands/base_spec.rb
+++ b/spec/server/commands/base_spec.rb
@@ -39,7 +39,7 @@ describe YARD::Server::Commands::Base do
     it "should return a valid redirection" do
       cmd = MyProcCommand.new { redirect '/foo' }
       cmd.call(mock_request('/foo')).should == 
-        [302, {"Content-Type" => "text/html", "Location" => "/foo"}, [""]]
+        [302, {"Content-Type" => "text/html; charset=UTF-8", "Location" => "/foo"}, [""]]
     end
   end
   


### PR DESCRIPTION
I've noticed that some browsers fall back to their default charset when there is no charset declared in the `Content-type` header, _even_ if it’s declared with `<meta name="Content-Type" content="text/html; charset=UTF-8" />`.

Do you think it’s something that should be implemented by default in YARD?

Cheers!
