### PR TITLE
Minor change on autoload

### DIFF
--- a/lib/yard/autoload.rb
+++ b/lib/yard/autoload.rb
@@ -1,5 +1,5 @@
 # @private
-def __p(*path) File.join(YARD::ROOT, 'yard', *path) end
+def __p(path) File.join(YARD::ROOT, 'yard', *path.split('/')); end
 
 module YARD
   module CLI # Namespace for command-line interface components


### PR DESCRIPTION
__p method should not depend on / file path separator. Actually it has only one parameter.

If you think that we should use '/', there is no need of *args logic.
