### PR TITLE
[html] fix missing escape in title.

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -246,7 +246,7 @@ module YARD
         return title if obj.is_a?(CodeObjects::Proxy)
 
         link = url_for(obj, anchor, relative)
-        link = link ? link_url(link, title, :title => "#{obj.path} (#{obj.type})") : title
+        link = link ? link_url(link, title, :title => h("#{obj.path} (#{obj.type})")) : title
         "<span class='object_link'>" + link + "</span>"
       end
 

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -194,6 +194,20 @@ describe YARD::Templates::Helpers::HtmlHelper do
       stub!(:serializer).and_return(serializer)
       link_object("YARD").should =~ %r{>YARD</a>}
     end
+
+    it "should escape method name in title" do
+      YARD.parse_string <<-'eof'
+        class Array
+          def &(other)
+          end
+        end
+      eof
+      obj = Registry.at('Array#&')
+      serializer = Serializers::FileSystemSerializer.new
+      stub!(:serializer).and_return(serializer)
+      stub!(:object).and_return(obj)
+      link_object("Array#&").should =~ %r{title="Array#&amp; \(method\)"}
+    end
   end
 
   describe '#url_for' do


### PR DESCRIPTION
I found that "&" method isn't escaped in <a title="...">. "&" is a valid method name in Ruby. e.g.: Array#&.
