### PR TITLE
[Bugfix] Only show toggle, when visible children are present.

### DIFF
--- a/templates/default/fulldoc/html/setup.rb
+++ b/templates/default/fulldoc/html/setup.rb
@@ -186,7 +186,7 @@ def class_list(root = Registry.root)
   children.reject {|c| c.nil? }.sort_by {|child| child.path }.map do |child|
     if child.is_a?(CodeObjects::NamespaceObject)
       name = child.namespace.is_a?(CodeObjects::Proxy) ? child.path : child.name
-      has_children = child.children.any? {|o| o.is_a?(CodeObjects::NamespaceObject) }
+      has_children = run_verifier(child.children).any? {|o| o.is_a?(CodeObjects::NamespaceObject) }
       out << "<li>"
       out << "<a class='toggle'></a> " if has_children
       out << linkify(child, name)


### PR DESCRIPTION
### Bug Description

This concerns the `default` template. When a class `a` contains a subclass `b` and that subclass `b` is `@private`, it is not listed in the Class List, when the option `--no-private` is set (so far all good). But the class `a` gets a toggle in the Class List indicating it has subclasses, even if all subclasses are `@private` or otherwise hidden.
### Bugfix

To calculate `has_children` all children are also ran through `run_verifier` to filter out hidden children.

I couldn't find specs for this, so it's only tested manually.
