### PR TITLE
Updated css for Ruby syntax highlighting.

### DIFF
--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -324,9 +324,9 @@ pre.code .dot + pre.code .id,
 pre.code .rubyid_to_i pre.code .rubyid_each { color: #0085FF; }
 pre.code .comment { color: #0066FF; }
 pre.code .const, pre.code .constant { color: #585CF6; }
+pre.code .label,
 pre.code .symbol { color: #C5060B; }
 pre.code .kw,
-pre.code .label,
 pre.code .rubyid_require,
 pre.code .rubyid_extend,
 pre.code .rubyid_include { color: #0000FF; }


### PR DESCRIPTION
The label class name is used for styling the new symbolized hash syntax from Ruby 1.9+.

```
# "key" is a label and should be colored like a symbol.
some_method(key: 'value')
```

Updated the color on label to match that of symbol.
