### PR TITLE
i18n: support Docstring translation

### DIFF
--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -495,8 +495,8 @@ module YARD
       # @return [void]
       # @since 0.8.3
       def apply_locale
-        options.files.each do |file|
-          file.locale = options.locale
+        (all_objects + options.files).each do |object|
+          object.locale = options.locale
         end
       end
 

--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -18,7 +18,10 @@ module YARD
       def push(value)
         value = Proxy.new(@owner, value) if value.is_a?(String) || value.is_a?(Symbol)
         if value.is_a?(CodeObjects::Base) || value.is_a?(Proxy)
-          super(value) unless include?(value)
+          unless include?(value)
+            value.locale = @owner.locale if @owner
+            super(value)
+          end
         else
           raise ArgumentError, "#{value.class} is not a valid CodeObject"
         end
@@ -157,6 +160,9 @@ module YARD
       undef visibility=
       def visibility=(v) @visibility = v.to_sym end
 
+      # @since 0.8.3
+      attr_reader :locale
+
       class << self
         # Allocates a new code object
         # @return [Base]
@@ -218,6 +224,7 @@ module YARD
         @source_type = :ruby
         @visibility = :public
         @tags = []
+        @locale = nil
         @docstring = Docstring.new('', self)
         @docstring_extra = nil
         @docstring_extra_tags = nil
@@ -363,6 +370,13 @@ module YARD
         else
           @source = format_source(statement.to_s)
         end
+      end
+
+      # @param [String] locale the locale name to be translated.
+      # @return [void]
+      # @since 0.8.3
+      def locale=(locale)
+        @locale = locale
       end
 
       undef docstring

--- a/lib/yard/code_objects/proxy.rb
+++ b/lib/yard/code_objects/proxy.rb
@@ -20,6 +20,8 @@ module YARD
 
       attr_reader :namespace
       alias_method :parent, :namespace
+      # @since 0.8.3
+      attr_accessor :locale
 
       # Creates a new Proxy
       #
@@ -41,6 +43,8 @@ module YARD
         else
           @orignamespace, @origname, @imethod = nil, nil, nil
         end
+
+        @locale = nil
 
         @name = name.to_sym
         @namespace = namespace

--- a/spec/code_objects/code_object_list_spec.rb
+++ b/spec/code_objects/code_object_list_spec.rb
@@ -30,4 +30,13 @@ describe YARD::CodeObjects::CodeObjectList do
     list << "Test"
     list.size.should == 2
   end
+
+  it "should set owner's locale to pushed object" do
+    obj = ModuleObject.new(nil, :YARD)
+    owner = P(:YARD)
+    owner.stub!(:locale).and_return("fr")
+    list = CodeObjectList.new(owner)
+    list << "Test"
+    list[0].locale.should == "fr"
+  end
 end

--- a/templates/default/docstring/setup.rb
+++ b/templates/default/docstring/setup.rb
@@ -38,7 +38,7 @@ end
 def docstring_text
   text = ""
   unless object.tags(:overload).size == 1 && object.docstring.empty?
-    text = object.docstring
+    text = object.docstring.localized
   end
 
   if text.strip.empty? && object.tags(:return).size == 1 && object.tag(:return).text


### PR DESCRIPTION
Docstring#document is added. It returns localized document. We should
use for it when we want localized document. We should use
Docstring#to_s or Docstring itself when we want non-localized
document.

The template for docstring uses Docstring#document because it should
render localized document. Docstring#summary also uses
Docstring#document because the same reason.

`bin/yard doc --locale ja` with this change generates documents in
Japanese. You can find a document in Japanese at doc/YARD.html.
