### PR TITLE
[template][html] add missing escape in object link label.

### DIFF
--- a/templates/default/fulldoc/html/full_list_methods.erb
+++ b/templates/default/fulldoc/html/full_list_methods.erb
@@ -1,7 +1,7 @@
 <% n = 1 %>
 <% @items.each do |item| %>
   <li class="r<%= n %> <%= item.has_tag?(:deprecated) ? 'deprecated' : '' %>">
-    <%= linkify item, item.name(true) %> 
+    <%= linkify item, h(item.name(true)) %>
     <% if item.namespace && !item.namespace.root? %>
       <small><%= item.namespace %></small>
     <% else %>


### PR DESCRIPTION
This problem can be reproducable by the following steps:
1. Create the following script:
   
      class Array
    def &(other)
    end
      end
2. Genreate documents from the above script:
   
      % yardoc array-amp.rb
3. Find link markup in method_list.html:
   
      % grep '#&' method_list.html
      <span class='object_link'><a href="Array.html#%26-instance_method" title="Array#& (method)">#&</a></span>
   
    '>#&</a' should be '>#&amp;</a'.

It seems that other places in templates have the same problem.
