### PR TITLE
Fix namespace fetching in handle_alias()

### DIFF
--- a/lib/yard/parser/c_parser.rb
+++ b/lib/yard/parser/c_parser.rb
@@ -102,7 +102,7 @@ module YARD
       end
       
       def handle_alias(var_name, new_name, old_name)
-        namespace = P(remove_var_prefix(var_name))
+        namespace = @namespaces[var_name] || P(remove_var_prefix(var_name))
         ensure_loaded!(namespace)
         new_meth, old_meth = new_name.to_sym, old_name.to_sym
         old_obj = namespace.child(:name => old_meth, :scope => :instance)


### PR DESCRIPTION
Hi. This is the last patch for today :)

It fixes namespace lookup for aliases. Your specs cannot detect this issue because of mock of `ensure_loaded!` method.

Thanks again
