### PR TITLE
Added Runtime Dependency and Removed Trailing Whitespace

### DIFF
--- a/benchmarks/builtins_vs_eval.rb
+++ b/benchmarks/builtins_vs_eval.rb
@@ -9,7 +9,7 @@ end
 
 def bench_eval(name)
   eval(name).is_a?(Class)
-rescue 
+rescue
   false
 end
 

--- a/benchmarks/erb_vs_erubis.rb
+++ b/benchmarks/erb_vs_erubis.rb
@@ -17,7 +17,7 @@ Benchmark.bmbm do |x|
         def erb_with(str, x) Erubis::Eruby.new(str) end
       end end end
     eof
-    
+
     rungen
   end
 
@@ -27,7 +27,7 @@ Benchmark.bmbm do |x|
         def erb_with(str, x) Erubis::FastEruby.new(str) end
       end end end
     eof
-    
+
     rungen
   end
 
@@ -37,7 +37,7 @@ Benchmark.bmbm do |x|
         def erb_with(str, x) Erubis::TinyEruby.new(str) end
       end end end
     eof
-    
+
     rungen
   end
 
@@ -47,7 +47,7 @@ Benchmark.bmbm do |x|
         def erb_with(str, x) ERB.new(str, nil) end
       end end end
     eof
-    
+
     rungen
   end
 end

--- a/benchmarks/generation.rb
+++ b/benchmarks/generation.rb
@@ -2,20 +2,20 @@ require "benchmark"
 require File.join(File.dirname(__FILE__), '..', 'lib', 'yard')
 
 unless YARD::CodeObjects::Proxy.private_instance_methods.include?('to_obj')
-  raise "This benchmark is dependent on YARD::CodeObjects::Proxy#to_obj" 
+  raise "This benchmark is dependent on YARD::CodeObjects::Proxy#to_obj"
 end
 
 def rungen
   YARD::Registry.clear
-  YARD::CLI::Yardoc.run('--quiet', '--use-cache') 
+  YARD::CLI::Yardoc.run('--quiet', '--use-cache')
 end
 
 def redef(lock = false)
   eval <<-eof
-    class YARD::CodeObjects::Proxy; 
+    class YARD::CodeObjects::Proxy;
       def to_obj
-        @obj #{lock ? '||' : ''}= YARD::Registry.resolve(@namespace, @name) 
-      end 
+        @obj #{lock ? '||' : ''}= YARD::Registry.resolve(@namespace, @name)
+      end
     end
   eof
 end

--- a/benchmarks/parsing.rb
+++ b/benchmarks/parsing.rb
@@ -15,8 +15,8 @@ PATH_ORDER = [
 ]
 
 Benchmark.bmbm do |x|
-  x.report("parse in order") { YARD::Registry.clear; YARD.parse PATH_ORDER, [], Logger::ERROR } 
-  x.report("parse") { YARD::Registry.clear; YARD.parse 'lib/**/*.rb', [], Logger::ERROR } 
+  x.report("parse in order") { YARD::Registry.clear; YARD.parse PATH_ORDER, [], Logger::ERROR }
+  x.report("parse") { YARD::Registry.clear; YARD.parse 'lib/**/*.rb', [], Logger::ERROR }
 end
 
 =begin

--- a/lib/yard/cli/diff.rb
+++ b/lib/yard/cli/diff.rb
@@ -63,7 +63,7 @@ module YARD
       end
 
       private
-      
+
       def load_git_commit(commit)
         commit_path = 'git_commit' + commit.gsub(/\W/, '_')
         tmpdir = File.join(Dir.tmpdir, commit_path)

--- a/lib/yard/cli/list.rb
+++ b/lib/yard/cli/list.rb
@@ -3,7 +3,7 @@ module YARD
     # Lists all constant and method names in the codebase. Uses {Yardoc} --list.
     class List < Command
       def description; 'Lists all constant and methods. Uses `yard doc --list`' end
-      
+
       # Runs the commandline utility, parsing arguments and displaying a
       # list of objects
       #

--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -150,7 +150,7 @@ module YARD
       # @return [Array<String>] a list of assets to copy after generation
       # @since 0.6.0
       attr_accessor :assets
-      
+
       # @return [Boolean] whether markup option was specified
       # @since 0.7.0
       attr_accessor :has_markup
@@ -256,7 +256,7 @@ module YARD
         end
         Tags::Library.visible_tags -= hidden_tags
         add_visibility_verifier
-        
+
         if generate && !verify_markup_options
           false
         else
@@ -351,7 +351,7 @@ module YARD
           puts "#{item.file}:#{item.line}: #{item.path}"
         end
       end
-      
+
       # Parses out the yardopts/document options
       def parse_yardopts_options(*args)
         opts = OptionParser.new
@@ -501,10 +501,10 @@ module YARD
           self.excluded << path
         end
       end
-      
+
       # Adds --[no-]yardopts / --[no-]document
       def yardopts_options(opts)
-        opts.on('--[no-]yardopts [FILE]', 
+        opts.on('--[no-]yardopts [FILE]',
                 "If arguments should be read from FILE",
                 "  (defaults to yes, FILE defaults to .yardopts)") do |use_yardopts|
           if use_yardopts.is_a?(String)
@@ -614,12 +614,12 @@ module YARD
         end
 
         opts.on('-M', '--markup-provider MARKUP_PROVIDER',
-                'Overrides the library used to process markup ', 
+                'Overrides the library used to process markup ',
                 '  formatting (specify the gem name)') do |markup_provider|
           options[:markup_provider] = markup_provider.to_sym
         end
 
-        opts.on('--charset ENC', 'Character set to use when parsing files ', 
+        opts.on('--charset ENC', 'Character set to use when parsing files ',
                                  '  (default is system locale)') do |encoding|
           begin
             Encoding.default_external, Encoding.default_internal = encoding, encoding

--- a/lib/yard/code_objects/extra_file_object.rb
+++ b/lib/yard/code_objects/extra_file_object.rb
@@ -66,7 +66,7 @@ module YARD::CodeObjects
       end
       data = data[cut_index..-1] if cut_index > 0
       self.contents = data.join("\n")
-      
+
       if contents.respond_to?(:force_encoding) && attributes[:encoding]
         begin
           contents.force_encoding(attributes[:encoding])

--- a/lib/yard/code_objects/macro_object.rb
+++ b/lib/yard/code_objects/macro_object.rb
@@ -4,24 +4,24 @@ module YARD
     # reused by specifying the tag +@macro NAME+. You can also provide the
     # +attached+ type flag to the macro definition to have it attached to the
     # specific DSL method so it will be implicitly reused.
-    # 
+    #
     # Macros are fully described in the {file:docs/Tags.md#macros Tags Overview}
     # document.
-    # 
+    #
     # @example Creating a basic named macro
     #   # @macro prop
     #   # @method $1(${3-})
     #   # @return [$2] the value of the $0
     #   property :foo, String, :a, :b
-    #   
+    #
     #   # @macro prop
     #   property :bar, Numeric, :value
-    # 
+    #
     # @example Creating a macro that is attached to the method call
     #   # @macro [attach] prop2
     #   # @method $1(value)
     #   property :foo
-    #   
+    #
     #   # Extra data added to docstring
     #   property :bar
     class MacroObject < Base
@@ -40,22 +40,22 @@ module YARD
           obj.method_object = method_object
           obj
         end
-    
+
         # Finds a macro using +macro_name+
         # @return [MacroObject] if a macro is found
         # @return [nil] if there is no registered macro by that name
         def find(macro_name)
           Registry.at('.macro.' + macro_name.to_s)
         end
-      
+
         # Parses a given docstring and determines if the macro is "new" or
         # not. If the macro has $variable names or if it has a @macro tag
-        # with the [new] or [attached] flag, it is considered new. 
-        # 
+        # with the [new] or [attached] flag, it is considered new.
+        #
         # If a new macro is found, the macro is created and registered. Otherwise
         # the macro name is searched and returned. If a macro is not found,
         # nil is returned.
-        # 
+        #
         # @param [CodeObjects::Base] method_object an optional method to attach
         #   the macro to. Only used if the macro is being created, otherwise
         #   this argument is ignored.
@@ -75,21 +75,21 @@ module YARD
           end
         end
         alias create_docstring find_or_create
-        
+
         # Expands +macro_data+ using the interpolation parameters.
-        # 
+        #
         # Interpolation rules:
         # * $0, $1, $2, ... = the Nth parameter in +call_params+
         # * $& = the full statement source (excluding block)
         # * Also supports $\{N-M} ranges, as well as negative indexes on N or M
         # * Use \$ to escape the variable name in a macro.
-        # 
+        #
         # @macro [new] macro.expand
         #   @param [Array<String>] call_params the method name and parameters
         #     to the method call. These arguments will fill \$0-N
-        #   @param [String] full_source the full source line (excluding block) 
+        #   @param [String] full_source the full source line (excluding block)
         #     interpolated as \$&
-        #   @param [String] block_source Currently unused. Will support 
+        #   @param [String] block_source Currently unused. Will support
         #     interpolating the block data as a variable.
         #   @return [String] the expanded macro data
         # @param [String] macro_data the macro data to expand (taken from {#macro_data})
@@ -113,7 +113,7 @@ module YARD
         # Applies a macro on a docstring by creating any macro data inside of
         # the docstring first. Equivalent to calling {find_or_create} and {apply_macro}
         # on the new macro object.
-        # 
+        #
         # @param [Docstring] docstring the docstring to create a macro out of
         # @macro macro.expand
         # @see find_or_create
@@ -125,7 +125,7 @@ module YARD
         # Applies a macro to a docstring, interpolating the macro's data on the
         # docstring and appending any extra local docstring data that was in
         # the original +docstring+ object.
-        # 
+        #
         # @param [MacroObject] macro the macro object
         # @macro macro.expand
         def apply_macro(macro, docstring, call_params = [], full_source = '', block_source = '')
@@ -140,9 +140,9 @@ module YARD
         end
 
         private
-      
+
         def new_macro?(docstring)
-          if docstring.tag(:macro) 
+          if docstring.tag(:macro)
             if types = docstring.tag(:macro).types
               return true if types.include?('new') || types.include?('attach')
             end
@@ -152,17 +152,17 @@ module YARD
           end
           false
         end
-        
+
         def attached_macro?(docstring, method_object)
           return false if method_object.nil?
           return false if docstring.tag(:macro).types.nil?
           docstring.tag(:macro).types.include?('attach')
         end
-        
+
         def macro_name(docstring)
           docstring.tag(:macro).name
         end
-        
+
         def macro_data(docstring)
           new_docstring = docstring.dup
           new_docstring.delete_tags(:macro)
@@ -173,7 +173,7 @@ module YARD
             tag_text
           end
         end
-        
+
         def nonmacro_data(docstring)
           if new_macro?(docstring)
             text = docstring.tag(:macro).text
@@ -184,20 +184,20 @@ module YARD
           new_docstring.to_raw
         end
       end
-    
+
       # @return [String] the macro data stored on the object
       attr_accessor :macro_data
-      
+
       # @return [CodeObjects::Base] the method object that this macro is
       #   attached to.
       attr_accessor :method_object
-    
+
       # @return [Boolean] whether this macro is attached to a method
       def attached?; method_object ? true : false end
       def path; '.macro.' + name.to_s end
       def sep; '.' end
-      
-      # Expands the macro using 
+
+      # Expands the macro using
       # @param [Array<String>] call_params a list of tokens that are passed
       #   to the method call
       # @param [String] full_source the full method call (not including the block)

--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -75,9 +75,9 @@ module YARD
       super parse_comments(content)
     end
     alias all= replace
-    
+
     # Deep-copies a docstring
-    # 
+    #
     # @note This method creates a new docstring with new tag lists, but does
     #   not create new individual tags. Modifying the tag objects will still
     #   affect the original tags.
@@ -124,10 +124,10 @@ module YARD
       @summary += '.' unless @summary.empty?
       @summary
     end
-    
+
     # Reformats and returns a raw representation of the tag data using the
     # current tag and docstring data, not the original text.
-    # 
+    #
     # @return [String] the updated raw formatted docstring data
     # @since 0.7.0
     # @todo Add Tags::Tag#to_raw and refactor
@@ -154,7 +154,7 @@ module YARD
     # @group Creating and Accessing Meta-data
 
     # Creates a tag from the {Tags::DefaultFactory tag factory}.
-    # 
+    #
     # To add an already created tag object, use {#add_tag}
     #
     # @param [String] tag_name the tag name
@@ -179,7 +179,7 @@ module YARD
     # Adds a tag or reftag object to the tag list. If you want to parse
     # tag data based on the {Tags::DefaultFactory} tag factory, use {#create_tag}
     # instead.
-    # 
+    #
     # @param [Tags::Tag, Tags::RefTag] tags list of tag objects to add
     # @return [void]
     def add_tag(*tags)
@@ -226,7 +226,7 @@ module YARD
     def has_tag?(name)
       tags.any? {|tag| tag.tag_name.to_s == name.to_s }
     end
-    
+
     # Delete all tags with +name+
     # @param [String] name the tag name
     # @return [void]
@@ -234,10 +234,10 @@ module YARD
     def delete_tags(name)
       delete_tag_if {|tag| tag.tag_name.to_s == name.to_s }
     end
-    
+
     # Deletes all tags where the block returns true
     # @yieldparam [Tags::Tag] tag the tag that is being tested
-    # @yieldreturn [Boolean] true if the tag should be deleted 
+    # @yieldreturn [Boolean] true if the tag should be deleted
     # @return [void]
     # @since 0.7.0
     def delete_tag_if(&block)

--- a/lib/yard/handlers/base.rb
+++ b/lib/yard/handlers/base.rb
@@ -325,7 +325,7 @@ module YARD
 
       # (see Processor#extra_state)
       attr_reader :extra_state
-      
+
       undef owner, owner=, namespace, namespace=
       undef visibility, visibility=, scope, scope=
 
@@ -496,9 +496,9 @@ module YARD
         end
         object
       end
-      
+
       # @group Macro Support
-      
+
       # @abstract Implement this method to return the parameters in a method call
       #   statement. It should return an empty list if the statement is not a
       #   method call.
@@ -506,7 +506,7 @@ module YARD
       def call_params
         raise NotImplementedError
       end
-      
+
       # @abstract Implement this method to return the method being called in
       #   a method call. It should return nil if the statement is not a method
       #   call.
@@ -515,10 +515,10 @@ module YARD
       def caller_method
         raise NotImplementedError
       end
-      
+
       # Attempts to find or create a macro if a +@macro+ tag is found in the
       # docstring (or the object's docstring).
-      # 
+      #
       # @param [Docstring, CodeObjects::Base] object_or_docstring the docstring
       #   or it's object with which to check for a macro
       # @return [CodeObjects::MacroObject] the newly created macro
@@ -553,7 +553,7 @@ module YARD
         end
         macro
       end
-      
+
       # Sets the docstring on +object+ to the expanded macro.
       # @param [CodeObjects::Base] object the object to expand the macro on
       # @param [CodeObjects::MacroObject] macro the macro object to expand

--- a/lib/yard/handlers/processor.rb
+++ b/lib/yard/handlers/processor.rb
@@ -59,17 +59,17 @@ module YARD
 
       # @return [Symbol] the parser type (:ruby, :ruby18, :c)
       attr_accessor :parser_type
-      
-      # Handlers can share state for the entire post processing stage through 
+
+      # Handlers can share state for the entire post processing stage through
       # this attribute. Note that post processing stage spans multiple files.
       # To share state only within a single file, use {#extra_state}
-      # 
+      #
       # @example Sharing state among two handlers
       #   class Handler1 < YARD::Handlers::Ruby::Base
       #     handles :class
       #     process { globals.foo = :bar }
       #   end
-      # 
+      #
       #   class Handler2 < YARD::Handlers::Ruby::Base
       #     handles :method
       #     process { puts globals.foo }
@@ -77,14 +77,14 @@ module YARD
       # @return [OpenStruct] global shared state for post-processing stage
       # @see #extra_state
       attr_accessor :globals
-      
+
       # Share state across different handlers inside of a file.
       # This attribute is similar to {#visibility}, {#scope}, {#namespace}
       # and {#owner}, in that they all maintain state across all handlers
       # for the entire source file. Use this attribute to store any data
       # your handler might need to save during the parsing of a file. If
       # you need to save state across files, see {#globals}.
-      # 
+      #
       # @return [OpenStruct] an open structure that can store arbitrary data
       # @see #globals
       attr_accessor :extra_state

--- a/lib/yard/handlers/ruby/base.rb
+++ b/lib/yard/handlers/ruby/base.rb
@@ -135,7 +135,7 @@ module YARD
             parser.process(nodes)
           end
         end
-        
+
         # @group Macro Handling
 
         def call_params

--- a/lib/yard/handlers/ruby/legacy/base.rb
+++ b/lib/yard/handlers/ruby/legacy/base.rb
@@ -41,7 +41,7 @@ module YARD
             end
           end
         end
-        
+
         def call_params
           tokens = statement.tokens[1..-1]
           tokval_list(tokens, :attr, :identifier, TkId).map do |value|

--- a/lib/yard/handlers/ruby/macro_handler.rb
+++ b/lib/yard/handlers/ruby/macro_handler.rb
@@ -7,18 +7,18 @@ module YARD
         include MacroHandlerMethods
         handles method_call
         namespace_only
-        
-        IGNORE_METHODS = Hash[*%w(alias alias_method autoload attr attr_accessor 
-          attr_reader attr_writer extend include public private protected 
+
+        IGNORE_METHODS = Hash[*%w(alias alias_method autoload attr attr_accessor
+          attr_reader attr_writer extend include public private protected
           private_constant).map {|n| [n, true] }.flatten]
-        
+
         process do
           globals.__attached_macros ||= {}
           if !globals.__attached_macros[caller_method]
             return if IGNORE_METHODS[caller_method]
             return if !statement.comments || statement.comments.empty?
           end
-          
+
           @macro, @docstring = nil, Docstring.new(statement.comments)
           find_or_create_macro(@docstring)
           return if !@macro && !statement.comments_hash_flag && @docstring.tags.size == 0

--- a/lib/yard/handlers/ruby/macro_handler_methods.rb
+++ b/lib/yard/handlers/ruby/macro_handler_methods.rb
@@ -4,7 +4,7 @@ module YARD
       module MacroHandlerMethods
         include CodeObjects
         include Parser
-        
+
         def find_or_create_macro(docstring)
           return @macro if @macro
           return if @macro = super(docstring)
@@ -16,14 +16,14 @@ module YARD
             end
           end
         end
-        
+
         def expanded_macro_or_docstring
           return @docstring unless @macro
           all_params = ([caller_method] + call_params).compact
           data = MacroObject.apply_macro(@macro, @docstring, all_params, statement.source)
           Docstring.new(data)
         end
-        
+
         def expand_macro(object, macro)
           if @docstring
             object.docstring = @docstring
@@ -34,7 +34,7 @@ module YARD
             super(object, macro)
           end
         end
-        
+
         def sanitize_scope
           tmp_scope = @docstring.tag(:scope) ? @docstring.tag(:scope).text : ''
           %w(class instance).include?(tmp_scope) ? tmp_scope.to_sym : scope
@@ -66,7 +66,7 @@ module YARD
             namespace.attributes[object.scope][clean_name][:write] = writer
           end
         end
-        
+
         def method_name
           name = nil
           [:method, :attribute, :overload].each do |tag_name|
@@ -110,7 +110,7 @@ module YARD
         private
 
         def attribute_writable?
-          if @docstring.tag(:attribute) 
+          if @docstring.tag(:attribute)
             types = @docstring.tag(:attribute).types
             return types ? types.join.include?('w') : true
           end
@@ -118,7 +118,7 @@ module YARD
         end
 
         def attribute_readable?
-          if @docstring.tag(:attribute) 
+          if @docstring.tag(:attribute)
             types = @docstring.tag(:attribute).types
             return types ? (types.join =~ /(?!w)r/ ? true : false) : true
           end

--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -327,7 +327,7 @@ module YARD
             end
           eof
         end
-        
+
         def on_qwords_new(*args)
           node = LiteralNode.new(:qwords_literal, args)
           if @map[:qwords_beg]
@@ -337,7 +337,7 @@ module YARD
           end
           node
         end
-        
+
         def on_qwords_add(list, item)
           list.source_range = (list.source_range.first..@ns_charno)
           list.line_range = (list.line_range.first..lineno)

--- a/lib/yard/parser/source_parser.rb
+++ b/lib/yard/parser/source_parser.rb
@@ -35,7 +35,7 @@ module YARD
     class SourceParser
       SHEBANG_LINE  = /\A\s*#!\S+/
       ENCODING_LINE = /\A(?:\s*#*!.*\r?\n)?\s*#+.*coding\s*[:=]{1,2}\s*(\S+)/i
-      
+
       # Byte order marks for various encodings
       # @since 0.7.0
       ENCODING_BYTE_ORDER_MARKS = {
@@ -154,20 +154,20 @@ module YARD
         def validated_parser_type(type)
           !defined?(::Ripper) && type == :ruby ? :ruby18 : type
         end
-        
+
         # @group Parser Callbacks
-        
-        # Registers a callback to be called before a list of files is parsed 
-        # via {parse}. The block passed to this method will be called on 
+
+        # Registers a callback to be called before a list of files is parsed
+        # via {parse}. The block passed to this method will be called on
         # subsequent parse calls.
-        # 
+        #
         # @example Installing a simple callback
         #   SourceParser.before_parse_list do |files, globals|
         #     puts "Starting to parse..."
         #   end
         #   YARD.parse('lib/**/*.rb')
         #   # prints "Starting to parse..."
-        # 
+        #
         # @example Setting global state
         #   SourceParser.before_parse_list do |files, globals|
         #     globals.method_count = 0
@@ -181,16 +181,16 @@ module YARD
         #   end
         #   YARD.parse
         #   # Prints: "Found 37 methods"
-        # 
+        #
         # @example Using a global callback to cancel parsing
         #   SourceParser.before_parse_list do |files, globals|
         #     return false if files.include?('foo.rb')
         #   end
-        # 
+        #
         #   YARD.parse(['foo.rb', 'bar.rb']) # callback cancels this method
         #   YARD.parse('bar.rb') # parses normally
-        # 
-        # @yield [files, globals] the yielded block is called once before 
+        #
+        # @yield [files, globals] the yielded block is called once before
         #   parsing all files
         # @yieldparam [Array<String>] files the list of files that will be parsed.
         # @yieldparam [OpenStruct] globals a global structure to store arbitrary
@@ -204,18 +204,18 @@ module YARD
         def before_parse_list(&block)
           before_parse_list_callbacks << block
         end
-        
-        # Registers a callback to be called after a list of files is parsed 
-        # via {parse}. The block passed to this method will be called on 
+
+        # Registers a callback to be called after a list of files is parsed
+        # via {parse}. The block passed to this method will be called on
         # subsequent parse calls.
-        # 
+        #
         # @example Printing results after parsing occurs
         #   SourceParser.after_parse_list do
         #     puts "Finished parsing!"
         #   end
         #   YARD.parse
         #   # Prints "Finished parsing!" after parsing files
-        # @yield [files, globals] the yielded block is called once before 
+        # @yield [files, globals] the yielded block is called once before
         #   parsing all files
         # @yieldparam [Array<String>] files the list of files that will be parsed.
         # @yieldparam [OpenStruct] globals a global structure to store arbitrary
@@ -228,14 +228,14 @@ module YARD
         def after_parse_list(&block)
           after_parse_list_callbacks << block
         end
-        
-        # Registers a callback to be called before an individual file is parsed. 
-        # The block passed to this method will be called on subsequent parse 
+
+        # Registers a callback to be called before an individual file is parsed.
+        # The block passed to this method will be called on subsequent parse
         # calls.
-        # 
+        #
         # To register a callback that is called before the entire list of files
         # is processed, see {before_parse_list}.
-        # 
+        #
         # @example Installing a simple callback
         #   SourceParser.before_parse_file do |parser|
         #     puts "I'm parsing #{parser.file}"
@@ -245,18 +245,18 @@ module YARD
         #   "I'm parsing lib/foo.rb"
         #   "I'm parsing lib/foo_bar.rb"
         #   "I'm parsing lib/last_file.rb"
-        # 
+        #
         # @example Cancel parsing of any test_*.rb files
         #   SourceParser.before_parse_file do |parser|
         #     return false if parser.file =~ /^test_.+\.rb$/
         #   end
-        # 
+        #
         # @yield [parser] the yielded block is called once before each
         #   file that is parsed. This might happen many times for a single
         #   codebase.
         # @yieldparam [SourceParser] parser the parser object that will {#parse}
         #   the file.
-        # @yieldreturn [Boolean] if the block returns +false+, parsing for 
+        # @yieldreturn [Boolean] if the block returns +false+, parsing for
         #   the file is cancelled.
         # @return [Proc] the yielded block
         # @see after_parse_file
@@ -265,14 +265,14 @@ module YARD
         def before_parse_file(&block)
           before_parse_file_callbacks << block
         end
-        
-        # Registers a callback to be called after an individual file is parsed. 
-        # The block passed to this method will be called on subsequent parse 
+
+        # Registers a callback to be called after an individual file is parsed.
+        # The block passed to this method will be called on subsequent parse
         # calls.
-        # 
+        #
         # To register a callback that is called after the entire list of files
         # is processed, see {after_parse_list}.
-        # 
+        #
         # @example Printing the length of each file after it is parsed
         #   SourceParser.after_parse_file do |parser|
         #     puts "#{parser.file} is #{parser.contents.size} characters"
@@ -281,8 +281,8 @@ module YARD
         #   # prints:
         #   "lib/foo.rb is 1240 characters"
         #   "lib/foo_bar.rb is 248 characters"
-        # 
-        # @yield [parser] the yielded block is called once after each file 
+        #
+        # @yield [parser] the yielded block is called once after each file
         #   that is parsed. This might happen many times for a single codebase.
         # @yieldparam [SourceParser] parser the parser object that parsed
         #   the file.
@@ -294,35 +294,35 @@ module YARD
         def after_parse_file(&block)
           after_parse_file_callbacks << block
         end
-        
+
         # @return [Array<Proc>] the list of callbacks to be called before
         #   parsing a list of files. Should only be used for testing.
         # @since 0.7.0
         def before_parse_list_callbacks
           @before_parse_list_callbacks ||= []
         end
-        
+
         # @return [Array<Proc>] the list of callbacks to be called after
         #   parsing a list of files. Should only be used for testing.
         # @since 0.7.0
         def after_parse_list_callbacks
           @after_parse_list_callbacks ||= []
         end
-        
+
         # @return [Array<Proc>] the list of callbacks to be called before
         #   parsing a file. Should only be used for testing.
         # @since 0.7.0
         def before_parse_file_callbacks
           @before_parse_file_callbacks ||= []
         end
-        
+
         # @return [Array<Proc>] the list of callbacks to be called after
         #   parsing a file. Should only be used for testing.
         # @since 0.7.0
         def after_parse_file_callbacks
           @after_parse_file_callbacks ||= []
         end
-        
+
         # @endgroup
 
         private
@@ -337,11 +337,11 @@ module YARD
           global_state = OpenStruct.new
           files = files.sort_by {|x| x.length if x }
           files_copy = files.dup
-          
+
           before_parse_list_callbacks.each do |cb|
             return if cb.call(files_copy, global_state) == false
           end
-          
+
           while file = files.shift
             begin
               if file.is_a?(Array) && file.last.is_a?(Continuation)
@@ -356,7 +356,7 @@ module YARD
               files.push([file, e.message])
             end
           end
-          
+
           after_parse_list_callbacks.each do |cb|
             cb.call(files_copy, global_state)
           end
@@ -375,12 +375,12 @@ module YARD
       # @return [Symbol] the parser type associated with the parser instance.
       #   This should be set by the {#initialize constructor}.
       attr_reader :parser_type
-      
+
       # @return [OpenStruct] an open struct containing arbitrary global state
       #   shared between files and handlers.
       # @since 0.7.0
       attr_reader :globals
-      
+
       # @return [String] the contents of the file to be parsed
       # @since 0.7.0
       attr_reader :contents
@@ -421,18 +421,18 @@ module YARD
 
         @contents = content
         @parser = parser_class.new(content, file)
-        
+
         self.class.before_parse_file_callbacks.each do |cb|
           return @parser if cb.call(self) == false
         end
-          
+
         @parser.parse
         post_process
-        
+
         self.class.after_parse_file_callbacks.each do |cb|
           cb.call(self)
         end
-        
+
         @parser
       rescue ArgumentError, NotImplementedError => e
         log.warn("Cannot parse `#{file}': #{e.message}")

--- a/lib/yard/rake/yardoc_task.rb
+++ b/lib/yard/rake/yardoc_task.rb
@@ -27,7 +27,7 @@ module YARD
       # @return [Proc] a proc to call after running the task
       attr_accessor :after
 
-      # @return [Verifier, Proc] an optional {Verifier} to run against all objects 
+      # @return [Verifier, Proc] an optional {Verifier} to run against all objects
       #   being generated. Any object that the verifier returns false for will be
       #   excluded from documentation. This attribute can also be a lambda.
       # @see Verifier

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -107,11 +107,11 @@ module YARD
       def html_markup_html(text)
         text
       end
-      
+
       # Highlights Ruby source. Similar to {#html_syntax_highlight}, but
       # this method is meant to be called from {#htmlify} when markup is
       # set to "ruby".
-      # 
+      #
       # @param [String] source the Ruby source
       # @return [String] the highlighted HTML
       # @since 0.7.0
@@ -208,7 +208,7 @@ module YARD
         return title || file.title unless serializer
         link_url(url_for_file(file, anchor), title || file.title)
       end
-      
+
       # (see BaseHelper#link_include_file)
       def link_include_file(file)
         unless file.is_a?(CodeObjects::ExtraFileObject)

--- a/yard.gemspec
+++ b/yard.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path(File.dirname(__FILE__) + '/lib/yard')
 Gem::Specification.new do |s|
   s.name          = "yard"
-  s.summary       = "Documentation tool for consistent and usable documentation in Ruby." 
+  s.summary       = "Documentation tool for consistent and usable documentation in Ruby."
   s.description   = <<-eof
     YARD is a documentation generation tool for the Ruby programming language.
     It enables the user to generate consistent, usable documentation that can be


### PR DESCRIPTION
I added rdiscount as a dependency. The default functionality on 'yard doc' is to use rdiscount which if not installed will generate an error message, it should be a dependency rather than an error message. Adding this in will install rdiscount when the yard gem is installed.

This is a huge library and a great tool btw, keep up the good work. ^_^
