### PR TITLE
don't add default @return if a @overload has @return. fixes #458

### DIFF
--- a/lib/yard/handlers/ruby/method_handler.rb
+++ b/lib/yard/handlers/ruby/method_handler.rb
@@ -47,7 +47,9 @@ class YARD::Handlers::Ruby::MethodHandler < YARD::Handlers::Ruby::Base
       if obj.tag(:return) && (obj.tag(:return).types || []).empty?
         obj.tag(:return).types = ['Boolean']
       elsif obj.tag(:return).nil?
-        obj.docstring.add_tag(YARD::Tags::Tag.new(:return, "", "Boolean"))
+        unless obj.tags(:overload).any? {|overload| overload.tag(:return)}
+          obj.docstring.add_tag(YARD::Tags::Tag.new(:return, "", "Boolean"))
+        end
       end
     end
 

--- a/spec/handlers/examples/method_handler_001.rb.txt
+++ b/spec/handlers/examples/method_handler_001.rb.txt
@@ -69,6 +69,10 @@ end
   # @return [NotBoolean, nil]
   def boolean3?; end
 
+  # @overload rainy?
+  #   @return whether today is the rainy day.
+  def rainy?; end
+
   attr_writer :attr_name
   def attr_name; end
 

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -106,6 +106,13 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHandler"
     meth.tag(:return).types.should == ['NotBoolean', 'nil']
   end
   
+  it "should not change return type for method ending in ? with return types set by @overload" do
+    meth = P('Foo#rainy?')
+    meth.should have_tag(:overload)
+    meth.tag(:overload).should have_tag(:return)
+    meth.should_not have_tag(:return)
+  end
+  
   it "should add method writer to existing attribute" do
     Registry.at('Foo#attr_name').should be_reader
     Registry.at('Foo#attr_name=').should be_writer


### PR DESCRIPTION
YARD should also check @return value in @overload tags to detect whether does a @return tag exist or not.
