### PR TITLE
Change usage of undef_method to remove_method

### DIFF
--- a/lib/yard/verifier.rb
+++ b/lib/yard/verifier.rb
@@ -118,7 +118,7 @@ module YARD
     # @return [void]
     def unmodify_nilclass
       NILCLASS_METHODS.each do |meth|
-        NilClass.send(:undef_method, meth)
+        NilClass.send(:remove_method, meth)
       end
     end
 


### PR DESCRIPTION
undef_method has very different semantics. It prevents the class
from responding to the named method. This means that also original
methods on super classes won't be called. This for example results
in weird behavior on Rubinius since the original method_missing
method can't be called which normally throws the NoMethodError.

Also see:
http://www.nach-vorne.de/2008/2/28/undef_method-remove_method/index.html
