### PR TITLE
gem install (and gem rdoc) no longer installs rdoc or ri

### DIFF
--- a/lib/yard/rubygems/doc_manager.rb
+++ b/lib/yard/rubygems/doc_manager.rb
@@ -38,8 +38,10 @@ class Gem::DocManager
 
     FileUtils.mkdir_p @doc_dir unless File.exist?(@doc_dir)
 
-    self.class.load_rdoc if @spec.has_rdoc?
-    self.class.load_yardoc if @spec.has_yardoc?
+    if @spec.has_yardoc?
+    then self.class.load_yardoc
+    else self.class.load_rdoc
+    end
   end
 
   def install_yardoc
@@ -52,8 +54,7 @@ class Gem::DocManager
   end
 
   def install_ri_yard
-    install_ri_yard_orig if @spec.has_rdoc?
-    return if @spec.has_rdoc? == false
+    install_ri_yard_orig unless FalseClass === @spec.has_rdoc?
     return if @spec.has_yardoc?
 
     self.class.load_yardoc
@@ -64,10 +65,9 @@ class Gem::DocManager
   alias install_ri install_ri_yard
 
   def install_rdoc_yard
-    if @spec.has_rdoc?
-      install_rdoc_yard_orig
-    elsif @spec.has_yardoc?
-      install_yardoc
+    if @spec.has_yardoc?
+    then install_yardoc
+    else install_rdoc_yard_orig
     end
   end
   alias install_rdoc_yard_orig install_rdoc


### PR DESCRIPTION
After installing yard, neither gem install nor gem rdoc is able to install rdoc or ri, even when specifying --rdoc or --ri. I imagine that this is not intentional, but maybe I'm missing something.

I tracked the problem down to the fact that the overridden setup/install methods in lib/yard/rubygems/doc_manager.rb is actually more restrictive than the original rubygems version.

I've created a fix that also retains the behavior where has_yardoc? == true inhibits rdoc generation, and tested that the yri, ri, and rdoc are all being generated again by gem update/install/rdoc. I also tested that yardoc is still generated instead of rdoc when has_yardoc? == true.

Please me know what you think.
