### PR TITLE
recognize all established AsciiDoc file extensions

### DIFF
--- a/lib/yard/templates/helpers/markup_helper.rb
+++ b/lib/yard/templates/helpers/markup_helper.rb
@@ -57,7 +57,7 @@ module YARD
         :html => ['htm', 'html', 'shtml'],
         :text => ['txt'],
         :textile => ['textile', 'txtile'],
-        :asciidoc => ['asciidoc'],
+        :asciidoc => ['asciidoc', 'ad', 'adoc', 'asc'],
         :markdown => ['markdown', 'md', 'mdown', 'mkd'],
         :rdoc => ['rdoc'],
         :ruby => ['rb', 'ru']


### PR DESCRIPTION
Currently, only `.asciidoc` is being recognized. However, many projects use one of the other three well-established extensions: `.adoc`, `.asc` and `.ad`. YARD should recognize these additional AsciiDoc extensions.
