### PR TITLE
Ajax method/class search should not fire when a non-printable character is pressed

### DIFF
--- a/templates/default/fulldoc/html/js/full_list.js
+++ b/templates/default/fulldoc/html/js/full_list.js
@@ -4,6 +4,9 @@ var searchCache = [];
 var searchString = '';
 var regexSearchString = '';
 var caseSensitiveMatch = false;
+var ignoreKeyCodeMin = 8;
+var ignoreKeyCodeMax = 46;
+var commandKey = 91;
 
 RegExp.escape = function(text) {
     return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
@@ -19,6 +22,9 @@ function fullListSearch() {
   });
   
   $('#search input').keyup(function() {
+    if ((event.keyCode > ignoreKeyCodeMin && event.keyCode < ignoreKeyCodeMax) 
+         || event.keyCode == commandKey)
+      return;
     searchString = this.value;
     caseSensitiveMatch = searchString.match(/[A-Z]/) != null;
     regexSearchString = RegExp.escape(searchString);


### PR DESCRIPTION
Fix for the issue below where clicking on non-printable characters like left, right arrow, command key, etc. invokes an ajax request as seen by the displaying of the spinner.

https://github.com/lsegal/rubydoc.info/issues/24
