### PR TITLE
fix for ruby 2.0.0dev with respond_to? returning false for protected methods

### DIFF
--- a/lib/yard/server/library_version.rb
+++ b/lib/yard/server/library_version.rb
@@ -162,7 +162,7 @@ module YARD
       def prepare!
         return if yardoc_file
         meth = "load_yardoc_from_#{source}"
-        send(meth) if respond_to?(meth)
+        send(meth) if respond_to?(meth, true)
       end
 
       # @return [Gem::Specification] a gemspec object for a given library. Used
@@ -220,7 +220,7 @@ module YARD
 
       def load_source_path
         meth = "source_path_for_#{source}"
-        send(meth) if respond_to?(meth)
+        send(meth) if respond_to?(meth, true)
       end
     end
   end


### PR DESCRIPTION
Hello,

With ruby trunk (2.0.0dev), Object#respond_to? responds `false` for protected methods.
See https://github.com/ruby/ruby/blob/051799b674580fb96b928d990045976e948f7151/NEWS#L181-182
and https://github.com/ruby/ruby/commit/23473d1f9fc33151f0d5804e0cca824794a0bfe6.

This error causes `yard server` to fail, because `LibraryVersion#source_path` is not set properly due to this.

This mean, in the case you called respond_to? on +self+ (usually without receiver), to check for a defined protected method, it will return false instead of true. They are a few other cases of respond_to? without receiver in YARD, but they seem less obvious (in all cases, they are 8 specs failing with 2.0.0dev, 6 with 1.9.2).

I'm not sure of the usage of `protected` there. Is there a case when another LibraryVersion wants to call one of these methods? It seems the five last methods of LibraryVersion could be private. But I don't know YARD source well.
