### PR TITLE
Fix a bug that the default value of --po-dir isn't expanded

### DIFF
--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -683,7 +683,7 @@ module YARD
 
         opts.on('--po-dir DIR',
                 'The directory that has .po files.',
-                '  (defaults to #{YARD::Registry.po_dir})') do |dir|
+                "  (defaults to #{YARD::Registry.po_dir})") do |dir|
           YARD::Registry.po_dir = dir
         end
       end


### PR DESCRIPTION
`yardoc --help` shows raw Ruby expression as `--po-dir`'s default value.

```
% bin/yardoc --help
...
        --po-dir DIR                 The directory that has .po files.
                                       (defaults to #{YARD::Registry.po_dir})
...
```
