### PR TITLE
Custom reference links support

### DIFF
--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -540,6 +540,23 @@ module YARD
       #   and the name (default is {NSEP})
       def sep; NSEP end
 
+      # Override this method if you've registered a link keyword to refer to this
+      # object. The method should return whether the passed title identifies this
+      # instance.
+      #
+      # @param [String] title the component after the registered keyword
+      # @return [Boolean] whether this object is indeed identified by the passed title
+      #
+      # @abstract Should be defined in the subclass that wants to be linked by keywords.
+      #
+      # @note This method is invoked internally by a Proxy object when resolving a link.
+      #
+      # @see Registry#register_link
+      # @see Proxy#resolve_link
+      def linked_by?(title)
+        false
+      end
+
       protected
 
       # Override this method if your code object subclass does not allow

--- a/lib/yard/code_objects/proxy.rb
+++ b/lib/yard/code_objects/proxy.rb
@@ -213,6 +213,36 @@ module YARD
       # This class is never a root object
       def root?; false end
 
+      # Does this Proxy represent a link to another object?
+      #
+      # @return [TrueClass] when #to_s returns a keyword registered as a link identifier
+      #
+      # @see Registry.type_from_link
+      def object_link?
+        Registry.type_from_link(to_s)
+      end
+
+      # Attempts to locate a CodeObject instance for which a link has been
+      # registered using the given title.
+      #
+      # @param [String] title the title that will be passed to CodeObjects::Base#linked_by?
+      #  to identify the object
+      #
+      # @return [CodeObjects::Base] if an object was located
+      # @return nil otherwise
+      #
+      # @see Registry#register_link
+      # @see CodeObjects::Base#linked_by?
+      def resolve_link(title)
+        return if !title || title.empty?
+
+        if klass = object_link?
+          return Registry.all(klass.to_sym).select { |o| o.linked_by?(title) }.first
+        end
+
+        nil
+      end
+      
       private
 
       # @note this method fixes a bug in 1.9.2: http://gist.github.com/437136

--- a/lib/yard/serializers/yardoc_serializer.rb
+++ b/lib/yard/serializers/yardoc_serializer.rb
@@ -36,6 +36,7 @@ module YARD
       def proxy_types_path; File.join(basepath, 'proxy_types') end
       def checksums_path; File.join(basepath, 'checksums') end
       def object_types_path; File.join(basepath, 'object_types') end
+      def object_links_path; File.join(basepath, 'object_links') end
 
       def serialized_path(object)
         path = case object

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -246,8 +246,19 @@ module YARD
       def link_object(obj, otitle = nil, anchor = nil, relative = true)
         return otitle if obj.nil?
         obj = Registry.resolve(object, obj, true, true) if obj.is_a?(String)
+        
         if !otitle && obj.root?
           title = "Top Level Namespace"
+        elsif otitle && obj.is_a?(CodeObjects::Proxy)
+          # Check for any CodeObjects linked by custom keywords (@obj)
+          proxy = obj
+          if proxy.object_link?
+            if o = proxy.resolve_link(otitle)
+              title, obj = h(o.title), o
+            end
+          end
+
+          return h(obj.to_s) if !title || title.empty?
         elsif otitle
           title = otitle.to_s
         elsif object.is_a?(CodeObjects::Base)
@@ -265,7 +276,6 @@ module YARD
           title = h(obj.to_s)
         end
         return title unless serializer
-        return title if obj.is_a?(CodeObjects::Proxy)
 
         link = url_for(obj, anchor, relative)
         link = link ? link_url(link, title, :title => h("#{obj.title} (#{obj.type})")) : title

--- a/spec/registry_store_spec.rb
+++ b/spec/registry_store_spec.rb
@@ -16,6 +16,7 @@ describe YARD::RegistryStore do
       File.should_receive(:file?).with('foo/checksums').and_return(false)
       File.should_receive(:file?).with('foo/proxy_types').and_return(false)
       File.should_receive(:file?).with('foo/object_types').and_return(false)
+      File.should_receive(:file?).with('foo/object_links').and_return(false)
       @serializer.should_receive(:deserialize).with('root').and_return({:root => @foo, :A => @bar})
       @store.load('foo').should == true
       @store.root.should == @foo
@@ -36,6 +37,7 @@ describe YARD::RegistryStore do
       File.should_receive(:file?).with('foo/checksums').and_return(false)
       File.should_receive(:file?).with('foo/proxy_types').and_return(false)
       File.should_receive(:file?).with('foo/object_types').and_return(false)
+      File.should_receive(:file?).with('foo/object_links').and_return(false)
       File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
 
       @store.load('foo').should == true
@@ -53,6 +55,7 @@ describe YARD::RegistryStore do
       File.should_receive(:file?).with('foo/checksums').and_return(false)
       File.should_receive(:file?).with('foo/proxy_types').and_return(false)
       File.should_receive(:file?).with('foo/object_types').and_return(false)
+      File.should_receive(:file?).with('foo/object_links').and_return(false)
       File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
       @store.load('foo').should == true
     end
@@ -71,6 +74,7 @@ describe YARD::RegistryStore do
       File.should_receive(:file?).with('foo/proxy_types').and_return(false)
       File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
       File.should_receive(:file?).with('foo/object_types').and_return(false)
+      File.should_receive(:file?).with('foo/object_links').and_return(false)
       File.should_receive(:readlines).with('foo/checksums').and_return([
         'file1 CHECKSUM1', '  file2 CHECKSUM2 '
       ])
@@ -83,6 +87,7 @@ describe YARD::RegistryStore do
       File.should_receive(:file?).with('foo/checksums').and_return(false)
       File.should_receive(:file?).with('foo/proxy_types').and_return(true)
       File.should_receive(:file?).with('foo/object_types').and_return(false)
+      File.should_receive(:file?).with('foo/object_links').and_return(false)
       File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
       File.should_receive(:read_binary).with('foo/proxy_types').and_return(Marshal.dump({'a' => 'b'}))
       @store.load('foo').should == true
@@ -94,6 +99,7 @@ describe YARD::RegistryStore do
       File.should_receive(:file?).with('foo/checksums').and_return(false)
       File.should_receive(:file?).with('foo/proxy_types').and_return(false)
       File.should_receive(:file?).with('foo/object_types').and_return(false)
+      File.should_receive(:file?).with('foo/object_links').and_return(false)
       File.should_receive(:file?).with('foo/objects/root.dat').and_return(true)
       File.should_receive(:read_binary).with('foo/objects/root.dat').and_return(Marshal.dump(@foo))
       @store.load('foo').should == true
@@ -214,6 +220,7 @@ describe YARD::RegistryStore do
       File.should_receive(:file?).with('foo/checksums').and_return(false)
       File.should_receive(:file?).with('foo/proxy_types').and_return(false)
       File.should_receive(:file?).with('foo/object_types').and_return(false)
+      File.should_receive(:file?).with('foo/object_links').and_return(false)
       @serializer.should_receive(:deserialize).with('root').and_return({:'A#foo' => @foo, :A => @bar})
       @store.load('foo')
       @store.paths_for_type(:method).should == ['#foo']
@@ -256,6 +263,7 @@ describe YARD::RegistryStore do
       File.should_receive(:directory?).with('foo').and_return(true)
       File.should_receive(:file?).with('foo/proxy_types').and_return(false)
       File.should_receive(:file?).with('foo/object_types').and_return(false)
+      File.should_receive(:file?).with('foo/object_links').and_return(false)
       File.should_receive(:file?).with('foo/checksums').and_return(false)
       File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
       @store.should_receive(:all_disk_objects).at_least(1).times.and_return(['foo/objects/foo', 'foo/objects/bar'])


### PR DESCRIPTION
The feature allows the registration of arbitrary "link keywords" that
can be used to link against certain object types. This is handy when
defining custom CodeObject implementations where referencing them by
path is unnatural and not human readable.

Modifications:
- RegistryStore now tracks object_links which is a keyword ->
  object_type map
- Proxy objects can now act as "links" and resolve themselves
- HTMLHelper#link_object handles linkable Proxy objects

There are specs that cover the added methods, and all
the modifications are documented with proper YARD syntax.

For lack of better place to write an example, here's what the feature would allow a user to do:

``` ruby
# @see Spec: name of spec
# @see Appendix: YARD Pipeline
```

As opposed to:

``` ruby
# @see .spec.path_to_spec Spec: name of spec
# @see .appendix.namespace.appendix_name Appendix: YARD Pipeline
```

Or whatever the object paths might be.

---

I tried to find the proper place to write some example of how to use the feature outside the actual API documentation (there's a proper example in the Registry.register_link method) but I wasn't sure. So if you're good with the changes and would like to merge them, I'll be happy to write the end-user doc for it.

_PS: we talked about this on IRC last night, my alias is kandie._
