### PR TITLE
Fix linking to method names that have been escaped

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -196,6 +196,8 @@ module YARD
             title = nil if title.empty?
           end
 
+          name = CGI.unescapeHTML(name)
+
           if object.is_a?(String)
             object
           else

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -390,6 +390,11 @@ describe YARD::Templates::Helpers::HtmlHelper do
         :title => "foo bar"
       }
     end
+
+    it "should resolve links to methods whose names have been escaped" do
+      should_receive(:linkify).with('Object#<<', nil).and_return('')
+      resolve_links("{Object#&lt;&lt;}")
+    end
     
     it "should warn about missing reference at right file location for object" do
       YARD.parse_string <<-eof


### PR DESCRIPTION
Methods with names such as #<< get escaped before {…} link resolution, so the name needs to be unescaped and then linked.
