### PR TITLE
don't discard tags by (see ...). fixes #457

### DIFF
--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -217,6 +217,8 @@ module YARD
         @visibility = :public
         @tags = []
         @docstring = Docstring.new('', self)
+        @docstring_extra = nil
+        @docstring_extra_tags = nil
         @namespace = nil
         self.namespace = namespace
         yield(self) if block_given?
@@ -353,7 +355,9 @@ module YARD
           return @docstring_extra
         when Base
           @docstring = @docstring.docstring + @docstring_extra
+          @docstring.add_tag(*@docstring_extra_tags)
           @docstring_extra = nil
+          @docstring_extra_tags = nil
         end
         @docstring
       end
@@ -368,9 +372,12 @@ module YARD
         if comments =~ /\A\s*\(see (\S+)\s*\)(?:\s|$)/
           path, extra = $1, $'
           @docstring_extra = Docstring.new(extra, self)
+          @docstring_extra_tags = Docstring === comments ? comments.tags : []
+          @docstring_extra.add_tag(*@docstring_extra_tags)
           @docstring = Proxy.new(namespace, path)
         else
           @docstring_extra = nil
+          @docstring_extra_tags = nil
           @docstring = Docstring === comments ? comments : Docstring.new(comments, self)
         end
       end

--- a/spec/code_objects/base_spec.rb
+++ b/spec/code_objects/base_spec.rb
@@ -298,7 +298,7 @@ describe YARD::CodeObjects::Base do
     it "should allow extra docstring after (see Path)" do
       ClassObject.new(:root, :AnotherObject) {|x| x.docstring = "FOO" }
       o = ClassObject.new(:root, :Me)
-      o.docstring = "(see AnotherObject)\n\nEXTRA\n@api private"
+      o.docstring = Docstring.new("(see AnotherObject)\n\nEXTRA\n@api private", o)
       o.docstring.should == "FOO\n\nEXTRA"
       o.docstring.should have_tag(:api)
     end


### PR DESCRIPTION
Docstring is a String but it has some metadata. e.g. tags. We should pass not only text data but also tags data to new Docstring.
