### PR TITLE
Enable --redcarpet-ext option to allow any RedCarpet extension(s) like tables one. refs #623

### DIFF
--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -45,6 +45,10 @@ module YARD
       #   The +object+ key is not used so that a file may be rendered in the context
       #   of an object's namespace (for generating links).
       attr_accessor :file
+
+      # @return [Array<String>] List of additional RedCarpet extensions to be loaded.
+      #   List of additional RedCarpet extensions to be loaded.
+      default_attr :redcarpet_exts, lambda { [] }
     end
 
     # Yardoc is the default YARD CLI command (+yard doc+ and historic +yardoc+
@@ -706,6 +710,12 @@ module YARD
                 'The directory that has .po files.',
                 "  (defaults to #{YARD::Registry.po_dir})") do |dir|
           YARD::Registry.po_dir = dir
+        end
+
+        opts.on('--redcarpet-ext EXT',
+                'RedCarpet extension(s), separated by comma.',
+                "  (no_intraemphasis, gh_blockcode, fenced_code, autolink extensions added by default and should not be listed).") do |ext|
+          options.redcarpet_exts = ext.split(/\s*,\s*/)
         end
       end
 

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -7,6 +7,13 @@ module YARD
       include MarkupHelper
       include HtmlSyntaxHighlightHelper
 
+      DEFAULT_REDCARPET_EXTS = %w[
+        no_intraemphasis
+        gh_blockcode
+        fenced_code
+        autolink
+      ].freeze
+
       # @group Escaping Template Data
 
       # Escapes HTML entities
@@ -60,8 +67,9 @@ module YARD
         if provider.to_s == 'RDiscount'
           provider.new(text, :autolink).to_html
         elsif provider.to_s == 'RedcarpetCompat'
-          provider.new(text, :no_intraemphasis, :gh_blockcode,
-                             :fenced_code, :autolink).to_html
+          redcarpet_exts = DEFAULT_REDCARPET_EXTS + options.redcarpet_exts
+          redcarpet_exts.map! { |name| name.to_sym }
+          provider.new(text, *redcarpet_exts.uniq).to_html
         else
           provider.new(text).to_html
         end


### PR DESCRIPTION
Typical use is writing to `.yardopts`:

```
--redcarpet-ext tables
```
