### PR TITLE
Add a 300px padding to the bottom of documents 

### DIFF
--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -1,5 +1,5 @@
 body { 
-  padding: 0 20px;
+  padding: 0 20px 300px;
   font-family: "Lucida Sans", "Lucida Grande", Verdana, Arial, sans-serif; 
   font-size: 13px;
 }


### PR DESCRIPTION
This allows users to scroll down further, and thus to have documentation
items centered on the screen rather than stuck to the bottom.
