### PR TITLE
Fix a rubygems deprecation 

### DIFF
--- a/lib/yard/registry.rb
+++ b/lib/yard/registry.rb
@@ -48,7 +48,7 @@ module YARD
       # @return [nil] if +for_writing+ is set to false and no yardoc file
       #   is found, returns nil.
       def yardoc_file_for_gem(gem, ver_require = ">= 0", for_writing = false)
-        spec = Gem.source_index.find_name(gem, ver_require)
+        spec = Gem::Specification.find_by_name(gem, ver_require)
         return if spec.empty?
         spec = spec.first
 


### PR DESCRIPTION
NOTE: Gem::SourceIndex#find_name is deprecated, use Specification.find_by_name. It will be removed on or after 2011-11-01.
