### PR TITLE
yard diff --git is not the intended behavior

### DIFF
--- a/lib/yard/cli/diff.rb
+++ b/lib/yard/cli/diff.rb
@@ -101,6 +101,7 @@ module YARD
       end
 
       def load_git_commit(commit)
+        Registry.clear
         commit_path = 'git_commit' + commit.gsub(/\W/, '_')
         tmpdir = File.join(Dir.tmpdir, commit_path)
         log.info "Expanding #{commit} to #{tmpdir}..."


### PR DESCRIPTION
This function is not the intended behavior
Before comparing to two point( tag or commit hash ), first element have to delete of itself registry.
But this method is not delete registory.
So this method does not become the expected behavior.

I did a test in a new repository (https://github.com/ryopeko/yard_diff)

This repository has three tags.

0.0.1 : I added two methods (`initialize`, `bar`)

0.0.2 : I added `baz` method.

0.0.3 : I deleted `baz` method and added `qux` method.

I run `yard diff 0.0.2 0.0.3 --git` in this state.

expect:

```
Added objects:

  Foo#qux (foo.rb:8)

Removed objects:

  Foo#baz (foo.rb:8)
```

But I got this result.

Added objects:

```
  Foo#qux (foo.rb:8)
```

So I have added a line to call a `Registory.clear`.

But Sorry, I could not write a test code.
Writting of test code of this method is difficulty for me and from the first this method does not has a test code.
