### PR TITLE
Improve encoding line detection

### DIFF
--- a/lib/yard/parser/source_parser.rb
+++ b/lib/yard/parser/source_parser.rb
@@ -43,7 +43,7 @@ module YARD
     # @see CodeObjects::Base
     class SourceParser
       SHEBANG_LINE  = /\A\s*#!\S+/
-      ENCODING_LINE = /\A(?:\s*#*!.*\r?\n)?\s*#+.*coding\s*[:=]{1,2}\s*([a-z\d_\-]+)/i
+      ENCODING_LINE = /\A(?:\s*#*!.*\r?\n)?\s*(?:#+|\/\*+|\/\/+).*coding\s*[:=]{1,2}\s*([a-z\d_\-]+)/i
       
       # Byte order marks for various encodings
       # @since 0.7.0

--- a/spec/parser/source_parser_spec.rb
+++ b/spec/parser/source_parser_spec.rb
@@ -497,6 +497,25 @@ describe YARD::Parser::SourceParser do
       end
     end
 
+    it "should convert C file contents to proper encoding if coding line is present" do
+      valid = []
+      valid << "/* coding: utf-8 */"
+      valid << "/* -*- coding: utf-8; c-file-style: \"ruby\" -*- */"
+      valid << "// coding: utf-8"
+      valid << "// -*- coding: utf-8; c-file-style: \"ruby\" -*-"
+      invalid = []
+      {:should => valid, :should_not => invalid}.each do |msg, list|
+        list.each do |src|
+          Registry.clear
+          parser = Parser::SourceParser.new
+          File.should_receive(:read_binary).with('tmpfile.c').and_return(src)
+          result = parser.parse("tmpfile.c")
+          content = result.instance_variable_get("@content")
+          ['UTF-8'].send(msg, include(content.encoding.to_s))
+        end
+      end
+    end if RUBY19
+
     Parser::SourceParser::ENCODING_BYTE_ORDER_MARKS.each do |encoding, bom|
       it "should understand #{encoding.upcase} BOM" do
         parser = Parser::SourceParser.new


### PR DESCRIPTION
Those patches the following encoding patterns:

Encoding names that have "-" like "utf-8":
    # coding: utf-8

Encoding line with Emacs style parameters:
    # -_\- coding: cp932; indent-tabs-mode: t -_

C style comment:
    /\* coding: utf-8 */

C++ style comment:
    // coding: utf-8

I really need "C style comment" support. Without it, I get many "???" in output HTML...
