### PR TITLE
Don't use bundler_args: --local in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 # Passes arguments to bundle install (http://gembundler.com/man/bundle-install.1.html)
-bundler_args: --local
+# bundler_args:
 
 # Specify which ruby versions you wish to run your tests on, each version will be used
 rvm:


### PR DESCRIPTION
This setting only works on the current production worker because the gems all happen to be installed already. The new worker setup will rollback changes after every install and so tests will always fail with this setting.
