### PR TITLE
escape HTML meta characters in text for HTML output.

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -96,7 +96,7 @@ module YARD
       # @return [String] the output HTML
       # @since 0.6.0
       def html_markup_text(text)
-        "<pre>" + text + "</pre>"
+        "<pre>" + h(text) + "</pre>"
       end
 
       # @return [String] the same text with no markup


### PR DESCRIPTION
Here is an example text file.

hello.txt:

```
Hello >_<!
```

Here is a command to generate HTML:

```
% yardoc - hello.txt
```

It generates the following HTML:

```
...
...<pre>Hello >_<!</pre>...
...
```

We should escape ">", "<" and so on in text to output valid HTML.
