### PR TITLE
i18n: create YARD::I18n::Messages and Message

### DIFF
--- a/lib/yard/autoload.rb
+++ b/lib/yard/autoload.rb
@@ -135,6 +135,8 @@ module YARD
   module I18n
     autoload :PotGenerator,    __p('i18n/pot_generator')
     autoload :Text,            __p('i18n/text')
+    autoload :Messages,        __p('i18n/messages')
+    autoload :Message,         __p('i18n/message')
   end
 
   # The parser namespace holds all parsing engines used by YARD.

--- a/lib/yard/i18n/message.rb
+++ b/lib/yard/i18n/message.rb
@@ -1,0 +1,64 @@
+require "set"
+
+module YARD
+  module I18n
+    # +Message+ is a translation target message. It has message ID as
+    # {#id} and some properties {#locations} and {#comments}.
+    #
+    # @since 0.8.1
+    class Message
+      # The message ID of the trnslation target message.
+      #
+      # @return [String]
+      attr_reader :id
+
+      # The array of locations. Location is an array of path and line
+      # number where the message is appered.
+      #
+      # @return [Set]
+      attr_reader :locations
+
+      # The array of comments for the messages.
+      #
+      # @return [Set]
+      attr_reader :comments
+
+      # Creates a trasnlate target message for message ID +id+.
+      #
+      # @param [String] id the message ID of the translate target message.
+      def initialize(id)
+        @id = id
+        @locations = Set.new
+        @comments = Set.new
+      end
+
+      # Adds a location where the messasge is appeared.
+      #
+      # @param [String] path the path where the message is appeared.
+      # @param [Integer] line the line number where the message is appeared.
+      # @return [void]
+      def add_location(path, line)
+        @locations << [path, line]
+      end
+
+      # Adds a comment for the message.
+      #
+      # @param [String] comment the comment for the message to be added.
+      # @return [void]
+      def add_comment(comment)
+        @comments << comment unless comment.nil?
+      end
+
+      # Compares equivalence between +self+ and +other+.
+      #
+      # @param [Message] other the +Message+ to be compared.
+      # @return [Boolean] whether +self+ and +other+ is equivalence or not.
+      def ==(other)
+        other.is_a?(self.class) and
+          @id == other.id and
+          @locations == other.locations and
+          @comments == other.comments
+      end
+    end
+  end
+end

--- a/lib/yard/i18n/messages.rb
+++ b/lib/yard/i18n/messages.rb
@@ -1,0 +1,56 @@
+module YARD
+  module I18n
+    # +Messages+ is a container for +Message+s.
+    #
+    # @since 0.8.1
+    class Messages
+      include Enumerable
+
+      # Creates a +Message+ container.
+      def initialize
+        @messages = {}
+      end
+
+      # Enumerates each +Message+ in the container.
+      #
+      # @return [void]
+      def each(&block)
+        @messages.each_value(&block)
+      end
+
+      # Retrieves the registered +Message+, the message ID of which is
+      # +id+. If corresponding +Message+ isn't registered, +nil+ is
+      # returned.
+      #
+      # @param [String] id the message ID to be retrieved.
+      # @return [Message] the registered +Message+ or +nil+.
+      def [](id)
+        @messages[id]
+      end
+
+      # Registers a +Message+, the mssage ID of which is +id+. If
+      # corresponding +Message+ exists in the +Messages+, existent
+      # +Message+ is returned.
+      #
+      # @param [String] id the message ID to be registered.
+      # @return [Message] the registered +Message+.
+      def register(id)
+        @messages[id] ||= Message.new(id)
+      end
+
+      # Compares equivalence between +self+ and +other+.
+      #
+      # @param [Messages] other the +Messages+ to be compared.
+      # @return [Boolean] whether +self+ and +other+ is equivalence or not.
+      def ==(other)
+        other.is_a?(self.class) and
+          @messages == other.messages
+      end
+
+      protected
+      def messages
+        @messages
+      end
+    end
+  end
+end

--- a/spec/i18n/message_spec.rb
+++ b/spec/i18n/message_spec.rb
@@ -1,0 +1,52 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+
+describe YARD::I18n::Message do
+  def message(id)
+    YARD::I18n::Message.new(id)
+  end
+
+  before do
+    @message = message("Hello World!")
+  end
+
+  describe "#id" do
+    it "should return ID" do
+      message("Hello World!").id.should == "Hello World!"
+    end
+  end
+
+  describe "#add_location" do
+    it "should add some locations" do
+      @message.add_location("hello.rb", 10)
+      @message.add_location("message.rb", 5)
+      @message.locations.should == Set.new([["hello.rb", 10], ["message.rb", 5]])
+    end
+  end
+
+  describe "#add_comment" do
+    it "should add some comments" do
+      @message.add_comment("YARD.title")
+      @message.add_comment("Hello#message")
+      @message.comments.should == Set.new(["YARD.title", "Hello#message"])
+    end
+  end
+
+  describe "#==" do
+    it "should return true for same value messages" do
+      locations = [["hello.rb", 10], ["message.rb", 5]]
+      comments = ["YARD.title", "Hello#message"]
+
+      other_message = message(@message.id)
+      locations.each do |path, line|
+        @message.add_location(path, line)
+        other_message.add_location(path, line)
+      end
+      comments.each do |comment|
+        @message.add_comment(comment)
+        other_message.add_comment(comment)
+      end
+
+      @message.should == other_message
+    end
+  end
+end

--- a/spec/i18n/messages_spec.rb
+++ b/spec/i18n/messages_spec.rb
@@ -1,0 +1,66 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+
+describe YARD::I18n::Messages do
+  def message(id)
+    YARD::I18n::Message.new(id)
+  end
+
+  def messages
+    YARD::I18n::Messages.new
+  end
+
+  before do
+    @messages = messages
+  end
+
+  describe "#each" do
+    it "should enumerate Message" do
+      @messages.register("Hello World!")
+      @messages.register("Title")
+      enumerated_messages = []
+      @messages.each do |message|
+        enumerated_messages << message
+      end
+      enumerated_messages.should == [message("Hello World!"), message("Title")]
+    end
+
+    it "should not any Message for empty messages" do
+      enumerated_messages = []
+      @messages.each do |message|
+        enumerated_messages << message
+      end
+      enumerated_messages.should == []
+    end
+  end
+
+  describe "#[]" do
+    it "should return registered message" do
+      @messages.register("Hello World!")
+      @messages["Hello World!"].should == message("Hello World!")
+    end
+
+    it "should return for nonexistent message ID" do
+      @messages["Hello World!"].should == nil
+    end
+  end
+
+  describe "#register" do
+    it "should return registered message" do
+      @messages.register("Hello World!").should == message("Hello World!")
+    end
+
+    it "should return existent message" do
+      message = @messages.register("Hello World!")
+      @messages.register("Hello World!").object_id.should == message.object_id
+    end
+  end
+
+  describe "#==" do
+    it "should return true for same value messages" do
+      @messages.register("Hello World!")
+      other_messages = messages
+      other_messages.register("Hello World!")
+      @messages.should == other_messages
+    end
+  end
+end

--- a/spec/i18n/text_spec.rb
+++ b/spec/i18n/text_spec.rb
@@ -1,3 +1,5 @@
+require File.dirname(__FILE__) + '/../spec_helper'
+
 describe YARD::I18n::Text do
   def extract_messages(input, options={})
     text = YARD::I18n::Text.new(StringIO.new(input), options)


### PR DESCRIPTION
This commit is corresponding to comment in #527:

>  https://github.com/lsegal/yard/pull/527#issuecomment-5427213
> 
>  One thing I noticed after you documented the code is that
>  PotGenerator#messages has a very long type signature. To me, this
>  usually implies that the API is equally complex to use. The type:
>  `Hash{:locations => Array<Array[String, Integer]>, :comments =>
>  Array<String>}` to me screams of refactoring into a separate class with
>  .locations and .comments attributes. That way we can have a properly
>  documented Message (would this be the right name? or PotMessage?)
>  class component that has meaning in our system, and `#messages` would
>  turn into `Hash{String=>Message}`, which is much clearer to me. Can you
>  do this refactor?
