### PR TITLE
Properly catch NotImplementedError raised by Rubinius when testing callcc

### DIFF
--- a/lib/yard.rb
+++ b/lib/yard.rb
@@ -37,7 +37,7 @@ begin
   begin; require 'continuation'; rescue LoadError; end
   cc = callcc {|cc| cc }; cc.call if cc
   CONTINUATIONS_SUPPORTED = true
-rescue
+rescue Exception
   CONTINUATIONS_SUPPORTED = false
 end
 


### PR DESCRIPTION
Properly catch NotImplementedError raised by Rubinius when testing `callcc`.

Using just `rescue` will only catch exceptions that inherit from StandardError. However, NotImplementedError inherits from ScriptError.
