### PR TITLE
Graph CLI now reads .yardopts for alternate yarddb paths.

### DIFF
--- a/lib/yard/cli/graph.rb
+++ b/lib/yard/cli/graph.rb
@@ -26,7 +26,7 @@ module YARD
       #   :format => :dot
       attr_reader :options
 
-      # The set of objects to include in the graph.
+      # The set of objects to include in the graph.
       attr_reader :objects
 
       # Creates a new instance of the command-line utility
@@ -48,6 +48,7 @@ module YARD
       #   grapher.run('--private')
       # @param [Array<String>] args each tokenized argument
       def run(*args)
+        CLI::Yardoc.read_yardoc_db_from_options_file
         Registry.load
         optparse(*args)
 
@@ -72,6 +73,7 @@ module YARD
 
         opts.on('-b', '--db FILE', 'Use a specified .yardoc db to load from or save to. (defaults to .yardoc)') do |yfile|
           YARD::Registry.yardoc_file = yfile
+          Registry.load
         end
 
         opts.on('--full', 'Full class diagrams (show methods and attributes).') do

--- a/lib/yard/cli/server.rb
+++ b/lib/yard/cli/server.rb
@@ -112,12 +112,7 @@ module YARD
          options_file = File.join(dir, Yardoc::DEFAULT_YARDOPTS_FILE)
          if File.exist?(options_file)
            # Found yardopts, extract db path
-           old_yfile = Registry.yardoc_file
-           y = CLI::Yardoc.new
-           y.options_file = options_file
-           y.parse_arguments
-           db = File.expand_path(YARD::Registry.yardoc_file, dir)
-           YARD::Registry.yardoc_file = old_yfile
+           db = CLI::Yardoc.read_yardoc_db_from_options_file(false, options_file)
 
            # Create libver
            libver = YARD::Server::LibraryVersion.new(library, nil, db)

--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -283,7 +283,7 @@ module YARD
 
         # Parse files and then command line arguments
         optparse(*support_rdoc_document_file!) if use_document_file
-        optparse(*yardopts) if use_yardopts_file
+        parse_options_file if use_yardopts_file
         optparse(*args)
 
         # Last minute modifications
@@ -331,6 +331,39 @@ module YARD
         File.read_binary(options_file).shell_split
       rescue Errno::ENOENT
         []
+      end
+
+      # Reads and parses the {#options_file}.
+      #
+      # @return (see #optparse)
+      def parse_options_file
+        optparse(*yardopts)
+      end
+
+      # Reads and parses a specified options file, usually +.yardopts+,
+      # and extracts the Yard DB file.
+      #
+      # @param [Boolean] use_discovered_yarddb Whether or not to set the
+      #   singleton Yard DB in {Registry#yardoc_file} to the yard db specified
+      #   in the options file.
+      # @param [String] options_file The file to parse that should contain Yard
+      #   doc options.
+      # @return [String] The full path of the yard db if specified, or the full
+      #   path to the default location (+.yardoc+) relative to the options file's
+      #   directory.
+      # @since 0.8.2.2
+      def self.read_yardoc_db_from_options_file(use_discovered_yarddb = true, options_file = DEFAULT_YARDOPTS_FILE)
+        old_yfile = Registry.yardoc_file
+        begin
+          Registry.yardoc_file = nil
+          y = CLI::Yardoc.new
+          y.options_file = options_file
+          y.parse_options_file
+          dir = File.dirname(options_file)
+          return File.expand_path(YARD::Registry.yardoc_file, dir)
+        ensure
+          YARD::Registry.yardoc_file = old_yfile unless use_discovered_yarddb
+        end
       end
 
       private

--- a/spec/cli/graph_spec.rb
+++ b/spec/cli/graph_spec.rb
@@ -1,10 +1,16 @@
 require File.dirname(__FILE__) + '/../spec_helper'
 
-describe YARD::CLI::Yardoc do
+describe YARD::CLI::Graph do
   it "should serialize output" do
     Registry.should_receive(:load)
-    @graph = YARD::CLI::Graph.new
-    @graph.options.serializer.should_receive(:serialize).once
-    @graph.run
+    subject.options.serializer.should_receive(:serialize).once
+    subject.run
+  end
+
+  it "should use the yardoc file specified in .yardopts" do
+    YARD::CLI::Yardoc.should_receive(:read_yardoc_db_from_options_file).once.with(no_args)
+    Registry.should_receive(:load)
+    Templates::Engine.stub :render
+    subject.run
   end
 end


### PR DESCRIPTION
How's this?

(Fixes #583)
