### PR TITLE
Fix a typo in the README example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ following method documented with YARD formatting:
      # @param [String, #read] contents the contents to reverse
      # @return [String] the contents reversed lexically
      def reverse(contents)
-       contents = contents.read if respond_to? :read
+       contents = contents.read if contents.respond_to? :read
        contents.reverse
      end
 


### PR DESCRIPTION
Hi, I just happened to notice what looks like a typo in the README
example, the `reverse` method. Sort of beside the point, I know, but
still. I hope this is helpful!
