### PR TITLE
ignore keyboard shortcuts when an input is active

### DIFF
--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -93,9 +93,9 @@ function keyboardShortcuts() {
   if (window.top.frames.main) return;
   $(document).keypress(function(evt) {
     if (evt.altKey || evt.ctrlKey || evt.metaKey || evt.shiftKey) return;
-    if (typeof evt.orignalTarget !== "undefined" &&  
-        (evt.originalTarget.nodeName == "INPUT" || 
-        evt.originalTarget.nodeName == "TEXTAREA")) return;
+    if (typeof evt.target !== "undefined" &&
+        (evt.target.nodeName == "INPUT" ||
+        evt.target.nodeName == "TEXTAREA")) return;
     switch (evt.charCode) {
       case 67: case 99:  $('#class_list_link').click(); break;  // 'c'
       case 77: case 109: $('#method_list_link').click(); break; // 'm'


### PR DESCRIPTION
use event.target since it's standard across all browsers, event.originalTarget
is mozilla-specific
