### PR TITLE
JavaScript bug fix for the default template.

### DIFF
--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -78,7 +78,12 @@ function framesInit() {
   if (hasFrames) {
     document.body.className = 'frames';
     $('#menu .noframes a').attr('href', document.location);
-    window.top.document.title = $('html head title').text();
+    try {
+      window.top.document.title = $('html head title').text();
+    } catch(error) {
+      // some browsers will not allow this when serving from file://
+      // but we don't want to stop the world.
+    }
   }
   else {
     $('#menu .noframes a').text('frames').attr('href', framesUrl);


### PR DESCRIPTION
When using the frames view in the default template, it attempts to set the page title when you load a page in the
main frame.  If you are serving content from disk using file://, some browsers, like Chrome, will raise an error. This stops the rest of the JavaScript on the page from running.

This pull request adds a try-catch block around the window title assignment statement.  In the case when this fails, the title simply is not updated.
