### PR TITLE
Support gettext 3.0.0

### DIFF
--- a/lib/yard/i18n/locale.rb
+++ b/lib/yard/i18n/locale.rb
@@ -46,20 +46,12 @@ module YARD
         po_file = File.join(locale_directory, "#{@name}.po")
         return false unless File.exist?(po_file)
 
-        begin
-          require "gettext/po_parser"
-          require "gettext/mo"
-        rescue LoadError
-          log.warn "Need gettext gem 3.0.0 or later for i18n feature:"
-          log.warn "  gem install gettext"
-          return false
-        end
+        require "yard/i18n/po_parser"
+        return false unless POParser.available?
 
-        parser = GetText::POParser.new
-        parser.report_warning = false
-        data = GetText::MO.new
-        parser.parse_file(po_file, data)
-        @messages.merge!(data)
+        po_parser = POParser.new
+        @messages.merge!(po_parser.parse(po_file))
+
         true
       end
 

--- a/lib/yard/i18n/po_parser.rb
+++ b/lib/yard/i18n/po_parser.rb
@@ -1,0 +1,60 @@
+module YARD
+  module I18n
+    # +Locale+ is a wrapper for gettext's PO parsing feature. It hides
+    # gettext API difference from YARD.
+    #
+    # @since 0.8.8
+    class POParser
+      if RUBY_VERSION < "1.9"
+        begin
+          require "gettext/tools/poparser"
+          require "gettext/runtime/mofile"
+          @@gettext_version = 2
+        rescue LoadError
+          log.warn "Need gettext gem 2.x for i18n feature:"
+          log.warn "  gem install gettext -v 2.3.9"
+        end
+      else
+        begin
+          require "gettext/po_parser"
+          require "gettext/mo"
+          @@gettext_version = 3
+        rescue LoadError
+          begin
+            require "gettext/tools/poparser"
+            require "gettext/runtime/mofile"
+            @@gettext_version = 2
+          rescue LoadError
+            log.warn "Need gettext gem for i18n feature:"
+            log.warn "  gem install gettext"
+          end
+        end
+      end
+
+      class << self
+        # @return [Boolean] true if gettext is available, false otherwise.
+        def available?
+          !@@gettext_version.nil?
+        end
+      end
+
+      # Parses PO file.
+      #
+      # @param [String] file path of PO file to be parsed.
+      # @return [Hash<String, String>] parsed messages.
+      def parse(file)
+        case @@gettext_version
+        when 2
+          parser = GetText::PoParser.new
+          data = GetText::MoFile.new
+        when 3
+          parser = GetText::POParser.new
+          data = GetText::MO.new
+        end
+        parser.report_warning = false
+        parser.parse_file(file, data)
+        data
+      end
+    end
+  end
+end

--- a/spec/i18n/locale_spec.rb
+++ b/spec/i18n/locale_spec.rb
@@ -22,11 +22,24 @@ describe YARD::I18n::Locale do
     end
 
     have_gettext_gem = true
-    begin
-      require "gettext/po_parser"
-    rescue LoadError
-      have_gettext_gem = false
+    if RUBY_VERSION < "1.9"
+      begin
+        require "gettext/tools/poparser"
+      rescue LoadError
+        have_gettext_gem = false
+      end
+    else
+      begin
+        require "gettext/po_parser"
+      rescue LoadError
+        begin
+          require "gettext/tools/poparser"
+        rescue LoadError
+          have_gettext_gem = false
+        end
+      end
     end
+
     it "should return true for existent PO", :if => have_gettext_gem do
       data = <<-eop
 msgid ""


### PR DESCRIPTION
Gettext 3.0.0 removes deprecated APIs.
See also: https://github.com/ruby-gettext/gettext/blob/master/doc/text/news.md#300-2013-08-31

API changes:

require "gettext/tools/poparser" ->
require "gettext/po_parser"

GetText::PoParser ->
GetText::POParser

require "gettext/runtime/mofile" ->
require "gettext/mo"

GetText::MoFile ->
GetText::MO
