### PR TITLE
Fix attribute parsing

### DIFF
--- a/lib/yard/parser/c_parser.rb
+++ b/lib/yard/parser/c_parser.rb
@@ -124,12 +124,12 @@ module YARD
 
         namespace.aliases[new_obj] = old_meth
       end
-      
-      def handle_attribute(var_name, name, func_name, read, write, source_file = nil)
+
+      def handle_attribute(var_name, name, read, write, source_file = nil)
         values = {:read => read.to_i, :write => write.to_i}
         {:read => name, :write => "#{name}="}.each do |type, meth_name|
           next unless values[type] > 0
-          obj = handle_method(:instance, var_name, meth_name, func_name, source_file)
+          obj = handle_method(:instance, var_name, meth_name, nil, source_file)
           ensure_loaded!(obj.namespace)
           obj.namespace.attributes[:instance][name] ||= SymbolHash[:read => nil, :write => nil]
           obj.namespace.attributes[:instance][name][type] = obj
@@ -420,10 +420,9 @@ module YARD
         @content.scan(%r{rb_define_attr
                        \s*\(\s*([\w\.]+),
                          \s*"([^"]+)",
-                         \s*(?:RUBY_METHOD_FUNC\(|VALUEFUNC\()?(\w+)\)?,
                          \s*(0|1)\s*,\s*(0|1)\s*\)
                        (?:;\s*/[*/]\s+in\s+(.+?\.[cy]))?
-                     }xm) do |var_name, name, func_name, read, write, source_file|
+                     }xm) do |var_name, name, read, write, source_file|
 
           # Ignore top-object and weird struct.c dynamic stuff
           next if var_name == "ruby_top_self"
@@ -431,7 +430,7 @@ module YARD
           next if var_name == "envtbl"
 
           var_name = "rb_cObject" if var_name == "rb_mKernel"
-          handle_attribute(var_name, name, func_name, read, write, source_file)
+          handle_attribute(var_name, name, read, write, source_file)
         end
       end
 

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -134,7 +134,7 @@ describe YARD::Parser::CParser do
           void Init_Foo() {
             rb_cFoo = rb_define_class("Foo", rb_cObject);
             #{commented ? '/*' : ''} 
-              rb_define_attr(rb_cFoo, "foo", foo, #{read}, #{write});
+              rb_define_attr(rb_cFoo, "foo", #{read}, #{write});
             #{commented ? '*/' : ''}
           }
         eof


### PR DESCRIPTION
Hi guys

There is a mistype of `rb_define_attr` signature in regex which cause that real attribute definitions cannot be parsed. Your specs used wrong signatures, therefore all was green. This is the real signature for rb_define_attr(). There is only four arguments.

```
void rb_define_attr(VALUE klass, const char *name, int read, int write)
```

Thanks
