### PR TITLE
Don't crash with #comment after =begin/=end

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -503,7 +503,7 @@ module YARD
             @comments_flags[lineno] = @comments_flags[lineno - 1]
             @comments_flags.delete(lineno - 1)
             range = @comments_range.delete(lineno - 1)
-            source_range = range.first..source_range.last
+            source_range = range ? (range.first..source_range.last) : source_range
             comment = append_comment + "\n" + comment
           end
 


### PR DESCRIPTION
I encountered this on a large, complex piece of code at work that used =begin/=end followed by a regular comment.  YARD tried to append one to the other and died with an exception.  This pull request seems to fix it, as does adding a newline between =end and the next comment.

Here is the offending excerpt:

=begin  
        if( encodeParams['MuxFormat'].nil? )
            raise "Must specify muxing format"
        else
            @muxFormats = @muxFormats + encodeParams['MuxFormat'] + ','
        end
=end  
        #optional params
