### PR TITLE
Allow aliases for attributes

### DIFF
--- a/lib/yard/parser/c_parser.rb
+++ b/lib/yard/parser/c_parser.rb
@@ -15,8 +15,8 @@ module YARD
         parse_modules
         parse_classes
         parse_methods
-        parse_aliases
         parse_attributes
+        parse_aliases
         parse_constants
         parse_includes
       end

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -186,6 +186,22 @@ describe YARD::Parser::CParser do
         Registry.at('Foo#bar').should be_is_alias
         Registry.at('Foo#bar').docstring.should == 'FOO'
       end
+
+      it "should allow defining of aliases (rb_define_alias) of attributes" do
+        @contents = <<-eof
+          /* FOO */
+          VALUE foo(VALUE x) { int value = x; }
+          void Init_Foo() {
+            rb_cFoo = rb_define_class("Foo", rb_cObject);
+            rb_define_attr(rb_cFoo, "foo", 1, 0);
+            rb_define_alias(rb_cFoo, "foo?", "foo");
+          }
+        eof
+        parse
+
+        Registry.at('Foo#foo').should be_reader
+        Registry.at('Foo#foo?').should be_is_alias
+      end
     end
   end
 


### PR DESCRIPTION
Hi again :)

It was impossible to extract attribute aliases because of order of parse methods. This patch fixes the order.

Thanks
