### PR TITLE
ensure test directory nonexistent.

### DIFF
--- a/spec/registry_store_spec.rb
+++ b/spec/registry_store_spec.rb
@@ -2,6 +2,7 @@ require File.join(File.dirname(__FILE__), "spec_helper")
 
 describe YARD::RegistryStore do
   before do
+    FileUtils.rm_rf("foo")
     @store = RegistryStore.new
     @serializer = Serializers::YardocSerializer.new('foo')
     Serializers::YardocSerializer.stub!(:new).and_return(@serializer)


### PR DESCRIPTION
The current spec may fail.

```
% rspec ./spec/registry_store_spec.rb:11
Run filtered including {:locations=>{"./spec/registry_store_spec.rb"=>[11]}}
F

Failures:

  1) YARD::RegistryStore#load should load root.dat as full object list if it is a Hash
     Failure/Error: @store.load('foo').should == true
       <File (class)> received :file? with unexpected arguments
         expected: ("foo/checksums")
              got: ("foo/objects/root.dat")
     # ./lib/yard/registry_store.rb:239:in `block in all_disk_objects'
     # ./lib/yard/registry_store.rb:239:in `select'
     # ./lib/yard/registry_store.rb:239:in `all_disk_objects'
     # ./lib/yard/registry_store.rb:193:in `load_yardoc'
     # ./lib/yard/registry_store.rb:90:in `load'
     # ./spec/registry_store_spec.rb:16:in `block (3 levels) in <top (required)>'

Finished in 0.2822 seconds
1 example, 1 failure

Failed examples:

rspec ./spec/registry_store_spec.rb:11 # YARD::RegistryStore#load should load root.dat as full object list if it is a Hash
```

See also http://travis-ci.org/#!/lsegal/yard/builds/50238
