### PR TITLE
Added basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ document your code and immediately preview the results by refreshing the page;
 YARD will do all the work in re-generating the HTML. This makes writing
 documentation a much faster process.
 
+If you want to protect your documentation server from "outside eyes", you can
+run YARD server under `Rack::Auth::Basic` authentication.
+
 
 ## Installing
 
@@ -248,6 +251,15 @@ RubyGems. To serve documentation for a project you are working on, simply run:
 
 And the project inside the current directory will be parsed (if the source has
 not yet been scanned by YARD) and served at [http://localhost:8808](http://localhost:8808).
+
+You can launch the server with `Rack::Auth::Basic` authentication by optionally launching
+with a specified username and/or password:
+
+    $ yard server [--username USER_NAME] [--password PASSWORD] [--realm REALM]
+
+In this scenario, users will need to authenticate before gaining access to the documentation server.
+If `REALM` is specified, then it becomes the title for the server in the login dialog; otherwise
+it defaults to 'Yard Documentation Server'.
 
 ### Live Reloading
 

--- a/lib/yard/server/authenticator.rb
+++ b/lib/yard/server/authenticator.rb
@@ -1,0 +1,41 @@
+require 'rack'
+
+module YARD
+  module Server
+    class Authenticator
+
+      # Set up authentication.  If both arguments expected_username and expected_password are nil, then
+      # don't require authentication.
+      # @param [String] expected_username the user name that users are expected to match. If nil, ignore
+      # @param [String] expected_password the password that users are expected to match. if nil, ignore
+      # @param [String] realm the name of the server to be shown in the login dialog.
+      def initialize(expected_username, expected_password, realm)
+        @username = expected_username
+        @password = expected_password
+        @realm    = realm
+      end
+
+      # Protect the YARD server
+      # @param [Rack::Server] rack_server the YARD documentation Rack server to be protected by authentication
+      # @return [Rack::Auth::Basic] the authentication object protecting the YARD server
+      def authorized_server(rack_server)
+        protected_server       = Rack::Auth::Basic.new(rack_server) do |username, password|
+          credentials_match?(password, username)
+        end
+        protected_server.realm = @realm
+        protected_server
+      end
+
+      # Answers whether the supplied credentials match
+      # @param [String] password the supplied password.  If nil, then the password is not checked
+      # @param [String] username the supplied user name.  If nil, then the user name is not checked
+      # @return [Boolean] true if the supplied credential both match the expected credentials; else false
+      def credentials_match?(password, username)
+        username_match = @username.nil? || @username == username
+        password_match = @password.nil? || @password == password
+        username_match && password_match
+      end
+
+    end
+  end
+end

--- a/spec/server/authenticator_spec.rb
+++ b/spec/server/authenticator_spec.rb
@@ -1,0 +1,53 @@
+require File.dirname(__FILE__) + '/spec_helper'
+require_relative '../../lib/yard/server/authenticator'
+
+describe YARD::Server::Authenticator do
+
+  context '#authorized_server' do
+
+    EXPECTED_USERNAME = 'username'
+    EXPECTED_PASSWORD = 'password'
+    EXPECTED_REALM    = 'specified realm'
+
+    before(:each) do
+      @auth = Authenticator.new(EXPECTED_USERNAME, EXPECTED_PASSWORD, EXPECTED_REALM)
+    end
+
+    context 'realm' do
+
+      before(:each) do
+        @mock_rack = double('Rack')
+      end
+
+      it 'should have the realm' do
+        @mock_rack.stub!(:start)
+        protected_server = @auth.authorized_server(@mock_rack)
+        protected_server.realm.should == EXPECTED_REALM
+      end
+
+    end
+
+    context ':credentials_match?' do
+
+      it 'does not when either password or else username does not match expected' do
+        [
+        # expected password, actual password  , expected user name,actual_user_name,  matches?
+          [EXPECTED_PASSWORD, EXPECTED_PASSWORD, EXPECTED_USERNAME, EXPECTED_USERNAME, true],
+          [EXPECTED_PASSWORD, nil,               EXPECTED_USERNAME, EXPECTED_USERNAME, false],
+          [EXPECTED_PASSWORD, 'passwordx',       EXPECTED_USERNAME, 'usernamex',       false],
+          [nil,               EXPECTED_PASSWORD, EXPECTED_USERNAME, EXPECTED_USERNAME, true],
+          [EXPECTED_PASSWORD, EXPECTED_PASSWORD, nil,               EXPECTED_USERNAME, true],
+          [EXPECTED_PASSWORD, EXPECTED_PASSWORD, EXPECTED_USERNAME, nil,               false],
+          [nil,               'passwordx',       EXPECTED_USERNAME, EXPECTED_USERNAME, true],
+          [EXPECTED_PASSWORD, EXPECTED_PASSWORD, nil,               'usernamex',       true]
+        ].each do |row|
+          auth = Authenticator.new(row[2], row[0], 'dummy_realm')
+          auth.credentials_match?(row[1], row[3]).should == row[4]
+        end
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
This pull request adds `Rack::Basic::Auth` authentication to **YARD** if you pass either of the following command line arguments:

```
--username <expected user name>
--password <expected password>
```

If neither of the above are specified, then the server is launched without requiring authentication.

I realize that `Rack::Basic::Auth` is not the most sophisticated authentication system out there, in that it does no maintenance of the user's browser session.  Hence, after closing my browser after authenticating, my next browse bypasses the login page and goes directly to the doc serving.  Also, when I close the server and restart it, my existing browser entry is able to continue accessing the documents without having to go through the login page.

For me, and I think most people who want authentication, this is adequate.  I just want to keep strangers from looking at the docs (and the source code).

I did add another optional command line argument:

```
--realm <the name of the server>
```

so that the login dialog could show a custom name for the Yard document server; some larger organizations might find this useful.  If not specified, then the server is identified as whatever's in `YARD::CLI::Server::DEFAULT_REALM` (presently 'Yard Documentation Server').

You will see that the only code file modified is `lib/yard/cli/server.rb` and its associated spec file.

I've tried to think of everything:
1. `README.md` is updated, both in the introduction and the detailed section below.
2. Added command line parameters are documented when `--help` is invoked
3. Added `rspecs` for my code.  The remaining tests run without error.

I am using this code without "hiccups" in our continuous integration server running Jenkins.

So, that being said, I think it's time for me to submit this; please give me feedback on anything you'd like corrected or changed.  If it's good enough as-is, then please merge it.

Thanks in advance.
