### PR TITLE
Type list ends at next occurrence of matching delimiter.

### DIFF
--- a/lib/yard/tags/default_factory.rb
+++ b/lib/yard/tags/default_factory.rb
@@ -2,7 +2,7 @@ module YARD
   module Tags
     class DefaultFactory
       TYPELIST_OPENING_CHARS = '[({<'
-      TYPELIST_CLOSING_CHARS = '>})]'
+      TYPELIST_CLOSING_CHARS = '])}>'
 
       # Parses tag text and creates a new tag with descriptive text
       #
@@ -108,11 +108,19 @@ module YARD
         s, e = 0, 0
         before = ''
         list, level, seen_space = [''], 0, false
+        closing_char = nil
         text.split(//).each_with_index do |c, i|
           if opening_types.include?(c)
+            if closing_char == nil
+              # Found opening character of type list.
+              closing_char = closing_types[opening_types.index(c), 1]
+            end
             list.last << c if level > 0
             s = i if level == 0
             level += 1
+          elsif c == closing_char
+            # Found matched closing character of type list.
+            break e = i
           elsif closing_types.include?(c)
             level -= 1 unless list.last[-1,1] == '='
             break e = i if level == 0

--- a/spec/tags/default_factory_spec.rb
+++ b/spec/tags/default_factory_spec.rb
@@ -57,6 +57,10 @@ describe YARD::Tags::DefaultFactory do
       v = parse_types(' [Test, Array<String, Hash{A => {B => C}}, C>, String]')
       v.should include(["Test", "Array<String, Hash{A => {B => C}}, C>", "String"])
     end
+
+    it "should allow opening characters in type list" do
+      parse_types('[#<<] description').should == [nil, ['#<<'], 'description']
+    end
   end
 
   describe '#parse_tag_with_types' do


### PR DESCRIPTION
YARD 0.7.3

I want to document a method parameter is an object that responds to the <<
method.  I tried writing:

```
# @param [#<<] output
#           where to write formatted data
```

The parameter is actually parsed as

name:

```
#<<]
```

type:

```
#<<] output where to write formatted data
```

This happens because the parser tracks nested delimiter pairs in the type list,
and `<` is an opening delimiter.

With this patch, the type list ends at the next occurrence of the closing
delimiter corresponding to the opening delimiter.  For example, if the type
list begins with `[`, then it ends at the next `]`.  If you want to include `]`
in the type list, then wrap the type list in a different delimiter pair:

```
# @param {[Integer, Integer]} point
#           co-ordinates in array
```
