### PR TITLE
Handle multi-layer symlink trails

### DIFF
--- a/bin/yard
+++ b/bin/yard
@@ -3,7 +3,7 @@
 # We do all this work just to find the proper load path
 path = __FILE__
 while File.symlink?(path)
-  path = File.expand_path(File.readlink(__FILE__), File.dirname(__FILE__))
+  path = File.expand_path(File.readlink(path), File.dirname(path))
 end
 $:.unshift(File.join(File.dirname(File.expand_path(path)), '..', 'lib'))
 

--- a/bin/yardoc
+++ b/bin/yardoc
@@ -3,7 +3,7 @@
 # We do all this work just to find the proper load path
 path = __FILE__
 while File.symlink?(path)
-  path = File.expand_path(File.readlink(__FILE__), File.dirname(__FILE__))
+  path = File.expand_path(File.readlink(path), File.dirname(path))
 end
 $:.unshift(File.join(File.dirname(File.expand_path(path)), '..', 'lib'))
 

--- a/bin/yri
+++ b/bin/yri
@@ -3,7 +3,7 @@
 # We do all this work just to find the proper load path
 path = __FILE__
 while File.symlink?(path)
-  path = File.expand_path(File.readlink(__FILE__), File.dirname(__FILE__))
+  path = File.expand_path(File.readlink(path), File.dirname(path))
 end
 $:.unshift(File.join(File.dirname(File.expand_path(path)), '..', 'lib'))
 


### PR DESCRIPTION
Handle the case where the executables in the path are a symlink to a symlink to the real thing.  I can't think of a good reason why this would be the case (rvm + local bundle + bundler-executable?), but the code as currently given would loop forever.
