### PR TITLE
various improvements to c_parser

### DIFF
--- a/lib/yard/parser/c_parser.rb
+++ b/lib/yard/parser/c_parser.rb
@@ -157,9 +157,18 @@ module YARD
           remove_private_comments(comment) if comment
 
           # see if we can find the whole body
+          open_braces = 0
+          start = content.index(body_text)
+          index = start + body_text.size
+          begin
+            index = content.index(/\{|\}/, index)
+            break if index.nil?
+            open_braces += content[index,1] == '{' ? +1 : -1
+            index += 1
+          end while (open_braces > 0)
 
-          re = Regexp.escape(body_text) + '[^(]*\{.*?\}'
-          body_text = $& if /#{re}/m =~ content
+          start += comment.to_s.size
+          body_text = content[start,index - start] unless index.nil?
 
           # The comment block may have been overridden with a 'Document-method'
           # block. This happens in the interpreter when multiple methods are


### PR DESCRIPTION
Hi,

while generating documentation for libarchive-rs.rubyforge.org, I found the following issues:
- Some C return types, such as (un)signed short|int|... were not mapped as I would have expected.
- Override comments for constructors in C were not recognized.
- The parser couldn't handle nested braces while scanning for the function body.

It would be nice if these patches could make their way into Yard.

Thanks for a great doc tool. The HTML generated by Yard looks awesome.

Cheers,
Tobias
