### PR TITLE
Support pot output.

### DIFF
--- a/.yardopts_i18n
+++ b/.yardopts_i18n
@@ -1,0 +1,14 @@
+--protected
+--no-private
+--exclude /server/templates/
+--exclude /yard/rubygems/
+-
+docs/WhatsNew.md
+docs/GettingStarted.md
+docs/Overview.md
+docs/CodeObjects.md
+docs/Tags.md
+docs/Parser.md
+docs/Handlers.md
+docs/Templates.md
+docs/Glossary.md

--- a/lib/yard/autoload.rb
+++ b/lib/yard/autoload.rb
@@ -15,6 +15,7 @@ module YARD
     autoload :Stats,          __p('cli/stats')
     autoload :Yardoc,         __p('cli/yardoc')
     autoload :YRI,            __p('cli/yri')
+    autoload :I18n,           __p('cli/i18n')
   end
 
   # A "code object" is defined as any entity in the Ruby language.

--- a/lib/yard/cli/command_parser.rb
+++ b/lib/yard/cli/command_parser.rb
@@ -40,7 +40,8 @@ module YARD
         :list   => List,
         :ri     => YRI,
         :server => Server,
-        :stats  => Stats
+        :stats  => Stats,
+        :i18n   => I18n
       ]
 
       self.default_command = :doc

--- a/lib/yard/cli/i18n.rb
+++ b/lib/yard/cli/i18n.rb
@@ -1,0 +1,292 @@
+require "pathname"
+require "stringio"
+
+module YARD
+  module CLI
+    # CLI command to support internationalization (a.k.a. i18n).
+    # I18n feature is based on gettext technology.
+    # This command generates .pot file from docstring and extra
+    # documentation.
+    #
+    # @since 0.8.0
+    # @todo Support msgminit and msgmerge features?
+    class I18n < Yardoc
+      def initialize
+        super
+        @options.serializer.basepath = "po/yard.pot"
+      end
+
+      def description
+        'Generates .pot file from source code and extra documentation'
+      end
+
+      def run(*args)
+        if args.size == 0 || !args.first.nil?
+          # fail early if arguments are not valid
+          return unless parse_arguments(*args)
+        end
+
+        YARD.parse(files, excluded)
+
+        serializer = options.serializer
+        pot_file_path = Pathname.new(serializer.basepath).expand_path
+        pot_file_dir_path, pot_file_basename = pot_file_path.split
+        relative_base_path = Pathname.pwd.relative_path_from(pot_file_dir_path)
+        serializer.basepath = pot_file_dir_path.to_s
+        serializer.serialize(pot_file_basename.to_s,
+                             generate_pot(relative_base_path.to_s))
+
+        true
+      end
+
+      private
+      def general_options(opts)
+        opts.banner = "Usage: yard i18n [options] [source_files [- extra_files]]"
+        opts.top.list.clear
+        opts.separator "(if a list of source files is omitted, "
+        opts.separator "  {lib,app}/**/*.rb ext/**/*.c is used.)"
+        opts.separator ""
+        opts.separator "Example: yard i18n -o yard.pot - FAQ LICENSE"
+        opts.separator "  The above example outputs .pot file for files in"
+        opts.separator "  lib/**/*.rb to yard.pot including the extra files"
+        opts.separator "  FAQ and LICENSE."
+        opts.separator ""
+        opts.separator "A base set of options can be specified by adding a .yardopts"
+        opts.separator "file to your base path containing all extra options separated"
+        opts.separator "by whitespace."
+        super(opts)
+      end
+
+      def generate_pot(relative_base_path)
+        generator = PotGenerator.new(relative_base_path)
+        objects = run_verifier(all_objects)
+        generator.parse_objects(objects)
+        generator.parse_files(options.files || [])
+        generator.generate
+      end
+
+      class PotGenerator
+        attr_reader :messages
+        def initialize(relative_base_path)
+          @relative_base_path = relative_base_path
+          @extracted_objects = {}
+          @messages = {}
+        end
+
+        def parse_objects(objects)
+          objects.each do |object|
+            extract_documents(object)
+          end
+        end
+
+        def parse_files(files)
+          files.each do |file|
+            extract_paragraphs(file)
+          end
+        end
+
+        def generate
+          pot = header
+          sorted_messages = @messages.sort_by do |message, options|
+            sorted_locations = (options[:locations] || []).sort_by do |location|
+              location
+            end
+            sorted_locations.first || []
+          end
+          sorted_messages.each do |message, options|
+            generate_message(pot, message, options)
+          end
+          pot
+        end
+
+        private
+        def header
+          <<-'EOH'
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2011-11-20 22:17+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+EOH
+        end
+
+        def generate_message(pot, message, options)
+          options[:comments].compact.uniq.each do |comment|
+            pot << "# #{comment}\n" unless comment.empty?
+          end
+          options[:locations].uniq.each do |path, line|
+            pot << "#: #{@relative_base_path}/#{path}:#{line}\n"
+          end
+          escaped_message = escape_message(message)
+          escaped_message = escaped_message.gsub(/\n/, "\\\\n\"\n\"")
+          pot << "msgid \"#{escaped_message}\"\n"
+          pot << "msgstr \"\"\n"
+          pot << "\n"
+          pot
+        end
+
+        def escape_message(message)
+          message.gsub(/(\\|")/) do
+            special_character = $1
+            "\\#{special_character}"
+          end
+        end
+
+        def add_message(text)
+          @messages[text] ||= {:locations => [], :comments => []}
+        end
+
+        def extract_documents(object)
+          return if @extracted_objects.has_key?(object)
+
+          @extracted_objects[object] = true
+          case object
+          when CodeObjects::NamespaceObject
+            object.children.each do |child|
+              extract_documents(child)
+            end
+          end
+
+          if object.group
+            message = add_message(object.group)
+            object.files.each do |path, line|
+              message[:locations] << [path, line]
+            end
+            message[:comments] << object.path unless object.path.empty?
+          end
+
+          docstring = object.docstring
+          unless docstring.empty?
+            text = Text.new(StringIO.new(docstring))
+            text.extract_messages do |type, *args|
+              case type
+              when :paragraph
+                paragraph, line_no = *args
+                message = add_message(paragraph.rstrip)
+                object.files.each do |path, line|
+                  message[:locations] << [path, (docstring.line || line) + line_no]
+                end
+                message[:comments] << object.path unless object.path.empty?
+              else
+                raise "should not reach here: unexpected type: #{type}"
+              end
+            end
+          end
+          docstring.tags.each do |tag|
+            extract_tag_documents(tag)
+          end
+        end
+
+        def extract_tag_documents(tag)
+          extract_tag_name(tag)
+          extract_tag_text(tag)
+        end
+
+        def extract_tag_name(tag)
+          return if tag.name.nil?
+          return if tag.name.is_a?(String) and tag.name.empty?
+          key = "tag|#{tag.tag_name}|#{tag.name}"
+          message = add_message(key)
+          tag.object.files.each do |file|
+            message[:locations] << file
+          end
+          tag_label = "@#{tag.tag_name}"
+          tag_label << " [#{tag.types.join(', ')}]" if tag.types
+          message[:comments] << tag_label
+        end
+
+        def extract_tag_text(tag)
+          return if tag.text.nil?
+          return if tag.text.empty?
+          message = add_message(tag.text)
+          tag.object.files.each do |file|
+            message[:locations] << file
+          end
+          tag_label = "@#{tag.tag_name}"
+          tag_label << " [#{tag.types.join(', ')}]" if tag.types
+          tag_label << " #{tag.name}" if tag.name
+          message[:comments] << tag_label
+        end
+
+        def extract_paragraphs(file)
+          File.open(file.filename) do |input|
+            text = Text.new(input, :have_header => true)
+            text.extract_messages do |type, *args|
+              case type
+              when :attribute
+                name, value, line_no = *args
+                message = add_message(value)
+                message[:locations] << [file.filename, line_no]
+                message[:comments] << name
+              when :paragraph
+                paragraph, line_no = *args
+                message = add_message(paragraph.rstrip)
+                message[:locations] << [file.filename, line_no]
+              else
+                raise "should not reach here: unexpected type: #{type}"
+              end
+            end
+          end
+        end
+      end
+
+      class Text
+        def initialize(input, options={})
+          @input = input
+          @options = options
+        end
+
+        def extract_messages
+          paragraph = ""
+          paragraph_start_line = 0
+          line_no = 0
+          in_header = @options[:have_header]
+
+          @input.each_line do |line|
+            line_no += 1
+            if in_header
+              case line
+              when /^#!\S+\s*$/
+                in_header = false unless line_no == 1
+              when /^\s*#\s*@(\S+)\s*(.+?)\s*$/
+                name, value = $1, $2
+                yield(:attribute, name, value, line_no)
+              else
+                in_header = false
+                next if line.chomp.empty?
+              end
+              next if in_header
+            end
+
+            case line
+            when /^\s*$/
+              next if paragraph.empty?
+              yield(:paragraph, paragraph.rstrip, paragraph_start_line)
+              paragraph = ""
+            else
+              paragraph_start_line = line_no if paragraph.empty?
+              paragraph << line
+            end
+          end
+          unless paragraph.empty?
+            yield(:paragraph, paragraph.rstrip, paragraph_start_line)
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/cli/i18n_spec.rb
+++ b/spec/cli/i18n_spec.rb
@@ -1,0 +1,653 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+
+describe YARD::CLI::I18n do
+  before do
+    @i18n = YARD::CLI::I18n.new
+    @i18n.use_document_file = false
+    @i18n.use_yardopts_file = false
+    output_path = File.expand_path(@i18n.options.serializer.basepath)
+    File.stub!(:open!).with(output_path, "wb")
+    YARD.stub!(:parse)
+  end
+
+  describe 'Defaults' do
+    before do
+      @i18n = YARD::CLI::I18n.new
+      @i18n.stub!(:yardopts).and_return([])
+      @i18n.stub!(:support_rdoc_document_file!).and_return([])
+      @i18n.parse_arguments
+    end
+
+    it "should read .yardopts by default" do
+      @i18n.use_yardopts_file.should == true
+    end
+
+    it "should use {lib,app}/**/*.rb and ext/**/*.c as default file glob" do
+      @i18n.files.should == ['{lib,app}/**/*.rb', 'ext/**/*.c']
+    end
+
+    it "should only show public visibility by default" do
+      @i18n.visibilities.should == [:public]
+    end
+  end
+
+  describe 'General options' do
+    def self.should_accept(*args, &block)
+      @counter ||= 0
+      @counter += 1
+      counter = @counter
+      args.each do |arg|
+        define_method("test_options_#{@counter}", &block)
+        it("should accept #{arg}") { send("test_options_#{counter}", arg) }
+      end
+    end
+
+    should_accept('--yardopts') do |arg|
+      @i18n = YARD::CLI::I18n.new
+      @i18n.use_document_file = false
+      @i18n.should_receive(:yardopts).at_least(1).times.and_return([])
+      @i18n.parse_arguments(arg)
+      @i18n.use_yardopts_file.should == true
+      @i18n.parse_arguments('--no-yardopts', arg)
+      @i18n.use_yardopts_file.should == true
+    end
+
+    should_accept('--yardopts with filename') do |arg|
+      @i18n = YARD::CLI::I18n.new
+      File.should_receive(:read_binary).with('.yardopts_i18n').and_return('')
+      @i18n.use_document_file = false
+      @i18n.parse_arguments('--yardopts', '.yardopts_i18n')
+      @i18n.use_yardopts_file.should == true
+      @i18n.options_file.should == '.yardopts_i18n'
+    end
+
+    should_accept('--no-yardopts') do |arg|
+      @i18n = YARD::CLI::I18n.new
+      @i18n.use_document_file = false
+      @i18n.should_not_receive(:yardopts)
+      @i18n.parse_arguments(arg)
+      @i18n.use_yardopts_file.should == false
+      @i18n.parse_arguments('--yardopts', arg)
+      @i18n.use_yardopts_file.should == false
+    end
+
+    should_accept('--exclude') do |arg|
+      YARD.should_receive(:parse).with(['a'], ['nota', 'b'])
+      @i18n.run(arg, 'nota', arg, 'b', 'a')
+    end
+  end
+
+  describe '--no-private option' do
+    it "should accept --no-private" do
+      obj = mock(:object)
+      obj.should_receive(:tag).ordered.with(:private).and_return(true)
+      @i18n.parse_arguments *%w( --no-private )
+      @i18n.options.verifier.call(obj).should == false
+    end
+
+    it "should hide object if namespace is @private with --no-private" do
+      ns = mock(:namespace)
+      ns.stub!(:type).and_return(:module)
+      ns.should_receive(:tag).with(:private).and_return(true)
+      obj = mock(:object)
+      obj.stub!(:namespace).and_return(ns)
+      obj.should_receive(:tag).with(:private).and_return(false)
+      @i18n.parse_arguments *%w( --no-private )
+      @i18n.options.verifier.call(obj).should == false
+    end
+
+    it "should not call #tag on namespace if namespace is proxy with --no-private" do
+      ns = mock(:namespace)
+      ns.should_receive(:is_a?).with(CodeObjects::Proxy).and_return(true)
+      ns.should_not_receive(:tag)
+      obj = mock(:object)
+      obj.stub!(:type).and_return(:class)
+      obj.stub!(:namespace).and_return(ns)
+      obj.stub!(:visibility).and_return(:public)
+      obj.should_receive(:tag).ordered.with(:private).and_return(false)
+      @i18n.parse_arguments *%w( --no-private )
+      @i18n.options.verifier.call(obj).should == true
+    end
+
+    # @bug gh-197
+    it "should not call #tag on namespace if namespace is proxy with --no-private" do
+      Registry.clear
+      YARD.parse_string "module Qux; class Foo::Bar; end; end"
+      foobar = Registry.at('Foo::Bar')
+      foobar.namespace.type = :module
+      @i18n.parse_arguments *%w( --no-private )
+      @i18n.options.verifier.call(foobar).should == true
+    end
+
+    it "should not call #tag on proxy object" do # @bug gh-197
+      @i18n.parse_arguments *%w( --no-private )
+      @i18n.options.verifier.call(P('ProxyClass')).should == true
+    end
+
+    it "should hide methods inside a 'private' class/module with --no-private" do
+      Registry.clear
+      YARD.parse_string <<-eof
+        # @private
+        class ABC
+          def foo; end
+        end
+      eof
+      @i18n.parse_arguments *%w( --no-private )
+      @i18n.options.verifier.call(Registry.at('ABC')).should be_false
+      @i18n.options.verifier.call(Registry.at('ABC#foo')).should be_false
+    end
+  end
+
+  describe '.yardopts handling' do
+    before do
+      @i18n.use_yardopts_file = true
+    end
+
+    it "should search for and use yardopts file specified by #options_file" do
+      File.should_receive(:read_binary).with("test").and_return("-o \n\nMYPATH\nFILE1 FILE2")
+      @i18n.use_document_file = false
+      @i18n.options_file = "test"
+      File.should_receive(:open!).with(File.expand_path("MYPATH"), "wb")
+      @i18n.run
+      @i18n.files.should == ["FILE1", "FILE2"]
+    end
+
+    it "should use String#shell_split to split .yardopts tokens" do
+      optsdata = "foo bar"
+      optsdata.should_receive(:shell_split)
+      File.should_receive(:read_binary).with("test").and_return(optsdata)
+      @i18n.options_file = "test"
+      @i18n.run
+    end
+
+    it "should allow opts specified in command line to override yardopts file" do
+      File.should_receive(:read_binary).with(".yardopts").and_return("-o NOTMYPATH")
+      File.should_receive(:open!).with(File.expand_path("MYPATH"), "wb")
+      @i18n.run("-o", "MYPATH", "FILE")
+      @i18n.files.should == ["FILE"]
+    end
+  end
+
+  describe 'Query options' do
+    before do
+      Registry.clear
+    end
+
+    it "should setup visibility rules as verifier" do
+      methobj = CodeObjects::MethodObject.new(:root, :test) {|o| o.visibility = :private }
+      File.should_receive(:read_binary).with("test").and_return("--private")
+      @i18n.use_yardopts_file = true
+      @i18n.options_file = "test"
+      @i18n.run
+      @i18n.options.verifier.call(methobj).should be_true
+    end
+
+    it "should accept a --query" do
+      @i18n.parse_arguments *%w( --query @return )
+      @i18n.options.verifier.should be_a(Verifier)
+    end
+
+    it "should accept multiple --query arguments" do
+      obj = mock(:object)
+      obj.should_receive(:tag).ordered.with('return').and_return(true)
+      obj.should_receive(:tag).ordered.with('tag').and_return(false)
+      @i18n.parse_arguments *%w( --query @return --query @tag )
+      @i18n.options.verifier.should be_a(Verifier)
+      @i18n.options.verifier.call(obj).should == false
+    end
+  end
+
+  describe 'Extra file arguments' do
+    it "should accept extra files if specified after '-' with source files" do
+      Dir.should_receive(:glob).with('README*').and_return([])
+      File.should_receive(:file?).with('extra_file1').and_return(true)
+      File.should_receive(:file?).with('extra_file2').and_return(true)
+      File.should_receive(:read).with('extra_file1').and_return('')
+      File.should_receive(:read).with('extra_file2').and_return('')
+      @i18n.parse_arguments *%w( file1 file2 - extra_file1 extra_file2 )
+      @i18n.files.should == %w( file1 file2 )
+      @i18n.options.files.should ==
+        [CodeObjects::ExtraFileObject.new('extra_file1', ''),
+          CodeObjects::ExtraFileObject.new('extra_file2', '')]
+    end
+
+    it "should accept files section only containing extra files" do
+      Dir.should_receive(:glob).with('README*').and_return([])
+      @i18n.parse_arguments *%w( - LICENSE )
+      @i18n.files.should == %w( {lib,app}/**/*.rb ext/**/*.c )
+      @i18n.options.files.should == [CodeObjects::ExtraFileObject.new('LICENSE', '')]
+    end
+
+    it "should accept globs as extra files" do
+      Dir.should_receive(:glob).with('README*').and_return []
+      Dir.should_receive(:glob).with('*.txt').and_return ['a.txt', 'b.txt']
+      File.should_receive(:read).with('a.txt').and_return('')
+      File.should_receive(:read).with('b.txt').and_return('')
+      File.should_receive(:file?).with('a.txt').and_return(true)
+      File.should_receive(:file?).with('b.txt').and_return(true)
+      @i18n.parse_arguments *%w( file1 file2 - *.txt )
+      @i18n.files.should == %w( file1 file2 )
+      @i18n.options.files.should ==
+        [CodeObjects::ExtraFileObject.new('a.txt', ''),
+          CodeObjects::ExtraFileObject.new('b.txt', '')]
+    end
+
+    it "should warn if extra file is not found" do
+      log.should_receive(:warn).with(/Could not find extra file: UNKNOWN/)
+      @i18n.parse_arguments *%w( - UNKNOWN )
+    end
+
+    it "should warn if readme file is not found" do
+      log.should_receive(:warn).with(/Could not find readme file: UNKNOWN/)
+      @i18n.parse_arguments *%w( -r UNKNOWN )
+    end
+  end
+
+  describe 'Source file arguments' do
+    it "should accept no params and parse {lib,app}/**/*.rb ext/**/*.c" do
+      @i18n.parse_arguments
+      @i18n.files.should == %w( {lib,app}/**/*.rb ext/**/*.c )
+    end
+  end
+
+  describe 'Tags options' do
+    def tag_created(switch, factory_method)
+      visible_tags = mock(:visible_tags)
+      visible_tags.should_receive(:|).ordered.with([:foo])
+      visible_tags.should_receive(:-).ordered.with([]).and_return(visible_tags)
+      Tags::Library.should_receive(:define_tag).with('Foo', :foo, factory_method)
+      Tags::Library.stub!(:visible_tags=)
+      Tags::Library.should_receive(:visible_tags).at_least(1).times.and_return(visible_tags)
+      @i18n.parse_arguments("--#{switch}-tag", 'foo')
+    end
+
+    def tag_hidden(tag)
+      visible_tags = mock(:visible_tags)
+      visible_tags.should_receive(:|).ordered.with([tag])
+      visible_tags.should_receive(:-).ordered.with([tag]).and_return([])
+      Tags::Library.should_receive(:define_tag).with(tag.to_s.capitalize, tag, nil)
+      Tags::Library.stub!(:visible_tags=)
+      Tags::Library.should_receive(:visible_tags).at_least(1).times.and_return(visible_tags)
+    end
+
+    it "should accept --tag" do
+      Tags::Library.should_receive(:define_tag).with('Title of Foo', :foo, nil)
+      @i18n.parse_arguments('--tag', 'foo:Title of Foo')
+    end
+
+    it "should accept --tag without title (and default to captialized tag name)" do
+      Tags::Library.should_receive(:define_tag).with('Foo', :foo, nil)
+      @i18n.parse_arguments('--tag', 'foo')
+    end
+
+    it "should only list tag once if declared twice" do
+      visible_tags = []
+      Tags::Library.stub!(:define_tag)
+      Tags::Library.stub!(:visible_tags).and_return([:foo])
+      Tags::Library.stub!(:visible_tags=) {|value| visible_tags = value }
+      @i18n.parse_arguments('--tag', 'foo', '--tag', 'foo')
+      visible_tags.should == [:foo]
+    end
+
+    it "should accept --type-tag" do
+      tag_created 'type', :with_types
+    end
+
+    it "should accept --type-name-tag" do
+      tag_created 'type-name', :with_types_and_name
+    end
+
+    it "should accept --name-tag" do
+      tag_created 'name', :with_name
+    end
+
+    it "should accept --title-tag" do
+      tag_created 'title', :with_title_and_text
+    end
+
+    it "should accept --hide-tag before tag is listed" do
+      tag_hidden(:anewfoo)
+      @i18n.parse_arguments('--hide-tag', 'anewfoo', '--tag', 'anewfoo')
+    end
+
+    it "should accept --hide-tag after tag is listed" do
+      tag_hidden(:anewfoo2)
+      @i18n.parse_arguments('--tag', 'anewfoo2', '--hide-tag', 'anewfoo2')
+    end
+
+    it "should accept --transitive-tag" do
+      @i18n.parse_arguments('--transitive-tag', 'foo')
+      Tags::Library.transitive_tags.should include(:foo)
+    end
+  end
+
+  describe '#run' do
+    it "should parse_arguments if run() is called" do
+      @i18n.should_receive(:parse_arguments)
+      @i18n.run
+    end
+
+    it "should parse_arguments if run(arg1, arg2, ...) is called" do
+      @i18n.should_receive(:parse_arguments)
+      @i18n.run('--private', '-p', 'foo')
+    end
+
+    it "should not parse_arguments if run(nil) is called" do
+      @i18n.should_not_receive(:parse_arguments)
+      @i18n.run(nil)
+    end
+  end
+end
+
+describe YARD::CLI::I18n::PotGenerator do
+  before do
+    @generator = YARD::CLI::I18n::PotGenerator.new("..")
+  end
+
+  describe "Generate" do
+    it "should generate the default header" do
+      @generator.generate.should == <<-'eoh'
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2011-11-20 22:17+0900\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+eoh
+    end
+
+    it "should generate messages in location order" do
+      @generator.stub!(:header).and_return("HEADER\n\n")
+      @generator.messages["tag|see|Parser::SourceParser.parse"] = {
+        :locations => [["yard.rb", 14]],
+        :comments => ["@see"],
+      }
+      @generator.messages["Parses a path or set of paths"] = {
+        :locations => [["yard.rb", 12], ["yard/parser/source_parser.rb", 83]],
+        :comments => ["YARD.parse", "YARD::Parser::SourceParser.parse"],
+      }
+      @generator.generate.should == <<-'eoh'
+HEADER
+
+# YARD.parse
+# YARD::Parser::SourceParser.parse
+#: ../yard.rb:12
+#: ../yard/parser/source_parser.rb:83
+msgid "Parses a path or set of paths"
+msgstr ""
+
+# @see
+#: ../yard.rb:14
+msgid "tag|see|Parser::SourceParser.parse"
+msgstr ""
+
+eoh
+    end
+  end
+
+  describe "Escape" do
+    def generate_message_pot(message)
+      pot = ""
+      options = {
+        :comments => [],
+        :locations => [],
+      }
+      @generator.send(:generate_message, pot, message, options)
+      pot
+    end
+
+    it "should escape <\\>" do
+      generate_message_pot("hello \\ world").should == <<-'eop'
+msgid "hello \\ world"
+msgstr ""
+
+eop
+    end
+
+    it "should escape <\">" do
+      generate_message_pot("hello \" world").should == <<-'eop'
+msgid "hello \" world"
+msgstr ""
+
+eop
+    end
+
+    it "should escape <\\n>" do
+      generate_message_pot("hello \n world").should == <<-'eop'
+msgid "hello \n"
+" world"
+msgstr ""
+
+eop
+    end
+  end
+
+  describe "Object" do
+    before do
+      Registry.clear
+      @yard = YARD::CodeObjects::ModuleObject.new(:root, :YARD)
+    end
+
+    it "should extract docstring" do
+      object = YARD::CodeObjects::MethodObject.new(@yard, :parse, :module) do |o|
+        o.docstring = "An alias to {Parser::SourceParser}'s parsing method"
+      end
+      @generator.parse_objects([object])
+      @generator.messages.should == {
+        "An alias to {Parser::SourceParser}'s parsing method" => {
+          :locations => [],
+          :comments => ["YARD.parse"],
+        }
+      }
+    end
+
+    it "should extract location" do
+      object = YARD::CodeObjects::MethodObject.new(@yard, :parse, :module) do |o|
+        o.docstring = "An alias to {Parser::SourceParser}'s parsing method"
+        o.files = [["yard.rb", 12]]
+      end
+      @generator.parse_objects([object])
+      @generator.messages.should == {
+        "An alias to {Parser::SourceParser}'s parsing method" => {
+          :locations => [["yard.rb", 13]],
+          :comments => ["YARD.parse"],
+        }
+      }
+    end
+
+    it "should extract tag name" do
+      object = YARD::CodeObjects::MethodObject.new(@yard, :parse, :module) do |o|
+        o.docstring = "@see Parser::SourceParser.parse"
+        o.files = [["yard.rb", 12]]
+      end
+      @generator.parse_objects([object])
+      @generator.messages.should == {
+        "tag|see|Parser::SourceParser.parse" => {
+          :locations => [["yard.rb", 12]],
+          :comments => ["@see"],
+        },
+      }
+    end
+
+    it "should extract tag text" do
+      object = YARD::CodeObjects::MethodObject.new(@yard, :parse, :module) do |o|
+        o.docstring = <<-eod
+@example Parse a glob of files
+  YARD.parse('lib/**/*.rb')
+eod
+        o.files = [["yard.rb", 12]]
+      end
+      @generator.parse_objects([object])
+      @generator.messages.should == {
+        "tag|example|Parse a glob of files" => {
+          :locations => [["yard.rb", 12]],
+          :comments => ["@example"],
+        },
+        "YARD.parse('lib/**/*.rb')" => {
+          :locations => [["yard.rb", 12]],
+          :comments => ["@example Parse a glob of files"],
+        }
+      }
+    end
+
+    it "should extract tag types" do
+      object = YARD::CodeObjects::MethodObject.new(@yard, :parse, :module) do |o|
+        o.docstring = <<-eod
+@param [String, Array<String>] paths a path, glob, or list of paths to
+  parse
+eod
+        o.files = [["yard.rb", 12]]
+      end
+      @generator.parse_objects([object])
+      @generator.messages.should == {
+        "tag|param|paths" => {
+          :locations => [["yard.rb", 12]],
+          :comments => ["@param [String, Array<String>]"],
+        },
+        "a path, glob, or list of paths to\nparse" => {
+          :locations => [["yard.rb", 12]],
+          :comments => ["@param [String, Array<String>] paths"],
+        }
+      }
+    end
+  end
+
+  describe "File" do
+    it "should extract attribute" do
+      path = "GettingStarted.md"
+      text = <<-eor
+# @title Getting Started Guide
+
+# Getting Started with YARD
+eor
+      File.stub!(:open).with(path).and_yield(StringIO.new(text))
+      File.stub!(:read).with(path).and_return(text)
+      file = YARD::CodeObjects::ExtraFileObject.new(path)
+      @generator.parse_files([file])
+      @generator.messages.should == {
+        "Getting Started Guide" => {
+          :locations => [[path, 1]],
+          :comments => ["title"],
+        },
+        "# Getting Started with YARD" => {
+          :locations => [[path, 3]],
+          :comments => [],
+        }
+      }
+    end
+
+    it "should extract paragraphs" do
+      path = "README.md"
+      paragraph1 = <<-eop.strip
+Note that class methods must not be referred to with the "::" namespace
+separator. Only modules, classes and constants should use "::".
+eop
+      paragraph2 = <<-eop.strip
+You can also do lookups on any installed gems. Just make sure to build the
+.yardoc databases for installed gems with:
+eop
+      text = <<-eot
+#{paragraph1}
+
+#{paragraph2}
+eot
+      File.stub!(:open).with(path).and_yield(StringIO.new(text))
+      File.stub!(:read).with(path).and_return(text)
+      file = YARD::CodeObjects::ExtraFileObject.new(path)
+      @generator.parse_files([file])
+      @generator.messages.should == {
+        paragraph1 => {
+          :locations => [[path, 1]],
+          :comments => [],
+        },
+        paragraph2 => {
+          :locations => [[path, 4]],
+          :comments => [],
+        }
+      }
+    end
+  end
+end
+
+describe YARD::CLI::I18n::Text do
+  def extract_messages(input, options={})
+    text = YARD::CLI::I18n::Text.new(StringIO.new(input), options)
+    messages = []
+    text.extract_messages do |*message|
+      messages << message
+    end
+    messages
+  end
+
+  describe "Header" do
+    it "should extract attribute" do
+      text = <<-eot
+# @title Getting Started Guide
+
+# Getting Started with YARD
+eot
+      extract_messages(text, :have_header => true).should ==
+        [[:attribute, "title", "Getting Started Guide", 1],
+         [:paragraph, "# Getting Started with YARD", 3]]
+    end
+
+    it "should ignore markup line" do
+      text = <<-eot
+#!markdown
+# @title Getting Started Guide
+
+# Getting Started with YARD
+eot
+      extract_messages(text, :have_header => true).should ==
+        [[:attribute, "title", "Getting Started Guide", 2],
+         [:paragraph, "# Getting Started with YARD", 4]]
+    end
+
+    it "should terminate header block by markup line not at the first line" do
+      text = <<-eot
+# @title Getting Started Guide
+#!markdown
+
+# Getting Started with YARD
+eot
+      extract_messages(text, :have_header => true).should ==
+        [[:attribute, "title", "Getting Started Guide", 1],
+         [:paragraph, "#!markdown", 2],
+         [:paragraph, "# Getting Started with YARD", 4]]
+    end
+  end
+
+  describe "Body" do
+    it "should split to paragraphs" do
+      paragraph1 = <<-eop.strip
+Note that class methods must not be referred to with the "::" namespace
+separator. Only modules, classes and constants should use "::".
+eop
+      paragraph2 = <<-eop.strip
+You can also do lookups on any installed gems. Just make sure to build the
+.yardoc databases for installed gems with:
+eop
+      text = <<-eot
+#{paragraph1}
+
+#{paragraph2}
+eot
+      extract_messages(text).should ==
+        [[:paragraph, paragraph1, 1],
+         [:paragraph, paragraph2, 4]]
+    end
+  end
+end


### PR DESCRIPTION
This change adds pot formatter.

Here is a sample transcript:

```
% ruby -I lib bin/yardoc --format pot --output po lib/**/*.rb
Files:         135
Modules:        37 (    5 undocumented)
Classes:       148 (   32 undocumented)
Constants:      62 (   25 undocumented)
Methods:       680 (   78 undocumented)
 84.90% documented
% head po/yard.pot
# YARD::ROOT
#: ../lib/yard.rb:4
msgid "The root path for YARD source libraries"
msgstr ""

# YARD::TEMPLATE_ROOT
#: ../lib/yard.rb:7
msgid "The root path for YARD builtin templates"
msgstr ""
```

Translators generates #{LOCALE}.po from yard.pot. For example, here is a transcript that generates ja.po from yard.pot:

```
% LANG=C msginit --locale ja --input po/yard.pot --output po/ja.po
The new message catalog should contain your email address, so that users can
give you feedback about the translations, and so that maintainers can contact
you in case of unexpected technical problems.

Is the following your email address?
  kou@clear-code.com
Please confirm by pressing Return, or enter your email address.
kou@clear-code.com
Retrieving http://translationproject.org/team/index.html... done.
A translation team for your language (ja) does not exist yet.
If you want to create a new translation team for ja, please visit
  http://www.iro.umontreal.ca/contrib/po/HTML/teams.html
  http://www.iro.umontreal.ca/contrib/po/HTML/leaders.html
  http://www.iro.umontreal.ca/contrib/po/HTML/index.html
po/yard.pot:10858: warning: The following msgid contains non-ASCII characters.
                            This will cause problems to translators who use a character encoding
                            different from yours. Consider using a pure ASCII msgid instead.
                            YARD is a documentation generation tool for the Ruby programming language. 
                            It enables the user to generate consistent, usable documentation that can be 
                            exported to a number of formats very easily, and also supports extending for 
                            custom Ruby constructs such as custom class level definitions. Below is a 
                            summary of some of YARD's notable features.
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10858: invalid multibyte sequence
po/yard.pot:10868: warning: The following msgid contains non-ASCII characters.
                            This will cause problems to translators who use a character encoding
                            different from yours. Consider using a pure ASCII msgid instead.
                            Feature List
                            ------------

                            **1. RDoc/SimpleMarkup Formatting Compatibility**: YARD is made to be compatible 
                            with RDoc formatting. In fact, YARD does no processing on RDoc documentation 
                            strings, and leaves this up to the output generation tool to decide how to 
                            render the documentation. 
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10868: invalid multibyte sequence
po/yard.pot:10880: warning: The following msgid contains non-ASCII characters.
                            This will cause problems to translators who use a character encoding
                            different from yours. Consider using a pure ASCII msgid instead.
                            **2. Yardoc Meta-tag Formatting Like Python, Java, Objective-C and other languages**: 
                            YARD uses a '@tag' style definition syntax for meta tags alongside  regular code 
                            documentation. These tags should be able to happily sit side by side RDoc formatted 
                            documentation, but provide a much more consistent and usable way to describe 
                            important information about objects, such as what parameters they take and what types
                            they are expected to be, what type a method should return, what exceptions it can 
                            raise, if it is deprecated, etc.. It also allows information to be better (and more 
                            consistently) organized during the output generation phase. You can find a list
                            of tags in the {file:docs/Tags.md#taglist Tags.md} file.
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10880: invalid multibyte sequence
po/yard.pot:10889: warning: The following msgid contains non-ASCII characters.
                            This will cause problems to translators who use a character encoding
                            different from yours. Consider using a pure ASCII msgid instead.
                            YARD also supports an optional "types" declarations for certain tags. 
                            This allows the developer to document type signatures for ruby methods and 
                            parameters in a non intrusive but helpful and consistent manner. Instead of 
                            describing this data in the body of the description, a developer may formally 
                            declare the parameter or return type(s) in a single line. Consider the 
                            following Yardoc'd method: 
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10889: invalid multibyte sequence
po/yard.pot:10925: warning: The following msgid contains non-ASCII characters.
                            This will cause problems to translators who use a character encoding
                            different from yours. Consider using a pure ASCII msgid instead.
                                 # Reverses the contents of a String or IO object. 
                                 # 
                                 # @param [String, #read] contents the contents to reverse 
                                 # @return [String] the contents reversed lexically 
                                 def reverse(contents) 
                                   contents = contents.read if respond_to? :read 
                                   contents.reverse 
                                 end

                            With the above @param tag, we learn that the contents parameter can either be
                            a String or any object that responds to the 'read' method, which is more 
                            powerful than the textual description, which says it should be an IO object. 
                            This also informs the developer that they should expect to receive a String 
                            object returned by the method, and although this may be obvious for a 
                            'reverse' method, it becomes very useful when the method name may not be as 
                            descriptive. 

                            **3. Custom Constructs and Extensibility of YARD**: YARD is designed to be 
                            extended and customized by plugins. Take for instance the scenario where you 
                            need to document the following code: 

                                class List
                                  # Sets the publisher name for the list.
                                  cattr_accessor :publisher
                                end

                            This custom declaration provides dynamically generated code that is hard for a
                            documentation tool to properly document without help from the developer. To 
                            ease the pains of manually documenting the procedure, YARD can be extended by 
                            the developer to handle the `cattr_accessor` construct and automatically create
                            an attribute on the class with the associated documentation. This makes 
                            documenting external API's, especially dynamic ones, a lot more consistent for
                            consumption by the users. 
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10925: invalid multibyte sequence
po/yard.pot:10942: warning: The following msgid contains non-ASCII characters.
                            This will cause problems to translators who use a character encoding
                            different from yours. Consider using a pure ASCII msgid instead.
                            YARD is also designed for extensibility everywhere else, allowing you to add
                            support for new programming languages, new data structures and even where/how
                            data is stored.

                            **4. Raw Data Output**: YARD also outputs documented objects as raw data (the 
                            dumped Namespace) which can be reloaded to do generation at a later date, or 
                            even auditing on code. This means that any developer can use the raw data to 
                            perform output generation for any custom format, such as YAML, for instance. 
                            While YARD plans to support XHTML style documentation output as well as 
                            command line (text based) and possibly XML, this may still be useful for those
                            who would like to reap the benefits of YARD's processing in other forms, such 
                            as throwing all the documentation into a database. Another useful way of 
                            exploiting this raw data format would be to write tools that can auto generate
                            test cases, for example, or show possible unhandled exceptions in code. 
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence
po/yard.pot:10942: invalid multibyte sequence

Created po/ja.po.
```

Those warning messages are caused by "U+2028" (LINE SEPARATOR) characters in README.md. LINE SEPARATOR isn't included in ASCII charset.
