### PR TITLE
Do not escape snippets twice

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -47,8 +47,8 @@ module YARD
         html = html.gsub(/<pre\s*(?:lang="(.+?)")?>(?:\s*<code\s*(?:class="(.+?)")?\s*>)?(.+?)(?:<\/code>\s*)?<\/pre>/m) do
           language = $1 || $2
           string   = $3
-          
-          string = html_syntax_highlight(h(string), language) unless options[:no_highlight]
+
+          string = html_syntax_highlight(CGI.unescapeHTML(string), language) unless options[:no_highlight]
           classes = ['code', language].compact.join(' ')
           %Q{<pre class="#{classes}"><code>#{string}</code></pre>}
         end unless [:text, :none, :pre].include?(markup)

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -529,6 +529,11 @@ describe YARD::Templates::Helpers::HtmlHelper do
       htmlify('def x; end', :ruby).should == '<pre class="code ruby">x</pre>'
     end
     
+    it "shouldn't escape code snippets twice" do
+      htmlify('<pre lang="foo"><code>{"foo" => 1}</code></pre>', :html).should == 
+        '<pre class="code foo"><code>{&quot;foo&quot; =&gt; 1}</code></pre>'
+    end
+    
     it "should highlight source when matching a pre lang= tag" do
       htmlify('<pre lang="foo"><code>x = 1</code></pre>', :html).should == 
         '<pre class="code foo"><code>x = 1</code></pre>'


### PR DESCRIPTION
Hi Loren

I noticed that code snippets is escaping twice. This patch is actually partial revert of 414e53424c28129625d743e41b15556f150fe083
