### PR TITLE
CParser: make sure structs are not mixed up with struct retvals

### DIFF
--- a/lib/yard/parser/c/c_parser.rb
+++ b/lib/yard/parser/c/c_parser.rb
@@ -80,7 +80,9 @@ module YARD
           stmts = nil
           if prevchar == '{'
             stmts = consume_body_statements
-            consume_until(';') if decl =~ /\A(typedef|enum|class|struct|union)\b/
+            if decl =~ /\A(typedef|enum|class|#{struct}|union)/
+              consume_until(';')
+            end
           end
           statement.source = @content[start..@index]
           statement.block = stmts
@@ -219,6 +221,10 @@ module YARD
         def char(num = 1) @content[@index, num] end
         def prevchar(num = 1) @content[@index - 1, num] end
         def nextchar(num = 1) @content[@index + 1, num] end
+
+        def struct
+          /struct\s[:alnum:]+\s\{/
+        end
       end
     end
   end

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -46,6 +46,11 @@ describe YARD::Parser::C::CParser do
         parse(@contents)
         Registry.at('Multifile#extra').docstring.should == ''
       end
+
+      it "should differentiate between a struct and a pointer to a struct retval" do
+        parse(@contents)
+        Registry.at('Multifile#hello_mars').docstring.should == 'Hello Mars'
+      end
     end
 
     describe 'Foo class' do

--- a/spec/parser/examples/multifile.c.txt
+++ b/spec/parser/examples/multifile.c.txt
@@ -1,6 +1,22 @@
+struct hoge *
+rb_fuga(VALUE obj)
+{
+  return Qtrue;
+}
+
+/*
+ * Hello Mars
+ */
+VALUE
+rb_hello_mars(VALUE obj, VALUE n)
+{
+    return Qtrue;
+}
+
 void
 Init_Multifile(void)
 {
     rb_cMultifile  = rb_define_class("Multifile", rb_cObject);
     rb_define_method(rb_cMultifile, "extra", rb_extra, 1); /* in extra.c */
+    rb_define_method(rb_cMultifile, "hello_mars", rb_hello_mars, 1);
 }


### PR DESCRIPTION
```
Fix issue #666 (Cannot properly parse Hash from Ruby 1.9.3-p392)

The underlying problem is that YARD mixes up C struct definitions with
functions that return structs. This results in improper parsing of C
files.

  STRUCT                     | FUNCTION
  ------------------------------------------------------
  struct foreach_safe_arg {  | struct st_table *
      /*                     | rb_hash_tbl(VALUE hash)
       * Blah-blah-blah.     | {
       */                    |     /*
  };                         |      * Yadda-yadda-yadda.
                             |      */
                             | }

So, what's the real problem? Well, YARD indeed cannot properly parse
'hash.c' from Ruby 1.9 (and some other files like 'thread.c') but
parsing 'hash.c' from Ruby 2.0 works as expected. And the reason for
that is quite amusing.  Note that the STRUCT definition terminates
with a semicolon while FUNCTION isn't. So given both cases to be
parsed, `consume_until(';')` from `CParser` would try to find a
semicolon. But in the case of FUNCTION it won't find it. And the loop
will keep advancing until a top-level semicolon is found. And in case
of Ruby 1.9 the first "good" semicolon is found somewhere near line 820.
It means that YARD just skipped like a quarter of useful docs.

Why is it possible to successfully parse 'hash.c' from Ruby 2.0, then?
Actually, it's not. Ruby 2.0 is lucky with regard to this aspect. The
first top-level semicolon can be found almost immediately after the
function, which returns a pointer to a struct. And between them there
are no any docs.

The fix is just to slightly amend the regexp for a top-level statement.
I also had to remove the `\b` from the regexp, but the good news is that
we don't use `$1` value anywhere, so there was no real purpose in the
`\b`.
```
