### PR TITLE
Upgrade rspec from 2.12 to 2.14 and update syntax to use expect().to instead of .should

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :development do
-  gem 'rspec', '= 2.12'
+  gem 'rspec', '= 2.14'
   gem 'rake'
   gem 'rvm-tester'
   gem 'simplecov'

--- a/spec/cli/command_parser_spec.rb
+++ b/spec/cli/command_parser_spec.rb
@@ -8,7 +8,7 @@ describe YARD::CLI::CommandParser do
 
     it "should show help if --help is provided" do
       command = mock(:command)
-      command.should_receive(:run).with('--help')
+      expect(command).to receive(:run).with('--help')
       CLI::CommandParser.commands[:foo] = command
       @cmd.class.default_command = :foo
       @cmd.run *%w( foo --help )
@@ -16,7 +16,7 @@ describe YARD::CLI::CommandParser do
 
     it "should use default command if first argument is a switch" do
       command = mock(:command)
-      command.should_receive(:run).with('--a', 'b', 'c')
+      expect(command).to receive(:run).with('--a', 'b', 'c')
       CLI::CommandParser.commands[:foo] = command
       @cmd.class.default_command = :foo
       @cmd.run *%w( --a b c )
@@ -24,19 +24,19 @@ describe YARD::CLI::CommandParser do
 
     it "should use default command if no arguments are provided" do
       command = mock(:command)
-      command.should_receive(:run)
+      expect(command).to receive(:run)
       CLI::CommandParser.commands[:foo] = command
       @cmd.class.default_command = :foo
       @cmd.run
     end
 
     it "should list commands if command is not found" do
-      @cmd.should_receive(:list_commands)
+      expect(@cmd).to receive(:list_commands)
       @cmd.run *%w( unknown_command --args )
     end
 
     it "should list commands if --help is provided as sole argument" do
-      @cmd.should_receive(:list_commands)
+      expect(@cmd).to receive(:list_commands)
       @cmd.run *%w( --help )
     end
   end

--- a/spec/cli/command_spec.rb
+++ b/spec/cli/command_spec.rb
@@ -15,22 +15,22 @@ describe YARD::CLI::Command do
     end
 
     it "should skip unrecognized options but continue to next option" do
-      log.should_receive(:warn).with(/Unrecognized.*--list/)
-      log.should_receive(:warn).with(/Unrecognized.*--list2/)
+      expect(log).to receive(:warn).with(/Unrecognized.*--list/)
+      expect(log).to receive(:warn).with(/Unrecognized.*--list2/)
       parse('--list', '--list2', '--foo')
-      @saw_foo.should be_true
+      expect(@saw_foo).to be_true
     end
 
     it "should skip unrecognized options and any extra non-option arg that follows" do
-      log.should_receive(:warn).with(/Unrecognized.*--list/)
+      expect(log).to receive(:warn).with(/Unrecognized.*--list/)
       parse('--list', 'foo', '--foo')
-      @saw_foo.should be_true
+      expect(@saw_foo).to be_true
     end
 
     it "should stop retrying to parse at non-switch argument" do
-      log.should_receive(:warn).with(/Unrecognized.*--list/)
+      expect(log).to receive(:warn).with(/Unrecognized.*--list/)
       args = parse('--list', 'foo', 'foo', 'foo')
-      args.should == %w(foo foo)
+      expect(args).to eq %w(foo foo)
     end
   end
 end

--- a/spec/cli/config_spec.rb
+++ b/spec/cli/config_spec.rb
@@ -16,20 +16,20 @@ describe YARD::CLI::Config do
   describe 'Listing configuration' do
     it "should accept --list" do
       opts = YARD::Config.options
-      YAML.should_receive(:dump).twice.and_return("--- foo\nbar\nbaz")
-      log.should_receive(:puts).twice.with("bar\nbaz")
+      expect(YAML).to receive(:dump).twice.and_return("--- foo\nbar\nbaz")
+      expect(log).to receive(:puts).twice.with("bar\nbaz")
       run
       run('--list')
-      YARD::Config.options.should == opts
+      expect(YARD::Config.options).to eq opts
     end
   end
 
   describe 'Viewing an item' do
     it "should view item if no value is given" do
       YARD::Config.options[:foo] = 'bar'
-      log.should_receive(:puts).with('"bar"')
+      expect(log).to receive(:puts).with('"bar"')
       run 'foo'
-      YARD::Config.options[:foo].should == 'bar'
+      expect(YARD::Config.options[:foo]).to eq 'bar'
     end
   end
 
@@ -37,55 +37,55 @@ describe YARD::CLI::Config do
     it "should accept --reset to set value" do
       YARD::Config.options[:load_plugins] = 'foo'
       run('--reset', 'load_plugins')
-      YARD::Config.options[:load_plugins].should == false
+      expect(YARD::Config.options[:load_plugins]).to eq false
     end
 
     it "should accept --as-list to force single item as list" do
       run('--as-list', 'foo', 'bar')
-      YARD::Config.options[:foo].should == ['bar']
+      expect(YARD::Config.options[:foo]).to eq ['bar']
     end
 
     it "should accept --append to append values to existing key" do
       YARD::Config.options[:foo] = ['bar']
       run('--append', 'foo', 'baz', 'quux')
-      YARD::Config.options[:foo].should == ['bar', 'baz', 'quux']
+      expect(YARD::Config.options[:foo]).to eq ['bar', 'baz', 'quux']
       run('-a', 'foo', 'last')
-      YARD::Config.options[:foo].should == ['bar', 'baz', 'quux', 'last']
+      expect(YARD::Config.options[:foo]).to eq ['bar', 'baz', 'quux', 'last']
     end
 
     it "should turn key into list if --append is used on single item" do
       YARD::Config.options[:foo] = 'bar'
       run('-a', 'foo', 'baz')
-      YARD::Config.options[:foo].should == ['bar', 'baz']
+      expect(YARD::Config.options[:foo]).to eq ['bar', 'baz']
     end
 
     it "should modify item if value is given" do
       run('foo', 'xxx')
-      YARD::Config.options[:foo].should == 'xxx'
+      expect(YARD::Config.options[:foo]).to eq 'xxx'
     end
 
     it "should turn list of values into array of values" do
       run('foo', 'a', 'b', '1', 'true', 'false')
-      YARD::Config.options[:foo].should == ['a', 'b', 1, true, false]
+      expect(YARD::Config.options[:foo]).to eq ['a', 'b', 1, true, false]
     end
 
     it "should turn number into numeric Ruby type" do
       run('foo', '1')
-      YARD::Config.options[:foo].should == 1
+      expect(YARD::Config.options[:foo]).to eq 1
     end
 
     it "should turn true into TrueClass" do
       run('foo', 'true')
-      YARD::Config.options[:foo].should == true
+      expect(YARD::Config.options[:foo]).to eq true
     end
 
     it "should turn false into FalseClass" do
       run('foo', 'false')
-      YARD::Config.options[:foo].should == false
+      expect(YARD::Config.options[:foo]).to eq false
     end
 
     it "should save on modification" do
-      YARD::Config.should_receive(:save)
+      expect(YARD::Config).to receive(:save)
       run('foo', 'true')
     end
   end

--- a/spec/cli/diff_spec.rb
+++ b/spec/cli/diff_spec.rb
@@ -11,8 +11,8 @@ describe YARD::CLI::Diff do
 
   describe 'Argument handling' do
     it "should exit if there is only one gem name" do
-      @diff.should_receive(:exit)
-      log.should_receive(:puts).with(/Usage/)
+      expect(@diff).to receive(:exit)
+      expect(log).to receive(:puts).with(/Usage/)
       @diff.run
     end
   end
@@ -29,7 +29,7 @@ describe YARD::CLI::Diff do
       @objects1 ||= %w( C#fooey C#baz D.bar )
       @objects2 ||= %w( A A::B A::B::C A.foo A#foo B C.foo C.bar C#baz )
       @objects = [@objects1, @objects2]
-      @diff.should_receive(:load_gem_data).ordered.with('gem1') do
+      expect(@diff).to receive(:load_gem_data).ordered.with('gem1') do
         Registry.clear
         YARD.parse_string <<-eof
           class C
@@ -41,7 +41,7 @@ describe YARD::CLI::Diff do
           end
         eof
       end
-      @diff.should_receive(:load_gem_data).ordered.with('gem2') do
+      expect(@diff).to receive(:load_gem_data).ordered.with('gem2') do
         Registry.clear
         YARD.parse_string <<-eof
           module A
@@ -65,7 +65,7 @@ describe YARD::CLI::Diff do
 
     it "should show differences between objects" do
       run
-      @data.string.should == <<-eof
+      expect(@data.string).to eq <<-eof
 Added objects:
 
   A ((stdin):1) (...)
@@ -87,7 +87,7 @@ eof
 
     it "should accept --compact" do
       run('--compact')
-      @data.string.should == <<-eof
+      expect(@data.string).to eq <<-eof
 A A ((stdin):1) (...)
 A A::B::C ((stdin):3)
 A C.bar ((stdin):10)
@@ -101,7 +101,7 @@ eof
     it "should accept -a/--all" do
       ['-a', '--all'].each do |opt|
         run(opt)
-        @data.string.should == <<-eof
+        expect(@data.string).to eq <<-eof
 Added objects:
 
   A ((stdin):1)
@@ -128,7 +128,7 @@ eof
 
     it "should accept --compact and --all" do
       run('--compact', '--all')
-      @data.string.should == <<-eof
+      expect(@data.string).to eq <<-eof
 A A ((stdin):1)
 A A#foo ((stdin):6)
 A A.foo ((stdin):5)
@@ -145,7 +145,7 @@ eof
 
     it "should accept --no-modified" do
       run('--compact', '--no-modified')
-      @data.string.should == <<-eof
+      expect(@data.string).to eq <<-eof
 A A ((stdin):1) (...)
 A A::B::C ((stdin):3)
 A C.bar ((stdin):10)
@@ -157,7 +157,7 @@ eof
 
     it "should accept --query" do
       run('--compact', '--query', 'o.type == :method')
-      @data.string.should == <<-eof
+      expect(@data.string).to eq <<-eof
 A A#foo ((stdin):6)
 A A.foo ((stdin):5)
 A C.bar ((stdin):10)
@@ -175,58 +175,58 @@ eof
     end
 
     it "should search for gem/.yardoc" do
-      File.should_receive(:directory?).with('gem1/.yardoc').and_return(true)
-      File.should_receive(:directory?).with('gem2/.yardoc').and_return(true)
-      Registry.should_receive(:load_yardoc).with('gem1/.yardoc')
-      Registry.should_receive(:load_yardoc).with('gem2/.yardoc')
+      expect(File).to receive(:directory?).with('gem1/.yardoc').and_return(true)
+      expect(File).to receive(:directory?).with('gem2/.yardoc').and_return(true)
+      expect(Registry).to receive(:load_yardoc).with('gem1/.yardoc')
+      expect(Registry).to receive(:load_yardoc).with('gem2/.yardoc')
       @diff.run('gem1', 'gem2')
     end
 
     it "should search for argument as yardoc" do
-      File.should_receive(:directory?).with('gem1/.yardoc').and_return(false)
-      File.should_receive(:directory?).with('gem2/.yardoc').and_return(false)
-      File.should_receive(:directory?).with('gem1').and_return(true)
-      File.should_receive(:directory?).with('gem2').and_return(true)
-      Registry.should_receive(:load_yardoc).with('gem1')
-      Registry.should_receive(:load_yardoc).with('gem2')
+      expect(File).to receive(:directory?).with('gem1/.yardoc').and_return(false)
+      expect(File).to receive(:directory?).with('gem2/.yardoc').and_return(false)
+      expect(File).to receive(:directory?).with('gem1').and_return(true)
+      expect(File).to receive(:directory?).with('gem2').and_return(true)
+      expect(Registry).to receive(:load_yardoc).with('gem1')
+      expect(Registry).to receive(:load_yardoc).with('gem2')
       @diff.run('gem1', 'gem2')
     end
 
     it "should search for installed gem" do
-      File.should_receive(:directory?).with('gem1-1.0.0.gem/.yardoc').and_return(false)
-      File.should_receive(:directory?).with('gem2-1.0.0/.yardoc').and_return(false)
-      File.should_receive(:directory?).with('gem1-1.0.0.gem').and_return(false)
-      File.should_receive(:directory?).with('gem2-1.0.0').and_return(false)
+      expect(File).to receive(:directory?).with('gem1-1.0.0.gem/.yardoc').and_return(false)
+      expect(File).to receive(:directory?).with('gem2-1.0.0/.yardoc').and_return(false)
+      expect(File).to receive(:directory?).with('gem1-1.0.0.gem').and_return(false)
+      expect(File).to receive(:directory?).with('gem2-1.0.0').and_return(false)
       gemmock = mock(:gemmock)
       spec1 = mock(:spec)
       spec2 = mock(:spec)
-      gemmock.should_receive(:find_name).at_least(1).times.and_return([spec1, spec2])
-      Gem.should_receive(:source_index).at_least(1).times.and_return(gemmock)
+      expect(gemmock).to receive(:find_name).at_least(1).times.and_return([spec1, spec2])
+      expect(Gem).to receive(:source_index).at_least(1).times.and_return(gemmock)
       spec1.stub!(:full_name).and_return('gem1-1.0.0')
       spec1.stub!(:name).and_return('gem1')
       spec1.stub!(:version).and_return('1.0.0')
       spec2.stub!(:full_name).and_return('gem2-1.0.0')
       spec2.stub!(:name).and_return('gem2')
       spec2.stub!(:version).and_return('1.0.0')
-      Registry.should_receive(:yardoc_file_for_gem).with('gem1', '= 1.0.0').and_return('/path/to/file')
-      Registry.should_receive(:yardoc_file_for_gem).with('gem2', '= 1.0.0').and_return(nil)
-      Registry.should_receive(:load_yardoc).with('/path/to/file')
-      CLI::Gems.should_receive(:run).with('gem2', '1.0.0').and_return(nil)
+      expect(Registry).to receive(:yardoc_file_for_gem).with('gem1', '= 1.0.0').and_return('/path/to/file')
+      expect(Registry).to receive(:yardoc_file_for_gem).with('gem2', '= 1.0.0').and_return(nil)
+      expect(Registry).to receive(:load_yardoc).with('/path/to/file')
+      expect(CLI::Gems).to receive(:run).with('gem2', '1.0.0').and_return(nil)
       Dir.stub!(:chdir)
       @diff.run('gem1-1.0.0.gem', 'gem2-1.0.0')
     end
 
     it "should search for .gem file" do
-      File.should_receive(:directory?).with('gem1/.yardoc').and_return(false)
-      File.should_receive(:directory?).with('gem2.gem/.yardoc').and_return(false)
-      File.should_receive(:directory?).with('gem1').and_return(false)
-      File.should_receive(:directory?).with('gem2.gem').and_return(false)
-      File.should_receive(:directory?).any_number_of_times
-      File.should_receive(:exist?).with('gem1.gem').and_return(true)
-      File.should_receive(:exist?).with('gem2.gem').and_return(true)
-      File.should_receive(:exist?).any_number_of_times
-      File.should_receive(:open).with('gem1.gem', 'rb')
-      File.should_receive(:open).with('gem2.gem', 'rb')
+      expect(File).to receive(:directory?).with('gem1/.yardoc').and_return(false)
+      expect(File).to receive(:directory?).with('gem2.gem/.yardoc').and_return(false)
+      expect(File).to receive(:directory?).with('gem1').and_return(false)
+      expect(File).to receive(:directory?).with('gem2.gem').and_return(false)
+      expect(File).to receive(:directory?).any_number_of_times
+      expect(File).to receive(:exist?).with('gem1.gem').and_return(true)
+      expect(File).to receive(:exist?).with('gem2.gem').and_return(true)
+      expect(File).to receive(:exist?).any_number_of_times
+      expect(File).to receive(:open).with('gem1.gem', 'rb')
+      expect(File).to receive(:open).with('gem2.gem', 'rb')
       FileUtils.stub(:mkdir_p)
       Gem::Package.stub(:open)
       FileUtils.stub(:rm_rf)
@@ -234,16 +234,16 @@ eof
     end
 
     it "should search for .gem file on rubygems.org" do
-      File.should_receive(:directory?).with('gem1/.yardoc').and_return(false)
-      File.should_receive(:directory?).with('gem2.gem/.yardoc').and_return(false)
-      File.should_receive(:directory?).with('gem1').and_return(false)
-      File.should_receive(:directory?).with('gem2.gem').and_return(false)
-      File.should_receive(:directory?).any_number_of_times
-      File.should_receive(:exist?).with('gem1.gem').and_return(false)
-      File.should_receive(:exist?).with('gem2.gem').and_return(false)
-      File.should_receive(:exist?).any_number_of_times
-      @diff.should_receive(:open).with('http://rubygems.org/downloads/gem1.gem')
-      @diff.should_receive(:open).with('http://rubygems.org/downloads/gem2.gem')
+      expect(File).to receive(:directory?).with('gem1/.yardoc').and_return(false)
+      expect(File).to receive(:directory?).with('gem2.gem/.yardoc').and_return(false)
+      expect(File).to receive(:directory?).with('gem1').and_return(false)
+      expect(File).to receive(:directory?).with('gem2.gem').and_return(false)
+      expect(File).to receive(:directory?).any_number_of_times
+      expect(File).to receive(:exist?).with('gem1.gem').and_return(false)
+      expect(File).to receive(:exist?).with('gem2.gem').and_return(false)
+      expect(File).to receive(:exist?).any_number_of_times
+      expect(@diff).to receive(:open).with('http://rubygems.org/downloads/gem1.gem')
+      expect(@diff).to receive(:open).with('http://rubygems.org/downloads/gem2.gem')
       FileUtils.stub(:mkdir_p)
       Gem::Package.stub(:open)
       FileUtils.stub(:rm_rf)
@@ -251,8 +251,8 @@ eof
     end
 
     it "should error if gem is not found" do
-      log.should_receive(:error).with("Cannot find gem gem1")
-      log.should_receive(:error).with("Cannot find gem gem2.gem")
+      expect(log).to receive(:error).with("Cannot find gem gem1")
+      expect(log).to receive(:error).with("Cannot find gem gem2.gem")
       @diff.stub!(:load_gem_data).and_return(false)
       @diff.run('gem1', 'gem2.gem')
     end

--- a/spec/cli/display_spec.rb
+++ b/spec/cli/display_spec.rb
@@ -9,22 +9,22 @@ describe YARD::CLI::Display do
 
   it "displays an object" do
     YARD::CLI::Display.run('-f', 'text', 'Foo')
-    log.io.string.strip.should eq(@object.format.strip)
+    expect(log.io.string.strip).to eq(@object.format.strip)
   end
 
   it "wraps output with -l (defaulting to layout)" do
     YARD::CLI::Display.run('-l', '-f', 'html', 'Foo')
     formatted_output = @object.format(:format => :html).strip
     actual_output = log.io.string.strip
-    actual_output.should_not eq(formatted_output)
-    actual_output.should include(formatted_output)
+    expect(actual_output).to_not eq(formatted_output)
+    expect(actual_output).to include(formatted_output)
   end
 
   it "wraps output with --layout onefile" do
     YARD::CLI::Display.run('--layout', 'onefile', '-f', 'html', 'Foo')
     formatted_output = @object.format(:format => :html).strip
     actual_output = log.io.string.strip
-    actual_output.should_not eq(formatted_output)
-    actual_output.should include(formatted_output)
+    expect(actual_output).to_not eq(formatted_output)
+    expect(actual_output).to include(formatted_output)
   end
 end

--- a/spec/cli/gems_spec.rb
+++ b/spec/cli/gems_spec.rb
@@ -19,62 +19,62 @@ describe YARD::CLI::Gems do
 
   def build_specs(*specs)
     specs.each do |themock|
-      Registry.should_receive(:yardoc_file_for_gem).with(themock.name, "= #{themock.version}").and_return(themock.yardoc_file)
-      File.should_receive(:directory?).with(themock.yardoc_file).and_return(@rebuild)
-      File.should_receive(:directory?).with(themock.full_gem_path).and_return(true)
-      Registry.should_receive(:yardoc_file_for_gem).with(themock.name, "= #{themock.version}", true).and_return(themock.yardoc_file)
-      Dir.should_receive(:chdir).with(themock.full_gem_path)
+      expect(Registry).to receive(:yardoc_file_for_gem).with(themock.name, "= #{themock.version}").and_return(themock.yardoc_file)
+      expect(File).to receive(:directory?).with(themock.yardoc_file).and_return(@rebuild)
+      expect(File).to receive(:directory?).with(themock.full_gem_path).and_return(true)
+      expect(Registry).to receive(:yardoc_file_for_gem).with(themock.name, "= #{themock.version}", true).and_return(themock.yardoc_file)
+      expect(Dir).to receive(:chdir).with(themock.full_gem_path)
     end
-    Registry.should_receive(:clear).exactly(specs.size).times
-    CLI::Yardoc.should_receive(:run).exactly(specs.size).times
+    expect(Registry).to receive(:clear).exactly(specs.size).times
+    expect(CLI::Yardoc).to receive(:run).exactly(specs.size).times
   end
 
   describe '#run' do
     it "should build all gem indexes if no gem is specified" do
       build_specs(@gem1, @gem2)
-      Gem.source_index.should_receive(:find_name).with('').and_return([@gem1, @gem2])
+      expect(Gem.source_index).to receive(:find_name).with('').and_return([@gem1, @gem2])
       CLI::Gems.run
     end
 
     it "should allow gem to be specified" do
       build_specs(@gem1)
-      Gem.source_index.should_receive(:find_name).with(@gem1.name, '>= 0').and_return([@gem1])
+      expect(Gem.source_index).to receive(:find_name).with(@gem1.name, '>= 0').and_return([@gem1])
       CLI::Gems.run(@gem1.name)
     end
 
     it "should allow multiple gems to be specified for building" do
       build_specs(@gem1, @gem2)
-      Gem.source_index.should_receive(:find_name).with(@gem1.name, @gem1.version).and_return([@gem1])
-      Gem.source_index.should_receive(:find_name).with(@gem2.name, '>= 0').and_return([@gem2])
+      expect(Gem.source_index).to receive(:find_name).with(@gem1.name, @gem1.version).and_return([@gem1])
+      expect(Gem.source_index).to receive(:find_name).with(@gem2.name, '>= 0').and_return([@gem2])
       CLI::Gems.run(@gem1.name, @gem1.version, @gem2.name)
     end
 
     it "should allow version to be specified with gem" do
       build_specs(@gem1)
-      Gem.source_index.should_receive(:find_name).with(@gem1.name, '>= 1.0').and_return([@gem1])
+      expect(Gem.source_index).to receive(:find_name).with(@gem1.name, '>= 1.0').and_return([@gem1])
       CLI::Gems.run(@gem1.name, '>= 1.0')
     end
 
     it "should warn if one of the gems is not found, but it should process others" do
       build_specs(@gem2)
-      Gem.source_index.should_receive(:find_name).with(@gem1.name, '>= 2.0').and_return([])
-      Gem.source_index.should_receive(:find_name).with(@gem2.name, '>= 0').and_return([@gem2])
-      log.should_receive(:warn).with(/#{@gem1.name} >= 2.0 could not be found/)
+      expect(Gem.source_index).to receive(:find_name).with(@gem1.name, '>= 2.0').and_return([])
+      expect(Gem.source_index).to receive(:find_name).with(@gem2.name, '>= 0').and_return([@gem2])
+      expect(log).to receive(:warn).with(/#{@gem1.name} >= 2.0 could not be found/)
       CLI::Gems.run(@gem1.name, '>= 2.0', @gem2.name)
     end
 
     it "should fail if specified gem(s) is/are not found" do
-      CLI::Yardoc.should_not_receive(:run)
-      Gem.source_index.should_receive(:find_name).with(@gem1.name, '>= 2.0').and_return([])
-      log.should_receive(:warn).with(/#{@gem1.name} >= 2.0 could not be found/)
-      log.should_receive(:error).with(/No specified gems could be found/)
+      expect(CLI::Yardoc).to_not receive(:run)
+      expect(Gem.source_index).to receive(:find_name).with(@gem1.name, '>= 2.0').and_return([])
+      expect(log).to receive(:warn).with(/#{@gem1.name} >= 2.0 could not be found/)
+      expect(log).to receive(:error).with(/No specified gems could be found/)
       CLI::Gems.run(@gem1.name, '>= 2.0')
     end
 
     it "should accept --rebuild" do
       @rebuild = true
       build_specs(@gem1)
-      Gem.source_index.should_receive(:find_name).with('').and_return([@gem1])
+      expect(Gem.source_index).to receive(:find_name).with('').and_return([@gem1])
       CLI::Gems.run('--rebuild')
     end
   end

--- a/spec/cli/graph_spec.rb
+++ b/spec/cli/graph_spec.rb
@@ -2,16 +2,16 @@ require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::Graph do
   it "should serialize output" do
-    Registry.should_receive(:load).at_least(1).times
+    expect(Registry).to receive(:load).at_least(1).times
     subject.stub(:yardopts) { [] }
-    subject.options.serializer.should_receive(:serialize).once
+    expect(subject.options.serializer).to receive(:serialize).once
     subject.run
   end
 
   it 'should read yardoc file from .yardopts' do
     subject.stub(:yardopts) { %w(--db /path/to/db) }
-    subject.options.serializer.should_receive(:serialize).once
+    expect(subject.options.serializer).to receive(:serialize).once
     subject.run
-    Registry.yardoc_file.should == '/path/to/db'
+    expect(Registry.yardoc_file).to eq '/path/to/db'
   end
 end

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -3,19 +3,19 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe YARD::CLI::Help do
   describe '#run' do
     it "should accept 'help command'" do
-      CLI::Yardoc.should_receive(:run).with('--help')
+      expect(CLI::Yardoc).to receive(:run).with('--help')
       CLI::Help.run('doc')
     end
 
     it "should accept no arguments (lists all commands)" do
-      CLI::CommandParser.should_receive(:run).with('--help')
+      expect(CLI::CommandParser).to receive(:run).with('--help')
       CLI::Help.run
     end
 
     it "should show all commands if command isn't found" do
-      CLI::CommandParser.should_receive(:run).with('--help')
+      expect(CLI::CommandParser).to receive(:run).with('--help')
       help = CLI::Help.new
-      log.should_receive(:puts).with(/not found/)
+      expect(log).to receive(:puts).with(/not found/)
       help.run('unknown')
     end
   end

--- a/spec/cli/i18n_spec.rb
+++ b/spec/cli/i18n_spec.rb
@@ -19,15 +19,15 @@ describe YARD::CLI::I18n do
     end
 
     it "should read .yardopts by default" do
-      @i18n.use_yardopts_file.should == true
+      expect(@i18n.use_yardopts_file).to eq true
     end
 
     it "should use {lib,app}/**/*.rb and ext/**/*.c as default file glob" do
-      @i18n.files.should == ['{lib,app}/**/*.rb', 'ext/**/*.c']
+      expect(@i18n.files).to eq ['{lib,app}/**/*.rb', 'ext/**/*.c']
     end
 
     it "should only show public visibility by default" do
-      @i18n.visibilities.should == [:public]
+      expect(@i18n.visibilities).to eq [:public]
     end
   end
 
@@ -45,34 +45,34 @@ describe YARD::CLI::I18n do
     should_accept('--yardopts') do |arg|
       @i18n = YARD::CLI::I18n.new
       @i18n.use_document_file = false
-      @i18n.should_receive(:yardopts).at_least(1).times.and_return([])
+      expect(@i18n).to receive(:yardopts).at_least(1).times.and_return([])
       @i18n.parse_arguments(arg)
-      @i18n.use_yardopts_file.should == true
+      expect(@i18n.use_yardopts_file).to eq true
       @i18n.parse_arguments('--no-yardopts', arg)
-      @i18n.use_yardopts_file.should == true
+      expect(@i18n.use_yardopts_file).to eq true
     end
 
     should_accept('--yardopts with filename') do |arg|
       @i18n = YARD::CLI::I18n.new
-      File.should_receive(:read_binary).with('.yardopts_i18n').and_return('')
+      expect(File).to receive(:read_binary).with('.yardopts_i18n').and_return('')
       @i18n.use_document_file = false
       @i18n.parse_arguments('--yardopts', '.yardopts_i18n')
-      @i18n.use_yardopts_file.should == true
-      @i18n.options_file.should == '.yardopts_i18n'
+      expect(@i18n.use_yardopts_file).to eq true
+      expect(@i18n.options_file).to eq '.yardopts_i18n'
     end
 
     should_accept('--no-yardopts') do |arg|
       @i18n = YARD::CLI::I18n.new
       @i18n.use_document_file = false
-      @i18n.should_not_receive(:yardopts)
+      expect(@i18n).to_not receive(:yardopts)
       @i18n.parse_arguments(arg)
-      @i18n.use_yardopts_file.should == false
+      expect(@i18n.use_yardopts_file).to eq false
       @i18n.parse_arguments('--yardopts', arg)
-      @i18n.use_yardopts_file.should == false
+      expect(@i18n.use_yardopts_file).to eq false
     end
 
     should_accept('--exclude') do |arg|
-      YARD.should_receive(:parse).with(['a'], ['nota', 'b'])
+      expect(YARD).to receive(:parse).with(['a'], ['nota', 'b'])
       @i18n.run(arg, 'nota', arg, 'b', 'a')
     end
   end
@@ -83,28 +83,28 @@ describe YARD::CLI::I18n do
     end
 
     it "should search for and use yardopts file specified by #options_file" do
-      File.should_receive(:read_binary).with("test").and_return("-o \n\nMYPATH\nFILE1 FILE2")
+      expect(File).to receive(:read_binary).with("test").and_return("-o \n\nMYPATH\nFILE1 FILE2")
       @i18n.use_document_file = false
       @i18n.options_file = "test"
-      File.should_receive(:open!).with(File.expand_path("MYPATH"), "wb")
+      expect(File).to receive(:open!).with(File.expand_path("MYPATH"), "wb")
       @i18n.run
-      @i18n.files.should == ["FILE1", "FILE2"]
+      expect(@i18n.files).to eq ["FILE1", "FILE2"]
     end
   end
 
   describe '#run' do
     it "should parse_arguments if run() is called" do
-      @i18n.should_receive(:parse_arguments)
+      expect(@i18n).to receive(:parse_arguments)
       @i18n.run
     end
 
     it "should parse_arguments if run(arg1, arg2, ...) is called" do
-      @i18n.should_receive(:parse_arguments)
+      expect(@i18n).to receive(:parse_arguments)
       @i18n.run('--private', '-p', 'foo')
     end
 
     it "should not parse_arguments if run(nil) is called" do
-      @i18n.should_not_receive(:parse_arguments)
+      expect(@i18n).to_not receive(:parse_arguments)
       @i18n.run(nil)
     end
   end

--- a/spec/cli/list_spec.rb
+++ b/spec/cli/list_spec.rb
@@ -2,7 +2,7 @@ require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::List do
   it "should pass command off to Yardoc with --list" do
-    YARD::CLI::Yardoc.should_receive(:run).with('-c', '--list', '--foo')
+    expect(YARD::CLI::Yardoc).to receive(:run).with('-c', '--list', '--foo')
     YARD::CLI::List.run('--foo')
   end
 end

--- a/spec/cli/markup_types_spec.rb
+++ b/spec/cli/markup_types_spec.rb
@@ -6,16 +6,16 @@ describe YARD::CLI::MarkupTypes do
     data = log.io.string
     exts = YARD::Templates::Helpers::MarkupHelper::MARKUP_EXTENSIONS
     YARD::Templates::Helpers::MarkupHelper::MARKUP_PROVIDERS.each do |name, providers|
-      data.should match(/\b#{name}\b/)
+      expect(data).to match(/\b#{name}\b/)
 
       # Match all extensions
       exts[name].each do |ext|
-        data.should include(".#{ext}")
+        expect(data).to include(".#{ext}")
       end if exts[name]
 
       # Match all provider libs
       providers.each do |provider|
-        data.should match(/\b#{provider[:lib]}\b/)
+        expect(data).to match(/\b#{provider[:lib]}\b/)
       end
     end
   end

--- a/spec/cli/server_spec.rb
+++ b/spec/cli/server_spec.rb
@@ -52,9 +52,9 @@ describe YARD::CLI::Server do
     end
     unless @no_adapter_mock
       @cli.stub!(:adapter).and_return(@adapter)
-      @adapter.should_receive(:new).
+      expect(@adapter).to receive(:new).
         with(@libraries, @options, @server_options).and_return(@adapter)
-      @adapter.should_receive(:start)
+      expect(@adapter).to receive(:start)
     end
 
     @cli.run(*args.flatten)
@@ -64,12 +64,12 @@ describe YARD::CLI::Server do
   end
 
   def assert_libraries(expected_libs, actual_libs)
-    actual_libs.should == expected_libs
+    expect(actual_libs).to eq expected_libs
     expected_libs.each do |name, libs|
       libs.each_with_index do |expected,i|
         actual = actual_libs[name][i]
         [:source, :source_path, :yardoc_file].each do |m|
-          actual.send(m).should == expected.send(m)
+          expect(actual.send(m)).to eq expected.send(m)
         end
       end
     end
@@ -118,7 +118,7 @@ describe YARD::CLI::Server do
     end
 
     it "should default to .yardoc if no library is specified" do
-      Dir.should_receive(:pwd).at_least(:once).and_return('/path/to/foo')
+      expect(Dir).to receive(:pwd).at_least(:once).and_return('/path/to/foo')
       @libraries['foo'] = [Server::LibraryVersion.new('foo', nil, '/path/to/foo/.yardoc')]
       run
     end
@@ -139,7 +139,7 @@ describe YARD::CLI::Server do
     it "should fail if specified directory does not exist" do
       @set_libraries = false
       File.stub(:exist?).with('b').and_return(false)
-      log.should_receive(:warn).with(/Cannot find yardoc db for a: "b"/)
+      expect(log).to receive(:warn).with(/Cannot find yardoc db for a: "b"/)
       run %w(a b)
     end
   end
@@ -177,19 +177,19 @@ describe YARD::CLI::Server do
       @server_options[:Host] = 'example.com'
       run '-B', 'example.com'
       run '--bind', 'example.com'
-    end    
+    end
 
     it "should bind address with WebRick adapter" do
       @server_options[:Host] = 'example.com'
       run '-B', 'example.com', '-a', 'webrick'
       run '--bind', 'example.com', '-a', 'webrick'
-    end  
+    end
 
     it "should bind address with Rack adapter" do
       @server_options[:Host] = 'example.com'
       run '-B', 'example.com', '-a', 'rack'
       run '--bind', 'example.com', '-a', 'rack'
-    end          
+    end
 
     it "should accept -p, --port" do
       @server_options[:Port] = 10
@@ -203,28 +203,28 @@ describe YARD::CLI::Server do
     end
 
     it "should accept -a webrick to create WEBrick adapter" do
-      @cli.should_receive(:adapter=).with(YARD::Server::WebrickAdapter)
+      expect(@cli).to receive(:adapter=).with(YARD::Server::WebrickAdapter)
       run '-a', 'webrick'
     end
 
     it "should accept -a rack to create Rack adapter" do
       rack_required
-      @cli.should_receive(:adapter=).with(YARD::Server::RackAdapter)
+      expect(@cli).to receive(:adapter=).with(YARD::Server::RackAdapter)
       run '-a', 'rack'
     end
 
     it "should default to Rack adapter if exists on system" do
       rack_required
-      @cli.should_receive(:require).with('rubygems').and_return(false)
-      @cli.should_receive(:require).with('rack').and_return(true)
-      @cli.should_receive(:adapter=).with(YARD::Server::RackAdapter)
+      expect(@cli).to receive(:require).with('rubygems').and_return(false)
+      expect(@cli).to receive(:require).with('rack').and_return(true)
+      expect(@cli).to receive(:adapter=).with(YARD::Server::RackAdapter)
       @cli.send(:select_adapter)
     end
 
     it "should fall back to WEBrick adapter if Rack is not on system" do
-      @cli.should_receive(:require).with('rubygems').and_return(false)
-      @cli.should_receive(:require).with('rack').and_raise(LoadError)
-      @cli.should_receive(:adapter=).with(YARD::Server::WebrickAdapter)
+      expect(@cli).to receive(:require).with('rubygems').and_return(false)
+      expect(@cli).to receive(:require).with('rack').and_raise(LoadError)
+      expect(@cli).to receive(:adapter=).with(YARD::Server::WebrickAdapter)
       @cli.send(:select_adapter)
     end
 
@@ -277,27 +277,27 @@ describe YARD::CLI::Server do
       lockfile_parser.stub!(:specs).and_return([gem1, gem2])
       Bundler::LockfileParser.stub!(:new).and_return(lockfile_parser)
 
-      File.should_receive(:exist?).at_least(2).times.with("Gemfile.lock").and_return(true)
+      expect(File).to receive(:exist?).at_least(2).times.with("Gemfile.lock").and_return(true)
       File.stub!(:read)
 
       run '-G'
       run '--gemfile'
 
-      File.should_receive(:exist?).with("different_name.lock").and_return(true)
+      expect(File).to receive(:exist?).with("different_name.lock").and_return(true)
       run '--gemfile', 'different_name'
     end
 
     it "should warn if lockfile is not found (with -G)" do
       bundler_required
-      File.should_receive(:exist?).with(/\.yardopts$/).at_least(:once).and_return(false)
-      File.should_receive(:exist?).with('somefile.lock').and_return(false)
-      log.should_receive(:warn).with(/Cannot find somefile.lock/)
+      expect(File).to receive(:exist?).with(/\.yardopts$/).at_least(:once).and_return(false)
+      expect(File).to receive(:exist?).with('somefile.lock').and_return(false)
+      expect(log).to receive(:warn).with(/Cannot find somefile.lock/)
       run '-G', 'somefile'
     end
 
     it "should error if Bundler not available (with -G)" do
-      @cli.should_receive(:require).with('bundler').and_raise(LoadError)
-      log.should_receive(:error).with(/Bundler not available/)
+      expect(@cli).to receive(:require).with('bundler').and_raise(LoadError)
+      expect(log).to receive(:error).with(/Bundler not available/)
       run '-G'
     end
 
@@ -305,7 +305,7 @@ describe YARD::CLI::Server do
       unstub_adapter
       @cli.adapter = Server::WebrickAdapter
       run '-t', 'foo'
-      Templates::Engine.template_paths.last.should == 'foo'
+      expect(Templates::Engine.template_paths.last).to eq 'foo'
     end
 
     it "should load ruby code (-e) after adapter" do
@@ -317,7 +317,7 @@ describe YARD::CLI::Server do
           f.puts "YARD::Templates::Engine.register_template_path 'foo'"
           f.flush
           run '-e', f.path
-          Templates::Engine.template_paths.last.should == 'foo'
+          expect(Templates::Engine.template_paths.last).to eq 'foo'
         end
       ensure
         File.unlink(path)

--- a/spec/cli/stats_spec.rb
+++ b/spec/cli/stats_spec.rb
@@ -33,7 +33,7 @@ describe YARD::CLI::Stats do
 
   it "should list undocumented objects with --list-undoc" do
     @stats.run('--list-undoc')
-    @output.string.should == <<-eof
+    expect(@output.string).to eq <<-eof
 #{@main_stats}
 Undocumented Objects:
 
@@ -52,7 +52,7 @@ eof
       def foo; end
     eof
     @stats.run('--list-undoc')
-    @output.string.should ==  "Files:           1\n" +
+    expect(@output.string).to eq  "Files:           1\n" +
                               "Modules:         0 (    0 undocumented)\n" +
                               "Classes:         0 (    0 undocumented)\n" +
                               "Constants:       0 (    0 undocumented)\n" +
@@ -62,7 +62,7 @@ eof
 
   it "should list undocumented objects in compact mode with --list-undoc --compact" do
     @stats.run('--list-undoc', '--compact')
-    @output.string.should == <<-eof
+    expect(@output.string).to eq <<-eof
 #{@main_stats}
 Undocumented Objects:
 B            ((stdin):9)
@@ -74,12 +74,12 @@ eof
 
   it "should still list stats with --quiet" do
     @stats.run('--quiet')
-    @output.string.should == @main_stats
+    expect(@output.string).to eq @main_stats
   end
 
   it "should ignore everything with --no-public" do
     @stats.run('--no-public')
-    @output.string.should ==
+    expect(@output.string).to eq \
       "Files:           0\n" +
       "Modules:         0 (    0 undocumented)\n" +
       "Classes:         0 (    0 undocumented)\n" +

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -23,63 +23,63 @@ describe YARD::CLI::Yardoc do
     end
 
     it "should use cache by default" do
-      @yardoc.use_cache.should == false
+      expect(@yardoc.use_cache).to eq false
     end
 
     it "print statistics by default" do
-      @yardoc.statistics.should == true
+      expect(@yardoc.statistics).to eq true
     end
 
     it "should generate output by default" do
-      @yardoc.generate.should == true
+      expect(@yardoc.generate).to eq true
     end
 
     it "should read .yardopts by default" do
-      @yardoc.use_yardopts_file.should == true
+      expect(@yardoc.use_yardopts_file).to eq true
     end
 
     it "should read .document by default" do
-      @yardoc.use_document_file.should == true
+      expect(@yardoc.use_document_file).to eq true
     end
 
     it "should use {lib,app}/**/*.rb and ext/**/*.c as default file glob" do
-      @yardoc.files.should == ['{lib,app}/**/*.rb', 'ext/**/*.c']
+      expect(@yardoc.files).to eq ['{lib,app}/**/*.rb', 'ext/**/*.c']
     end
 
     it "should use rdoc as default markup type (but falls back on none)" do
-      @yardoc.options.markup.should == :rdoc
+      expect(@yardoc.options.markup).to eq :rdoc
     end
 
     it "should use default as default template" do
-      @yardoc.options.template.should == :default
+      expect(@yardoc.options.template).to eq :default
     end
 
     it "should use HTML as default format" do
-      @yardoc.options.format.should == :html
+      expect(@yardoc.options.format).to eq :html
     end
 
     it "should use 'Object' as default return type" do
-      @yardoc.options.default_return.should == 'Object'
+      expect(@yardoc.options.default_return).to eq 'Object'
     end
 
     it "should not hide void return types by default" do
-      @yardoc.options.hide_void_return.should == false
+      expect(@yardoc.options.hide_void_return).to eq false
     end
 
     it "should only show public visibility by default" do
-      @yardoc.visibilities.should == [:public]
+      expect(@yardoc.visibilities).to eq [:public]
     end
 
     it "should not list objects by default" do
-      @yardoc.list.should == false
+      expect(@yardoc.list).to eq false
     end
 
     it "should not embed mixins by default" do
-      @yardoc.options.embed_mixins.should be_empty
+      expect(@yardoc.options.embed_mixins).to be_empty
     end
 
     it "should not set any locale by default" do
-      @yardoc.options.locale.should be_nil
+      expect(@yardoc.options.locale).to be_nil
     end
   end
 
@@ -96,90 +96,90 @@ describe YARD::CLI::Yardoc do
 
     should_accept('--single-db') do |arg|
       @yardoc.parse_arguments(arg)
-      Registry.single_object_db.should == true
+      expect(Registry.single_object_db).to eq true
       Registry.single_object_db = nil
     end
 
     should_accept('--no-single-db') do |arg|
       @yardoc.parse_arguments(arg)
-      Registry.single_object_db.should == false
+      expect(Registry.single_object_db).to eq false
       Registry.single_object_db = nil
     end
 
     should_accept('-c', '--use-cache') do |arg|
       @yardoc.parse_arguments(arg)
-      @yardoc.use_cache.should == true
+      expect(@yardoc.use_cache).to eq true
     end
 
     should_accept('--no-cache') do |arg|
       @yardoc.parse_arguments(arg)
-      @yardoc.use_cache.should == false
+      expect(@yardoc.use_cache).to eq false
     end
 
     should_accept('--yardopts') do |arg|
       @yardoc = CLI::Yardoc.new
       @yardoc.use_document_file = false
-      @yardoc.should_receive(:yardopts).at_least(1).times.and_return([])
+      expect(@yardoc).to receive(:yardopts).at_least(1).times.and_return([])
       @yardoc.parse_arguments(arg)
-      @yardoc.use_yardopts_file.should == true
+      expect(@yardoc.use_yardopts_file).to eq true
       @yardoc.parse_arguments('--no-yardopts', arg)
-      @yardoc.use_yardopts_file.should == true
+      expect(@yardoc.use_yardopts_file).to eq true
     end
 
     should_accept('--yardopts with filename') do |arg|
       @yardoc = CLI::Yardoc.new
-      File.should_receive(:read_binary).with('.foobar').and_return('')
+      expect(File).to receive(:read_binary).with('.foobar').and_return('')
       @yardoc.use_document_file = false
       @yardoc.parse_arguments('--yardopts', '.foobar')
-      @yardoc.use_yardopts_file.should == true
-      @yardoc.options_file.should == '.foobar'
+      expect(@yardoc.use_yardopts_file).to eq true
+      expect(@yardoc.options_file).to eq '.foobar'
     end
 
     should_accept('--no-yardopts') do |arg|
       @yardoc = CLI::Yardoc.new
       @yardoc.use_document_file = false
-      @yardoc.should_not_receive(:yardopts)
+      expect(@yardoc).to_not receive(:yardopts)
       @yardoc.parse_arguments(arg)
-      @yardoc.use_yardopts_file.should == false
+      expect(@yardoc.use_yardopts_file).to eq false
       @yardoc.parse_arguments('--yardopts', arg)
-      @yardoc.use_yardopts_file.should == false
+      expect(@yardoc.use_yardopts_file).to eq false
     end
 
     should_accept('--document') do |arg|
       @yardoc = CLI::Yardoc.new
       @yardoc.use_yardopts_file = false
-      @yardoc.should_receive(:support_rdoc_document_file!).and_return([])
+      expect(@yardoc).to receive(:support_rdoc_document_file!).and_return([])
       @yardoc.parse_arguments('--no-document', arg)
-      @yardoc.use_document_file.should == true
+      expect(@yardoc.use_document_file).to eq true
     end
 
     should_accept('--no-document') do |arg|
       @yardoc = CLI::Yardoc.new
       @yardoc.use_yardopts_file = false
-      @yardoc.should_not_receive(:support_rdoc_document_file!)
+      expect(@yardoc).to_not receive(:support_rdoc_document_file!)
       @yardoc.parse_arguments('--document', arg)
-      @yardoc.use_document_file.should == false
+      expect(@yardoc.use_document_file).to eq false
     end
 
     should_accept('-b', '--db') do |arg|
       @yardoc.parse_arguments(arg, 'test')
-      Registry.yardoc_file.should == 'test'
+      expect(Registry.yardoc_file).to eq 'test'
       Registry.yardoc_file = '.yardoc'
     end
 
     should_accept('-n', '--no-output') do |arg|
-      Templates::Engine.should_not_receive(:generate)
+      expect(Templates::Engine).to_not receive(:generate)
       @yardoc.run(arg)
     end
 
     should_accept('--exclude') do |arg|
-      YARD.should_receive(:parse).with(['a'], ['nota', 'b'])
+      expect(YARD).to receive(:parse).with(['a'], ['nota', 'b'])
       @yardoc.run(arg, 'nota', arg, 'b', 'a')
     end
 
     should_accept('--no-save') do |arg|
-      YARD.should_receive(:parse)
-      Registry.should_not_receive(:save)
+      expect(YARD).to receive(:parse)
+      expect(Registry).to_not receive(:save)
       @yardoc.run(arg)
     end
   end
@@ -187,69 +187,69 @@ describe YARD::CLI::Yardoc do
   describe 'Output options' do
     it "should accept --title" do
       @yardoc.parse_arguments('--title', 'hello world')
-      @yardoc.options.title.should == 'hello world'
+      expect(@yardoc.options.title).to eq 'hello world'
     end
 
     it "should allow --title to have multiple spaces in .yardopts" do
-      File.should_receive(:read_binary).with("test").and_return("--title \"Foo Bar\"")
+      expect(File).to receive(:read_binary).with("test").and_return("--title \"Foo Bar\"")
       @yardoc.options_file = "test"
       @yardoc.use_yardopts_file = true
       @yardoc.run
-      @yardoc.options.title.should == "Foo Bar"
+      expect(@yardoc.options.title).to eq "Foo Bar"
     end
 
     it "should alias --main to the --readme flag" do
       readme = File.join(File.dirname(__FILE__),'..','..','README.md')
 
       @yardoc.parse_arguments('--main', readme)
-      @yardoc.options.readme.should == CodeObjects::ExtraFileObject.new(readme, '')
+      expect(@yardoc.options.readme).to eq CodeObjects::ExtraFileObject.new(readme, '')
     end
 
     it "should select a markup provider when --markup-provider or -mp is set" do
       @yardoc.parse_arguments("-M", "test")
-      @yardoc.options.markup_provider.should == :test
+      expect(@yardoc.options.markup_provider).to eq :test
       @yardoc.parse_arguments("--markup-provider", "test2")
-      @yardoc.options.markup_provider.should == :test2
+      expect(@yardoc.options.markup_provider).to eq :test2
     end
 
     it "should select a markup format when -m is set" do
-      @yardoc.should_receive(:verify_markup_options).and_return(true)
+      expect(@yardoc).to receive(:verify_markup_options).and_return(true)
       @yardoc.generate = true
       @yardoc.parse_arguments('-m', 'markdown')
-      @yardoc.options.markup.should == :markdown
+      expect(@yardoc.options.markup).to eq :markdown
     end
 
     it "should accept --default-return" do
       @yardoc.parse_arguments *%w( --default-return XYZ )
-      @yardoc.options.default_return.should == "XYZ"
+      expect(@yardoc.options.default_return).to eq "XYZ"
     end
 
     it "should allow --hide-void-return to be set" do
       @yardoc.parse_arguments *%w( --hide-void-return )
-      @yardoc.options.hide_void_return.should be_true
+      expect(@yardoc.options.hide_void_return).to be_true
     end
 
     it "should accept --embed-mixins" do
       @yardoc.parse_arguments *%w( --embed-mixins )
-      @yardoc.options.embed_mixins.should == ['*']
+      expect(@yardoc.options.embed_mixins).to eq ['*']
     end
 
     it "should accept --embed-mixin MODULE" do
       @yardoc.parse_arguments *%w( --embed-mixin MyModule )
-      @yardoc.options.embed_mixins.should == ['MyModule']
+      expect(@yardoc.options.embed_mixins).to eq ['MyModule']
     end
 
     it "should generate all objects with --use-cache" do
-      YARD.should_receive(:parse)
-      Registry.should_receive(:load)
-      Registry.should_receive(:load_all)
+      expect(YARD).to receive(:parse)
+      expect(Registry).to receive(:load)
+      expect(Registry).to receive(:load_all)
       @yardoc.stub!(:generate).and_return(true)
       @yardoc.run *%w( --use-cache )
     end
 
     it "should not print statistics with --no-stats" do
       @yardoc.stub!(:statistics).and_return(false)
-      CLI::Stats.should_not_receive(:new)
+      expect(CLI::Stats).to_not receive(:new)
       @yardoc.run *%w( --no-stats )
     end
 
@@ -260,34 +260,34 @@ describe YARD::CLI::Yardoc do
       end
 
       it "should copy assets to output directory" do
-        FileUtils.should_receive(:cp_r).with('a', 'doc/a')
+        expect(FileUtils).to receive(:cp_r).with('a', 'doc/a')
         @yardoc.run *%w( --asset a )
-        @yardoc.assets.should == {'a' => 'a'}
+        expect(@yardoc.assets).to eq ({ 'a' => 'a'} )
       end
 
       it "should allow multiple --asset options" do
-        FileUtils.should_receive(:cp_r).with('a', 'doc/a')
-        FileUtils.should_receive(:cp_r).with('b', 'doc/b')
+        expect(FileUtils).to receive(:cp_r).with('a', 'doc/a')
+        expect(FileUtils).to receive(:cp_r).with('b', 'doc/b')
         @yardoc.run *%w( --asset a --asset b )
-        @yardoc.assets.should == {'a' => 'a', 'b' => 'b'}
+        expect(@yardoc.assets).to eq ({ 'a' => 'a', 'b' => 'b'} )
       end
 
       it "should not allow from or to to refer to a path above current path" do
-        log.should_receive(:warn).exactly(4).times.with(/invalid/i)
+        expect(log).to receive(:warn).exactly(4).times.with(/invalid/i)
         @yardoc.run *%w( --asset ../../../etc/passwd )
-        @yardoc.assets.should be_empty
+        expect(@yardoc.assets).to be_empty
         @yardoc.run *%w( --asset a/b/c/d/../../../../../../etc/passwd )
-        @yardoc.assets.should be_empty
+        expect(@yardoc.assets).to be_empty
         @yardoc.run *%w( --asset /etc/passwd )
-        @yardoc.assets.should be_empty
+        expect(@yardoc.assets).to be_empty
         @yardoc.run *%w( --asset normal:/etc/passwd )
-        @yardoc.assets.should be_empty
+        expect(@yardoc.assets).to be_empty
       end
 
       it "should allow from:to syntax" do
-        FileUtils.should_receive(:cp_r).with('foo', 'doc/bar')
+        expect(FileUtils).to receive(:cp_r).with('foo', 'doc/bar')
         @yardoc.run *%w( --asset foo:bar )
-        @yardoc.assets.should == {'foo' => 'bar'}
+        expect(@yardoc.assets).to eq ({ 'foo' => 'bar'} )
       end
 
       it "should not put from inside of to/ if from is a directory" do
@@ -299,8 +299,8 @@ describe YARD::CLI::Yardoc do
           @yardoc.options.serializer.basepath = File.dirname(__FILE__)
           @yardoc.run("--asset", "#{from}:#{to}")
           @yardoc.run("--asset", "#{from}:#{to}")
-          File.directory?(full_to).should be_true
-          File.directory?(File.join(full_to, 'tmp_foo')).should be_false
+          expect(File.directory?(full_to)).to be_true
+          expect(File.directory?(File.join(full_to, 'tmp_foo'))).to be_false
         ensure
           FileUtils.rm_rf(from)
           FileUtils.rm_rf(full_to)
@@ -315,8 +315,8 @@ describe YARD::CLI::Yardoc do
 
         extra_file_object1 = CodeObjects::ExtraFileObject.new('extra_file1')
         extra_file_object2 = CodeObjects::ExtraFileObject.new('extra_file2')
-        extra_file_object1.should_receive(:locale=).with('fr')
-        extra_file_object2.should_receive(:locale=).with('fr')
+        expect(extra_file_object1).to receive(:locale=).with('fr')
+        expect(extra_file_object2).to receive(:locale=).with('fr')
 
         CodeObjects::ExtraFileObject.stub!(:new).with('extra_file1').and_return(extra_file_object1)
         CodeObjects::ExtraFileObject.stub!(:new).with('extra_file2').and_return(extra_file_object2)
@@ -329,7 +329,7 @@ describe YARD::CLI::Yardoc do
 
     describe '--po-dir' do
       it 'should set Registry.po_dir' do
-        Registry.should_receive(:po_dir=).with("locale")
+        expect(Registry).to receive(:po_dir=).with("locale")
         @yardoc.run('--po-dir=locale')
       end
     end
@@ -347,7 +347,7 @@ describe YARD::CLI::Yardoc do
         class Baz; end
       eof
       @yardoc.run('--api', 'private')
-      @yardoc.options.verifier.run(Registry.all).should == [P('Foo')]
+      expect(@yardoc.options.verifier.run(Registry.all)).to eq [P('Foo')]
     end
 
     it "should allow multiple --api's to all be shown" do
@@ -359,8 +359,8 @@ describe YARD::CLI::Yardoc do
         class Baz; end
       eof
       @yardoc.run('--api', 'private', '--api', 'public')
-      @yardoc.options.verifier.run(Registry.all).
-        sort_by {|o| o.path }.should == [P('Bar'), P('Foo')]
+      expect(@yardoc.options.verifier.run(Registry.all).
+        sort_by {|o| o.path }).to eq ( [P('Bar'), P('Foo')] )
     end
 
     it "should allow --no-api to specify objects with no @api tag" do
@@ -372,10 +372,10 @@ describe YARD::CLI::Yardoc do
         class Baz; end
       eof
       @yardoc.run('--api', '')
-      @yardoc.options.verifier.run(Registry.all).should == [P('Baz')]
+      expect(@yardoc.options.verifier.run(Registry.all)).to eq [P('Baz')]
       @yardoc.options.verifier = Verifier.new
       @yardoc.run('--no-api')
-      @yardoc.options.verifier.run(Registry.all).should == [P('Baz')]
+      expect(@yardoc.options.verifier.run(Registry.all)).to eq [P('Baz')]
     end
 
     it "should allow --no-api to work with other --api switches" do
@@ -387,15 +387,15 @@ describe YARD::CLI::Yardoc do
         class Baz; end
       eof
       @yardoc.run('--no-api', '--api', 'public')
-      @yardoc.options.verifier.run(Registry.all).
-        sort_by {|o| o.path }.should == [P('Bar'), P('Baz')]
+      expect(@yardoc.options.verifier.run(Registry.all).
+        sort_by {|o| o.path }).to eq ([P('Bar'), P('Baz')])
     end
 
     it "should ensure Ruby code cannot be used" do
       [':symbol', '42', '"; exit'].each do |ruby|
         @yardoc.options.verifier.expressions = []
         @yardoc.run('--api', ruby)
-        @yardoc.options.verifier.expressions[1].should include(ruby.inspect)
+        expect(@yardoc.options.verifier.expressions[1]).to include(ruby.inspect)
       end
     end
   end
@@ -409,8 +409,8 @@ describe YARD::CLI::Yardoc do
         class Baz; end
       eof
       @yardoc.run('--hide-api', 'private')
-      @yardoc.options.verifier.run(Registry.all).
-        sort_by {|o| o.path }.should == [P('Bar'), P('Baz')]
+      expect(@yardoc.options.verifier.run(Registry.all).
+        sort_by {|o| o.path }).to eq ( [P('Bar'), P('Baz')] )
     end
 
     it "should allow --hide-api to work with --api" do
@@ -422,41 +422,41 @@ describe YARD::CLI::Yardoc do
         class Baz; end
       eof
       @yardoc.run('--api', 'public', '--hide-api', 'private')
-      @yardoc.options.verifier.run(Registry.all).
-        sort_by {|o| o.path }.should == [P('Bar')]
+      expect(@yardoc.options.verifier.run(Registry.all).
+        sort_by {|o| o.path }).to eq [P('Bar')]
     end
   end
 
   describe '--no-private option' do
     it "should accept --no-private" do
       obj = mock(:object)
-      obj.should_receive(:tag).ordered.with(:private).and_return(true)
+      expect(obj).to receive(:tag).ordered.with(:private).and_return(true)
       @yardoc.parse_arguments *%w( --no-private )
-      @yardoc.options.verifier.call(obj).should == false
+      expect(@yardoc.options.verifier.call(obj)).to eq false
     end
 
     it "should hide object if namespace is @private with --no-private" do
       ns = mock(:namespace)
       ns.stub!(:type).and_return(:module)
-      ns.should_receive(:tag).with(:private).and_return(true)
+      expect(ns).to receive(:tag).with(:private).and_return(true)
       obj = mock(:object)
       obj.stub!(:namespace).and_return(ns)
-      obj.should_receive(:tag).with(:private).and_return(false)
+      expect(obj).to receive(:tag).with(:private).and_return(false)
       @yardoc.parse_arguments *%w( --no-private )
-      @yardoc.options.verifier.call(obj).should == false
+      expect(@yardoc.options.verifier.call(obj)).to eq false
     end
 
     it "should not call #tag on namespace if namespace is proxy with --no-private" do
       ns = mock(:namespace)
-      ns.should_receive(:is_a?).with(CodeObjects::Proxy).and_return(true)
-      ns.should_not_receive(:tag)
+      expect(ns).to receive(:is_a?).with(CodeObjects::Proxy).and_return(true)
+      expect(ns).to_not receive(:tag)
       obj = mock(:object)
       obj.stub!(:type).and_return(:class)
       obj.stub!(:namespace).and_return(ns)
       obj.stub!(:visibility).and_return(:public)
-      obj.should_receive(:tag).ordered.with(:private).and_return(false)
+      expect(obj).to receive(:tag).ordered.with(:private).and_return(false)
       @yardoc.parse_arguments *%w( --no-private )
-      @yardoc.options.verifier.call(obj).should == true
+      expect(@yardoc.options.verifier.call(obj)).to eq true
     end
 
     # @bug gh-197
@@ -466,12 +466,12 @@ describe YARD::CLI::Yardoc do
       foobar = Registry.at('Foo::Bar')
       foobar.namespace.type = :module
       @yardoc.parse_arguments *%w( --no-private )
-      @yardoc.options.verifier.call(foobar).should == true
+      expect(@yardoc.options.verifier.call(foobar)).to eq true
     end
 
     it "should not call #tag on proxy object" do # @bug gh-197
       @yardoc.parse_arguments *%w( --no-private )
-      @yardoc.options.verifier.call(P('ProxyClass')).should == true
+      expect(@yardoc.options.verifier.call(P('ProxyClass'))).to eq true
     end
 
     it "should hide methods inside a 'private' class/module with --no-private" do
@@ -483,8 +483,8 @@ describe YARD::CLI::Yardoc do
         end
       eof
       @yardoc.parse_arguments *%w( --no-private )
-      @yardoc.options.verifier.call(Registry.at('ABC')).should be_false
-      @yardoc.options.verifier.call(Registry.at('ABC#foo')).should be_false
+      expect(@yardoc.options.verifier.call(Registry.at('ABC'))).to be_false
+      expect(@yardoc.options.verifier.call(Registry.at('ABC#foo'))).to be_false
     end
   end
 
@@ -494,36 +494,36 @@ describe YARD::CLI::Yardoc do
     end
 
     it "should search for and use yardopts file specified by #options_file" do
-      File.should_receive(:read_binary).with("test").and_return("-o \n\nMYPATH\nFILE1 FILE2")
+      expect(File).to receive(:read_binary).with("test").and_return("-o \n\nMYPATH\nFILE1 FILE2")
       @yardoc.use_document_file = false
       @yardoc.options_file = "test"
       @yardoc.run
-      @yardoc.options.serializer.options[:basepath].should == "MYPATH"
-      @yardoc.files.should == ["FILE1", "FILE2"]
+      expect(@yardoc.options.serializer.options[:basepath]).to eq "MYPATH"
+      expect(@yardoc.files).to eq ["FILE1", "FILE2"]
     end
 
     it "should use String#shell_split to split .yardopts tokens" do
       optsdata = "foo bar"
-      optsdata.should_receive(:shell_split)
-      File.should_receive(:read_binary).with("test").and_return(optsdata)
+      expect(optsdata).to receive(:shell_split)
+      expect(File).to receive(:read_binary).with("test").and_return(optsdata)
       @yardoc.options_file = "test"
       @yardoc.run
     end
 
     it "should allow opts specified in command line to override yardopts file" do
-      File.should_receive(:read_binary).with(".yardopts").and_return("-o NOTMYPATH")
+      expect(File).to receive(:read_binary).with(".yardopts").and_return("-o NOTMYPATH")
       @yardoc.run("-o", "MYPATH", "FILE")
-      @yardoc.options.serializer.options[:basepath].should == "MYPATH"
-      @yardoc.files.should == ["FILE"]
+      expect(@yardoc.options.serializer.options[:basepath]).to eq "MYPATH"
+      expect(@yardoc.files).to eq ["FILE"]
     end
 
     it "should load the RDoc .document file if found" do
-      File.should_receive(:read_binary).with(".yardopts").and_return("-o NOTMYPATH")
+      expect(File).to receive(:read_binary).with(".yardopts").and_return("-o NOTMYPATH")
       @yardoc.use_document_file = true
       @yardoc.stub!(:support_rdoc_document_file!).and_return(["FILE2", "FILE3"])
       @yardoc.run("-o", "MYPATH", "FILE1")
-      @yardoc.options.serializer.options[:basepath].should == "MYPATH"
-      @yardoc.files.should == ["FILE2", "FILE3", "FILE1"]
+      expect(@yardoc.options.serializer.options[:basepath]).to eq "MYPATH"
+      expect(@yardoc.files).to eq ["FILE2", "FILE3", "FILE1"]
     end
   end
 
@@ -533,100 +533,100 @@ describe YARD::CLI::Yardoc do
     it "should hide private constants in with default visibilities" do
       classobj = CodeObjects::ClassObject.new(:root, :Foo) {|o| o.visibility = :private }
       @yardoc.run
-      @yardoc.options.verifier.run([classobj]).should == []
+      expect(@yardoc.options.verifier.run([classobj])).to eq []
     end
 
     it "should setup visibility rules as verifier" do
       methobj = CodeObjects::MethodObject.new(:root, :test) {|o| o.visibility = :private }
-      File.should_receive(:read_binary).with("test").and_return("--private")
+      expect(File).to receive(:read_binary).with("test").and_return("--private")
       @yardoc.use_yardopts_file = true
       @yardoc.options_file = "test"
       @yardoc.run
-      @yardoc.options.verifier.call(methobj).should be_true
+      expect(@yardoc.options.verifier.call(methobj)).to be_true
     end
 
     it "should accept a --query" do
       @yardoc.parse_arguments *%w( --query @return )
-      @yardoc.options.verifier.should be_a(Verifier)
+      expect(@yardoc.options.verifier).to be_a(Verifier)
     end
 
     it "should accept multiple --query arguments" do
       obj = mock(:object)
-      obj.should_receive(:tag).ordered.with('return').and_return(true)
-      obj.should_receive(:tag).ordered.with('tag').and_return(false)
+      expect(obj).to receive(:tag).ordered.with('return').and_return(true)
+      expect(obj).to receive(:tag).ordered.with('tag').and_return(false)
       @yardoc.parse_arguments *%w( --query @return --query @tag )
-      @yardoc.options.verifier.should be_a(Verifier)
-      @yardoc.options.verifier.call(obj).should == false
+      expect(@yardoc.options.verifier).to be_a(Verifier)
+      expect(@yardoc.options.verifier.call(obj)).to eq false
     end
   end
 
   describe 'Extra file arguments' do
     it "should accept extra files if specified after '-' with source files" do
-      Dir.should_receive(:glob).with('README*').and_return([])
-      File.should_receive(:file?).with('extra_file1').and_return(true)
-      File.should_receive(:file?).with('extra_file2').and_return(true)
-      File.should_receive(:read).with('extra_file1').and_return('')
-      File.should_receive(:read).with('extra_file2').and_return('')
+      expect(Dir).to receive(:glob).with('README*').and_return([])
+      expect(File).to receive(:file?).with('extra_file1').and_return(true)
+      expect(File).to receive(:file?).with('extra_file2').and_return(true)
+      expect(File).to receive(:read).with('extra_file1').and_return('')
+      expect(File).to receive(:read).with('extra_file2').and_return('')
       @yardoc.parse_arguments *%w( file1 file2 - extra_file1 extra_file2 )
-      @yardoc.files.should == %w( file1 file2 )
-      @yardoc.options.files.should ==
+      expect(@yardoc.files).to eq %w( file1 file2 )
+      expect(@yardoc.options.files).to match_array(
         [CodeObjects::ExtraFileObject.new('extra_file1', ''),
-          CodeObjects::ExtraFileObject.new('extra_file2', '')]
+          CodeObjects::ExtraFileObject.new('extra_file2', '')])
     end
 
     it "should accept files section only containing extra files" do
-      Dir.should_receive(:glob).with('README*').and_return([])
+      expect(Dir).to receive(:glob).with('README*').and_return([])
       @yardoc.parse_arguments *%w( - LICENSE )
-      @yardoc.files.should == %w( {lib,app}/**/*.rb ext/**/*.c )
-      @yardoc.options.files.should == [CodeObjects::ExtraFileObject.new('LICENSE', '')]
+      expect(@yardoc.files).to eq %w( {lib,app}/**/*.rb ext/**/*.c )
+      expect(@yardoc.options.files).to eq [CodeObjects::ExtraFileObject.new('LICENSE', '')]
     end
 
     it "should accept globs as extra files" do
-      Dir.should_receive(:glob).with('README*').and_return []
-      Dir.should_receive(:glob).with('*.txt').and_return ['a.txt', 'b.txt']
-      File.should_receive(:read).with('a.txt').and_return('')
-      File.should_receive(:read).with('b.txt').and_return('')
-      File.should_receive(:file?).with('a.txt').and_return(true)
-      File.should_receive(:file?).with('b.txt').and_return(true)
+      expect(Dir).to receive(:glob).with('README*').and_return []
+      expect(Dir).to receive(:glob).with('*.txt').and_return ['a.txt', 'b.txt']
+      expect(File).to receive(:read).with('a.txt').and_return('')
+      expect(File).to receive(:read).with('b.txt').and_return('')
+      expect(File).to receive(:file?).with('a.txt').and_return(true)
+      expect(File).to receive(:file?).with('b.txt').and_return(true)
       @yardoc.parse_arguments *%w( file1 file2 - *.txt )
-      @yardoc.files.should == %w( file1 file2 )
-      @yardoc.options.files.should ==
+      expect(@yardoc.files).to eq %w( file1 file2 )
+      expect(@yardoc.options.files).to match_array(
         [CodeObjects::ExtraFileObject.new('a.txt', ''),
-          CodeObjects::ExtraFileObject.new('b.txt', '')]
+          CodeObjects::ExtraFileObject.new('b.txt', '')])
     end
 
     it "should warn if extra file is not found" do
-      log.should_receive(:warn).with(/Could not find extra file: UNKNOWN/)
+      expect(log).to receive(:warn).with(/Could not find extra file: UNKNOWN/)
       @yardoc.parse_arguments *%w( - UNKNOWN )
     end
 
     it "should warn if readme file is not found" do
-      log.should_receive(:warn).with(/Could not find readme file: UNKNOWN/)
+      expect(log).to receive(:warn).with(/Could not find readme file: UNKNOWN/)
       @yardoc.parse_arguments *%w( -r UNKNOWN )
     end
 
     it "should use first file as readme if no readme is specified when using --one-file" do
-      Dir.should_receive(:glob).with('README*').and_return []
-      Dir.should_receive(:glob).with('lib/*.rb').and_return(['lib/foo.rb'])
-      File.should_receive(:read).with('lib/foo.rb').and_return('')
+      expect(Dir).to receive(:glob).with('README*').and_return []
+      expect(Dir).to receive(:glob).with('lib/*.rb').and_return(['lib/foo.rb'])
+      expect(File).to receive(:read).with('lib/foo.rb').and_return('')
       @yardoc.parse_arguments *%w( --one-file lib/*.rb )
-      @yardoc.options.readme.should == CodeObjects::ExtraFileObject.new('lib/foo.rb', '')
+      expect(@yardoc.options.readme).to eq CodeObjects::ExtraFileObject.new('lib/foo.rb', '')
     end
 
     it "should use readme it exists when using --one-file" do
-      Dir.should_receive(:glob).with('README*').and_return ['README']
-      File.should_receive(:read).with('README').and_return('')
+      expect(Dir).to receive(:glob).with('README*').and_return ['README']
+      expect(File).to receive(:read).with('README').and_return('')
       @yardoc.parse_arguments *%w( --one-file lib/*.rb )
-      @yardoc.options.readme.should == CodeObjects::ExtraFileObject.new('README', '')
+      expect(@yardoc.options.readme).to eq CodeObjects::ExtraFileObject.new('README', '')
     end
 
     it "should not allow US-ASCII charset when using --one-file" do
       ienc = Encoding.default_internal
       eenc = Encoding.default_external
-      log.should_receive(:warn).with(/not compatible with US-ASCII.*using ASCII-8BIT/)
+      expect(log).to receive(:warn).with(/not compatible with US-ASCII.*using ASCII-8BIT/)
       @yardoc.parse_arguments *%w( --one-file --charset us-ascii )
-      Encoding.default_internal.name.should == 'ASCII-8BIT'
-      Encoding.default_external.name.should == 'ASCII-8BIT'
+      expect(Encoding.default_internal.name).to eq 'ASCII-8BIT'
+      expect(Encoding.default_external.name).to eq 'ASCII-8BIT'
       Encoding.default_internal = ienc
       Encoding.default_external = eenc
     end if defined?(::Encoding)
@@ -635,37 +635,37 @@ describe YARD::CLI::Yardoc do
   describe 'Source file arguments' do
     it "should accept no params and parse {lib,app}/**/*.rb ext/**/*.c" do
       @yardoc.parse_arguments
-      @yardoc.files.should == %w( {lib,app}/**/*.rb ext/**/*.c )
+      expect(@yardoc.files).to eq %w( {lib,app}/**/*.rb ext/**/*.c )
     end
   end
 
   describe 'Tags options' do
     def tag_created(switch, factory_method)
       visible_tags = mock(:visible_tags)
-      visible_tags.should_receive(:|).ordered.with([:foo])
-      visible_tags.should_receive(:-).ordered.with([]).and_return(visible_tags)
-      Tags::Library.should_receive(:define_tag).with('Foo', :foo, factory_method)
+      expect(visible_tags).to receive(:|).ordered.with([:foo])
+      expect(visible_tags).to receive(:-).ordered.with([]).and_return(visible_tags)
+      expect(Tags::Library).to receive(:define_tag).with('Foo', :foo, factory_method)
       Tags::Library.stub!(:visible_tags=)
-      Tags::Library.should_receive(:visible_tags).at_least(1).times.and_return(visible_tags)
+      expect(Tags::Library).to receive(:visible_tags).at_least(1).times.and_return(visible_tags)
       @yardoc.parse_arguments("--#{switch}-tag", 'foo')
     end
 
     def tag_hidden(tag)
       visible_tags = mock(:visible_tags)
-      visible_tags.should_receive(:|).ordered.with([tag])
-      visible_tags.should_receive(:-).ordered.with([tag]).and_return([])
-      Tags::Library.should_receive(:define_tag).with(tag.to_s.capitalize, tag, nil)
+      expect(visible_tags).to receive(:|).ordered.with([tag])
+      expect(visible_tags).to receive(:-).ordered.with([tag]).and_return([])
+      expect(Tags::Library).to receive(:define_tag).with(tag.to_s.capitalize, tag, nil)
       Tags::Library.stub!(:visible_tags=)
-      Tags::Library.should_receive(:visible_tags).at_least(1).times.and_return(visible_tags)
+      expect(Tags::Library).to receive(:visible_tags).at_least(1).times.and_return(visible_tags)
     end
 
     it "should accept --tag" do
-      Tags::Library.should_receive(:define_tag).with('Title of Foo', :foo, nil)
+      expect(Tags::Library).to receive(:define_tag).with('Title of Foo', :foo, nil)
       @yardoc.parse_arguments('--tag', 'foo:Title of Foo')
     end
 
     it "should accept --tag without title (and default to captialized tag name)" do
-      Tags::Library.should_receive(:define_tag).with('Foo', :foo, nil)
+      expect(Tags::Library).to receive(:define_tag).with('Foo', :foo, nil)
       @yardoc.parse_arguments('--tag', 'foo')
     end
 
@@ -675,7 +675,7 @@ describe YARD::CLI::Yardoc do
       Tags::Library.stub!(:visible_tags).and_return([:foo])
       Tags::Library.stub!(:visible_tags=) {|value| visible_tags = value }
       @yardoc.parse_arguments('--tag', 'foo', '--tag', 'foo')
-      visible_tags.should == [:foo]
+      expect(visible_tags).to eq [:foo]
     end
 
     it "should accept --type-tag" do
@@ -706,13 +706,13 @@ describe YARD::CLI::Yardoc do
 
     it "should accept --transitive-tag" do
       @yardoc.parse_arguments('--transitive-tag', 'foo')
-      Tags::Library.transitive_tags.should include(:foo)
+      expect(Tags::Library.transitive_tags).to include(:foo)
     end
 
     it "should accept --non-transitive-tag" do
       Tags::Library.transitive_tags |= [:foo]
       @yardoc.parse_arguments('--non-transitive-tag', 'foo')
-      Tags::Library.transitive_tags.should_not include(:foo)
+      expect(Tags::Library.transitive_tags).to_not include(:foo)
     end
   end
 
@@ -722,18 +722,18 @@ describe YARD::CLI::Yardoc do
     end
 
     it "should not allow --load or -e in safe mode" do
-      @yardoc.should_not_receive(:require)
+      expect(@yardoc).to_not receive(:require)
       @yardoc.run('--load', 'foo')
       @yardoc.run('-e', 'foo')
     end
 
     it "should not allow --query in safe mode" do
       @yardoc.run('--query', 'foo')
-      @yardoc.options.verifier.expressions.should_not include("foo")
+      expect(@yardoc.options.verifier.expressions).to_not include("foo")
     end
 
     it "should not allow modifying the template paths" do
-      YARD::Templates::Engine.should_not_receive(:register_template_path)
+      expect(YARD::Templates::Engine).to_not receive(:register_template_path)
       @yardoc.run('-p', 'foo')
       @yardoc.run('--template-path', 'foo')
     end
@@ -743,30 +743,30 @@ describe YARD::CLI::Yardoc do
     it "should load rdoc markup if no markup is provided" do
       @yardoc.generate = true
       @yardoc.run
-      @yardoc.options.markup.should == :rdoc
+      expect(@yardoc.options.markup).to eq :rdoc
     end
 
     it "should load rdoc markup even when no output is specified" do
       @yardoc.parse_arguments('--no-output')
-      @yardoc.options.markup.should == :rdoc
+      expect(@yardoc.options.markup).to eq :rdoc
     end
 
     it "should warn if rdoc cannot be loaded and fallback to :none" do
       mod = YARD::Templates::Helpers::MarkupHelper
       mod.clear_markup_cache
-      mod.const_get(:MARKUP_PROVIDERS).should_receive(:[]).with(:rdoc).and_return([{:lib => 'INVALID'}])
-      log.should_receive(:warn).with(/Could not load default RDoc formatter/)
+      expect(mod.const_get(:MARKUP_PROVIDERS)).to receive(:[]).with(:rdoc).and_return([{:lib => 'INVALID'}])
+      expect(log).to receive(:warn).with(/Could not load default RDoc formatter/)
       @yardoc.stub(:generate) { @yardoc.options.files = []; true }
       @yardoc.run
-      @yardoc.options.markup.should == :none
+      expect(@yardoc.options.markup).to eq :none
       mod.clear_markup_cache
     end
 
     it "should error immediately if markup for any files are missing" do
       mod = YARD::Templates::Helpers::MarkupHelper
       mod.clear_markup_cache
-      mod.const_get(:MARKUP_PROVIDERS).should_receive(:[]).with(:markdown).and_return([{:lib => 'INVALID'}])
-      log.should_receive(:error).with(/Missing 'INVALID' gem for Markdown formatting/)
+      expect(mod.const_get(:MARKUP_PROVIDERS)).to receive(:[]).with(:markdown).and_return([{:lib => 'INVALID'}])
+      expect(log).to receive(:error).with(/Missing 'INVALID' gem for Markdown formatting/)
       files = [CodeObjects::ExtraFileObject.new('test.md', '')]
       @yardoc.stub(:generate) { @yardoc.options.files = files; true }
       @yardoc.run
@@ -776,8 +776,8 @@ describe YARD::CLI::Yardoc do
     it "should error immediately if markup for any files are missing (file markup specified in attributes)" do
       mod = YARD::Templates::Helpers::MarkupHelper
       mod.clear_markup_cache
-      mod.const_get(:MARKUP_PROVIDERS).should_receive(:[]).with(:markdown).and_return([{:lib => 'INVALID'}])
-      log.should_receive(:error).with(/Missing 'INVALID' gem for Markdown formatting/)
+      expect(mod.const_get(:MARKUP_PROVIDERS)).to receive(:[]).with(:markdown).and_return([{:lib => 'INVALID'}])
+      expect(log).to receive(:error).with(/Missing 'INVALID' gem for Markdown formatting/)
       files = [CodeObjects::ExtraFileObject.new('test', '# @markup markdown')]
       @yardoc.stub(:generate) { @yardoc.options.files = files; true }
       @yardoc.run
@@ -787,17 +787,17 @@ describe YARD::CLI::Yardoc do
 
   describe '#run' do
     it "should parse_arguments if run() is called" do
-      @yardoc.should_receive(:parse_arguments)
+      expect(@yardoc).to receive(:parse_arguments)
       @yardoc.run
     end
 
     it "should parse_arguments if run(arg1, arg2, ...) is called" do
-      @yardoc.should_receive(:parse_arguments)
+      expect(@yardoc).to receive(:parse_arguments)
       @yardoc.run('--private', '-p', 'foo')
     end
 
     it "should not parse_arguments if run(nil) is called" do
-      @yardoc.should_not_receive(:parse_arguments)
+      expect(@yardoc).to_not receive(:parse_arguments)
       @yardoc.run(nil)
     end
   end

--- a/spec/cli/yri_spec.rb
+++ b/spec/cli/yri_spec.rb
@@ -15,30 +15,30 @@ describe YARD::CLI::YRI do
   describe '#find_object' do
     it "should use cache if available" do
       @yri.stub!(:cache_object)
-      File.should_receive(:exist?).with('.yardoc').and_return(false)
-      File.should_receive(:exist?).with('bar.yardoc').and_return(true)
-      Registry.should_receive(:load).with('bar.yardoc')
-      Registry.should_receive(:at).ordered.with('Foo').and_return(nil)
-      Registry.should_receive(:at).ordered.with('Foo').and_return('OBJ')
+      expect(File).to receive(:exist?).with('.yardoc').and_return(false)
+      expect(File).to receive(:exist?).with('bar.yardoc').and_return(true)
+      expect(Registry).to receive(:load).with('bar.yardoc')
+      expect(Registry).to receive(:at).ordered.with('Foo').and_return(nil)
+      expect(Registry).to receive(:at).ordered.with('Foo').and_return('OBJ')
       @yri.instance_variable_set("@cache", {'Foo' => 'bar.yardoc'})
-      @yri.find_object('Foo').should == 'OBJ'
+      expect(@yri.find_object('Foo')).to eq 'OBJ'
     end
 
     it "should never use cache ahead of current directory's .yardoc" do
       @yri.stub!(:cache_object)
-      File.should_receive(:exist?).with('.yardoc').and_return(true)
-      Registry.should_receive(:load).with('.yardoc')
-      Registry.should_receive(:at).ordered.with('Foo').and_return(nil)
-      Registry.should_receive(:at).ordered.with('Foo').and_return('OBJ')
+      expect(File).to receive(:exist?).with('.yardoc').and_return(true)
+      expect(Registry).to receive(:load).with('.yardoc')
+      expect(Registry).to receive(:at).ordered.with('Foo').and_return(nil)
+      expect(Registry).to receive(:at).ordered.with('Foo').and_return('OBJ')
       @yri.instance_variable_set("@cache", {'Foo' => 'bar.yardoc'})
-      @yri.find_object('Foo').should == 'OBJ'
-      @yri.instance_variable_get("@search_paths")[0].should == '.yardoc'
+      expect(@yri.find_object('Foo')).to eq 'OBJ'
+      expect(@yri.instance_variable_get("@search_paths")[0]).to eq '.yardoc'
     end
   end
 
   describe '#cache_object' do
     it "should skip caching for Registry.yardoc_file" do
-      File.should_not_receive(:open).with(CLI::YRI::CACHE_FILE, 'w')
+      expect(File).to_not receive(:open).with(CLI::YRI::CACHE_FILE, 'w')
       @yri.cache_object('Foo', Registry.yardoc_file)
     end
   end
@@ -46,24 +46,24 @@ describe YARD::CLI::YRI do
   describe '#initialize' do
     it "should load search paths" do
       path = %r{/\.yard/yri_search_paths$}
-      File.should_receive(:file?).with(%r{/\.yard/yri_cache$}).and_return(false)
-      File.should_receive(:file?).with(path).and_return(true)
-      File.should_receive(:readlines).with(path).and_return(%w(line1 line2))
+      expect(File).to receive(:file?).with(%r{/\.yard/yri_cache$}).and_return(false)
+      expect(File).to receive(:file?).with(path).and_return(true)
+      expect(File).to receive(:readlines).with(path).and_return(%w(line1 line2))
       @yri = YARD::CLI::YRI.new
       spaths = @yri.instance_variable_get("@search_paths")
-      spaths.should include('line1')
-      spaths.should include('line2')
+      expect(spaths).to include('line1')
+      expect(spaths).to include('line2')
     end
 
     it "should use DEFAULT_SEARCH_PATHS prior to other paths" do
       YARD::CLI::YRI::DEFAULT_SEARCH_PATHS.push('foo', 'bar')
       path = %r{/\.yard/yri_search_paths$}
-      File.should_receive(:file?).with(%r{/\.yard/yri_cache$}).and_return(false)
-      File.should_receive(:file?).with(path).and_return(true)
-      File.should_receive(:readlines).with(path).and_return(%w(line1 line2))
+      expect(File).to receive(:file?).with(%r{/\.yard/yri_cache$}).and_return(false)
+      expect(File).to receive(:file?).with(path).and_return(true)
+      expect(File).to receive(:readlines).with(path).and_return(%w(line1 line2))
       @yri = YARD::CLI::YRI.new
       spaths = @yri.instance_variable_get("@search_paths")
-      spaths[0,4].should == %w(foo bar line1 line2)
+      expect(spaths[0,4]).to eq %w(foo bar line1 line2)
       YARD::CLI::YRI::DEFAULT_SEARCH_PATHS.replace([])
     end
   end
@@ -71,20 +71,20 @@ describe YARD::CLI::YRI do
   describe '#run' do
     it "should search for objects and print their documentation" do
       obj = YARD::CodeObjects::ClassObject.new(:root, 'Foo')
-      @yri.should_receive(:print_object).with(obj)
+      expect(@yri).to receive(:print_object).with(obj)
       @yri.run('Foo')
       Registry.clear
     end
 
     it "should print usage if no object is provided" do
-      @yri.should_receive(:print_usage)
-      @yri.should_receive(:exit).with(1)
+      expect(@yri).to receive(:print_usage)
+      expect(@yri).to receive(:exit).with(1)
       @yri.run('')
     end
 
     it "should print no documentation exists for object if object is not found" do
-      STDERR.should_receive(:puts).with("No documentation for `Foo'")
-      @yri.should_receive(:exit).with(1)
+      expect(STDERR).to receive(:puts).with("No documentation for `Foo'")
+      expect(@yri).to receive(:exit).with(1)
       @yri.run('Foo')
     end
 

--- a/spec/code_objects/base_spec.rb
+++ b/spec/code_objects/base_spec.rb
@@ -5,42 +5,42 @@ describe YARD::CodeObjects::Base do
 
   # Fix this
   # it "should not allow empty object name" do
-  #   lambda { Base.new(:root, '') }.should raise_error(ArgumentError)
+  #   lambda { Base.new(:root, '') }.should_raise_error(ArgumentError)
   # end
 
   it "should return a unique instance of any registered object" do
     obj = ClassObject.new(:root, :Me)
     obj2 = ClassObject.new(:root, :Me)
-    obj.object_id.should == obj2.object_id
+    expect(obj.object_id).to eq obj2.object_id
 
     obj3 = ModuleObject.new(obj, :Too)
     obj4 = CodeObjects::Base.new(obj3, :Hello)
     obj4.parent = obj
 
     obj5 = CodeObjects::Base.new(obj3, :hello)
-    obj4.object_id.should_not == obj5.object_id
+    expect(obj4.object_id).to_not eq obj5.object_id
   end
 
   it "should create a new object if cached object is not of the same class" do
-    ConstantObject.new(:root, "MYMODULE").should be_instance_of(ConstantObject)
-    ModuleObject.new(:root, "MYMODULE").should be_instance_of(ModuleObject)
-    ClassObject.new(:root, "MYMODULE").should be_instance_of(ClassObject)
-    YARD::Registry.at("MYMODULE").should be_instance_of(ClassObject)
+    expect(ConstantObject.new(:root, "MYMODULE")).to be_instance_of(ConstantObject)
+    expect(ModuleObject.new(:root, "MYMODULE")).to be_instance_of(ModuleObject)
+    expect(ClassObject.new(:root, "MYMODULE")).to be_instance_of(ClassObject)
+    expect(YARD::Registry.at("MYMODULE")).to be_instance_of(ClassObject)
   end
 
   it "should simplify complex namespace paths" do
     obj = ClassObject.new(:root, "A::B::C::D")
-    obj.name.should == :D
-    obj.path.should == "A::B::C::D"
-    obj.namespace.should == P("A::B::C")
+    expect(obj.name).to eq :D
+    expect(obj.path).to eq "A::B::C::D"
+    expect(obj.namespace).to eq P("A::B::C")
   end
 
   # @bug gh-552
   it "should simplify complex namespace paths when path starts with ::" do
     obj = ClassObject.new(:root, "::A::B::C::D")
-    obj.name.should == :D
-    obj.path.should == "A::B::C::D"
-    obj.namespace.should == P("A::B::C")
+    expect(obj.name).to eq :D
+    expect(obj.path).to eq "A::B::C::D"
+    expect(obj.namespace).to eq P("A::B::C")
   end
 
   it "should recall the block if #new is called on an existing object" do
@@ -52,71 +52,71 @@ describe YARD::CodeObjects::Base do
       o.docstring = "NOT_DOCSTRING"
     end
 
-    o1.object_id.should == o2.object_id
-    o1.docstring.should == "NOT_DOCSTRING"
-    o2.docstring.should == "NOT_DOCSTRING"
+    expect(o1.object_id).to eq o2.object_id
+    expect(o1.docstring).to eq "NOT_DOCSTRING"
+    expect(o2.docstring).to eq "NOT_DOCSTRING"
   end
 
   it "should allow complex name and convert that to namespace" do
     obj = CodeObjects::Base.new(nil, "A::B")
-    obj.namespace.path.should == "A"
-    obj.name.should == :B
+    expect(obj.namespace.path).to eq "A"
+    expect(obj.name).to eq :B
   end
 
   it "should allow namespace to be nil and not register in the Registry" do
     obj = CodeObjects::Base.new(nil, :Me)
-    obj.namespace.should == nil
-    Registry.at(:Me).should == nil
+    expect(obj.namespace).to eq nil
+    expect(Registry.at(:Me)).to eq nil
   end
 
   it "should allow namespace to be a NamespaceObject" do
     ns = ModuleObject.new(:root, :Name)
     obj = CodeObjects::Base.new(ns, :Me)
-    obj.namespace.should == ns
+    expect(obj.namespace).to eq ns
   end
 
   it "should allow :root to be the shorthand namespace of `Registry.root`" do
     obj = CodeObjects::Base.new(:root, :Me)
-    obj.namespace.should == Registry.root
+    expect(obj.namespace).to eq Registry.root
   end
 
   it "should not allow any other types as namespace" do
-    lambda { CodeObjects::Base.new("ROOT!", :Me) }.should raise_error(ArgumentError)
+    expect{ CodeObjects::Base.new("ROOT!", :Me) }.to raise_error(ArgumentError)
   end
 
   it "should register itself in the registry if namespace is supplied" do
     obj = ModuleObject.new(:root, :Me)
-    Registry.at(:Me).should == obj
+    expect(Registry.at(:Me)).to eq obj
 
     obj2 = ModuleObject.new(obj, :Too)
-    Registry.at(:"Me::Too").should == obj2
+    expect(Registry.at(:"Me::Too")).to eq obj2
   end
 
   it "should set any attribute using #[]=" do
     obj = ModuleObject.new(:root, :YARD)
     obj[:some_attr] = "hello"
-    obj[:some_attr].should == "hello"
+    expect(obj[:some_attr]).to eq "hello"
   end
 
   it "#[]= should use the accessor method if available" do
     obj = CodeObjects::Base.new(:root, :YARD)
     obj[:source] = "hello"
-    obj.source.should == "hello"
+    expect(obj.source).to eq "hello"
     obj.source = "unhello"
-    obj[:source].should == "unhello"
+    expect(obj[:source]).to eq "unhello"
   end
 
   it "should set attributes via attr= through method_missing" do
     obj = CodeObjects::Base.new(:root, :YARD)
     obj.something = 2
-    obj.something.should == 2
-    obj[:something].should == 2
+    expect(obj.something).to eq 2
+    expect(obj[:something]).to eq 2
   end
 
   it "should exist in the parent's #children after creation" do
     obj = ModuleObject.new(:root, :YARD)
     obj2 = MethodObject.new(obj, :testing)
-    obj.children.should include(obj2)
+    expect(obj.children).to include(obj2)
   end
 
   it "should properly re-indent source starting from 0 indentation" do
@@ -131,7 +131,7 @@ describe YARD::CodeObjects::Base do
         end
       end
     eof
-    obj.source.should == "def mymethod\n  if x == 2 &&\n      5 == 5\n    3\n  else\n    1\n  end\nend"
+    expect(obj.source).to eq "def mymethod\n  if x == 2 &&\n      5 == 5\n    3\n  else\n    1\n  end\nend"
 
     Registry.clear
     Parser::SourceParser.parse_string <<-eof
@@ -139,7 +139,7 @@ describe YARD::CodeObjects::Base do
         super(key)
       end
     eof
-    Registry.at('#key?').source.should == "def key?(key)\n  super(key)\nend"
+    expect(Registry.at('#key?').source).to eq "def key?(key)\n  super(key)\nend"
 
     Registry.clear
     Parser::SourceParser.parse_string <<-eof
@@ -151,7 +151,7 @@ describe YARD::CodeObjects::Base do
           end
         end
     eof
-    Registry.at('#key?').source.should == "def key?(key)\n  if x == 2\n    puts key\n  else\n    exit\n  end\nend"
+    expect(Registry.at('#key?').source).to eq "def key?(key)\n  if x == 2\n    puts key\n  else\n    exit\n  end\nend"
   end
 
   it "should not add newlines to source when parsing sub blocks" do
@@ -166,21 +166,21 @@ describe YARD::CodeObjects::Base do
         end
       end
     eof
-    Registry.at('XYZ::ZYX::ABC#msg').source.should == "def msg\n  hello_world\nend"
+    expect(Registry.at('XYZ::ZYX::ABC#msg').source).to eq "def msg\n  hello_world\nend"
   end
 
   it "should handle source for 'def x; end'" do
     Registry.clear
     Parser::SourceParser.parse_string "def x; 2 end"
-    Registry.at('#x').source.should == "def x; 2 end"
+    expect(Registry.at('#x').source).to eq "def x; 2 end"
   end
 
   it "should set file and line information" do
     Parser::SourceParser.parse_string <<-eof
       class X; end
     eof
-    Registry.at(:X).file.should == '(stdin)'
-    Registry.at(:X).line.should == 1
+    expect(Registry.at(:X).file).to eq '(stdin)'
+    expect(Registry.at(:X).line).to eq 1
   end
 
   it "should maintain all file associations when objects are defined multiple times in one file" do
@@ -190,9 +190,9 @@ describe YARD::CodeObjects::Base do
       class X; end
     eof
 
-    Registry.at(:X).file.should == '(stdin)'
-    Registry.at(:X).line.should == 1
-    Registry.at(:X).files.should == [['(stdin)', 1], ['(stdin)', 2], ['(stdin)', 3]]
+    expect(Registry.at(:X).file).to eq '(stdin)'
+    expect(Registry.at(:X).line).to eq 1
+    expect(Registry.at(:X).files).to eq [['(stdin)', 1], ['(stdin)', 2], ['(stdin)', 3]]
   end
 
   it "should maintain all file associations when objects are defined multiple times in multiple files" do
@@ -201,9 +201,9 @@ describe YARD::CodeObjects::Base do
       Parser::SourceParser.new.parse("file#{i+1}.rb")
     end
 
-    Registry.at(:X).file.should == 'file1.rb'
-    Registry.at(:X).line.should == 1
-    Registry.at(:X).files.should == [['file1.rb', 1], ['file2.rb', 1], ['file3.rb', 1]]
+    expect(Registry.at(:X).file).to eq 'file1.rb'
+    expect(Registry.at(:X).line).to eq 1
+    expect(Registry.at(:X).files).to eq [['file1.rb', 1], ['file2.rb', 1], ['file3.rb', 1]]
   end
 
   it "should prioritize the definition with a docstring when returning #file" do
@@ -214,15 +214,15 @@ describe YARD::CodeObjects::Base do
       class X; end
     eof
 
-    Registry.at(:X).file.should == '(stdin)'
-    Registry.at(:X).line.should == 4
-    Registry.at(:X).files.should == [['(stdin)', 4], ['(stdin)', 1], ['(stdin)', 2]]
+    expect(Registry.at(:X).file).to eq '(stdin)'
+    expect(Registry.at(:X).line).to eq 4
+    expect(Registry.at(:X).files).to eq [['(stdin)', 4], ['(stdin)', 1], ['(stdin)', 2]]
   end
 
   describe '#format' do
     it "should send to Templates.render" do
       object = MethodObject.new(:root, :method)
-      Templates::Engine.should_receive(:render).with(:x => 1, :object => object)
+      expect(Templates::Engine).to receive(:render).with(:x => 1, :object => object)
       object.format :x => 1
     end
   end
@@ -230,62 +230,62 @@ describe YARD::CodeObjects::Base do
   describe '#source_type' do
     it "should default source_type to :ruby" do
       object = MethodObject.new(:root, :method)
-      object.source_type.should == :ruby
+      expect(object.source_type).to eq :ruby
     end
   end
 
   describe '#relative_path' do
     it "should accept a string" do
       YARD.parse_string "module A; class B; end; class C; end; end"
-      Registry.at('A::B').relative_path(Registry.at('A::C')).should ==
-        Registry.at('A::B').relative_path('A::C')
+      expect(Registry.at('A::B').relative_path(Registry.at('A::C'))).
+        to eq Registry.at('A::B').relative_path('A::C')
     end
 
     it "should return full class name when objects share a common class prefix" do
       YARD.parse_string "module User; end; module UserManager; end"
-      Registry.at('User').relative_path('UserManager').should == 'UserManager'
-      Registry.at('User').relative_path(Registry.at('UserManager')).should == 'UserManager'
+      expect(Registry.at('User').relative_path('UserManager')).to eq 'UserManager'
+      expect(Registry.at('User').relative_path(Registry.at('UserManager'))).to eq 'UserManager'
     end
 
     it "should return the relative path when they share a common namespace" do
       YARD.parse_string "module A; class B; end; class C; end; end"
-      Registry.at('A::B').relative_path(Registry.at('A::C')).should == 'C'
+      expect(Registry.at('A::B').relative_path(Registry.at('A::C'))).to eq 'C'
       YARD.parse_string "module Foo; module A; end; module B; def foo; end end end"
-      Registry.at('Foo::A').relative_path(Registry.at('Foo::B#foo')).should == 'B#foo'
+      expect(Registry.at('Foo::A').relative_path(Registry.at('Foo::B#foo'))).to eq 'B#foo'
     end
 
     it "should return the full path if they don't have a common namespace" do
       YARD.parse_string "module A; class B; end; end; module D; class C; end; end"
-      Registry.at('A::B').relative_path('D::C').should == 'D::C'
+      expect(Registry.at('A::B').relative_path('D::C')).to eq 'D::C'
       YARD.parse_string 'module C::B::C; module Apple; end; module Ant; end end'
-      Registry.at('C::B::C::Apple').relative_path('C::B::C::Ant').should == 'Ant'
+      expect(Registry.at('C::B::C::Apple').relative_path('C::B::C::Ant')).to eq 'Ant'
       YARD.parse_string 'module OMG::ABC; end; class Object; end'
-      Registry.at('OMG::ABC').relative_path('Object').should == "Object"
+      expect(Registry.at('OMG::ABC').relative_path('Object')).to eq "Object"
       YARD.parse_string("class YARD::Config; MYCONST = 1; end")
-      Registry.at('YARD::Config').relative_path('YARD::Config::MYCONST').should == "MYCONST"
+      expect(Registry.at('YARD::Config').relative_path('YARD::Config::MYCONST')).to eq "MYCONST"
     end
 
     it "should return a relative path for class methods" do
       YARD.parse_string "module A; def self.b; end; def self.c; end; end"
-      Registry.at('A.b').relative_path('A.c').should == 'c'
-      Registry.at('A').relative_path('A.c').should == 'c'
+      expect(Registry.at('A.b').relative_path('A.c')).to eq 'c'
+      expect(Registry.at('A').relative_path('A.c')).to eq 'c'
     end
 
     it "should return a relative path for instance methods" do
       YARD.parse_string "module A; def b; end; def c; end; end"
-      Registry.at('A#b').relative_path('A#c').should == '#c'
-      Registry.at('A').relative_path('A#c').should == '#c'
+      expect(Registry.at('A#b').relative_path('A#c')).to eq '#c'
+      expect(Registry.at('A').relative_path('A#c')).to eq '#c'
     end
 
     it "should return full path if relative path is to parent namespace" do
       YARD.parse_string "module A; module B; end end"
-      Registry.at('A::B').relative_path('A').should == 'A'
+      expect(Registry.at('A::B').relative_path('A')).to eq 'A'
     end
 
     it "should only return name for relative path to self" do
       YARD.parse_string("class A::B::C; def foo; end end")
-      Registry.at('A::B::C').relative_path('A::B::C').should == 'C'
-      Registry.at('A::B::C#foo').relative_path('A::B::C#foo').should == '#foo'
+      expect(Registry.at('A::B::C').relative_path('A::B::C')).to eq 'C'
+      expect(Registry.at('A::B::C#foo').relative_path('A::B::C#foo')).to eq '#foo'
     end
   end
 
@@ -293,29 +293,29 @@ describe YARD::CodeObjects::Base do
     it "should convert string into Docstring when #docstring= is set" do
       o = ClassObject.new(:root, :Me)
       o.docstring = "DOCSTRING"
-      o.docstring.should be_instance_of(Docstring)
+      expect(o.docstring).to be_instance_of(Docstring)
     end
 
     it "should set docstring to docstring of other object if docstring is '(see Path)'" do
       ClassObject.new(:root, :AnotherObject) {|x| x.docstring = "FOO" }
       o = ClassObject.new(:root, :Me)
       o.docstring = '(see AnotherObject)'
-      o.docstring.should == "FOO"
+      expect(o.docstring).to eq "FOO"
     end
 
     it "should not copy docstring mid-docstring" do
       doc = "Hello.\n(see file.rb)\nmore documentation"
       o = ClassObject.new(:root, :Me)
       o.docstring = doc
-      o.docstring.should == doc
+      expect(o.docstring).to eq doc
     end
 
     it "should allow extra docstring after (see Path)" do
       ClassObject.new(:root, :AnotherObject) {|x| x.docstring = "FOO" }
       o = ClassObject.new(:root, :Me)
       o.docstring = Docstring.new("(see AnotherObject)\n\nEXTRA\n@api private", o)
-      o.docstring.should == "FOO\n\nEXTRA"
-      o.docstring.should have_tag(:api)
+      expect(o.docstring).to eq "FOO\n\nEXTRA"
+      expect(o.docstring).to have_tag(:api)
     end
   end
 
@@ -323,15 +323,15 @@ describe YARD::CodeObjects::Base do
     it "should return empty string if docstring was '(see Path)' and Path is not resolved" do
       o = ClassObject.new(:root, :Me)
       o.docstring = '(see AnotherObject)'
-      o.docstring.should == ""
+      expect(o.docstring).to eq ""
     end
 
     it "should return docstring when object is resolved" do
       o = ClassObject.new(:root, :Me)
       o.docstring = '(see AnotherObject)'
-      o.docstring.should == ""
+      expect(o.docstring).to eq ""
       ClassObject.new(:root, :AnotherObject) {|x| x.docstring = "FOO" }
-      o.docstring.should == "FOO"
+      expect(o.docstring).to eq "FOO"
     end
 
     describe 'localization' do
@@ -341,10 +341,10 @@ describe YARD::CodeObjects::Base do
 
         o = ClassObject.new(:root, :Me)
         o.docstring = 'Hello'
-        o.docstring.should == 'Hello'
+        expect(o.docstring).to eq 'Hello'
 
         Registry.stub!(:locale).with('fr').and_return(fr_locale)
-        o.docstring('fr').should == "Bonjour"
+        expect(o.docstring('fr')).to eq "Bonjour"
       end
 
       it "should return updated localized docstring" do
@@ -353,15 +353,15 @@ describe YARD::CodeObjects::Base do
 
         o = ClassObject.new(:root, :Me)
         o.docstring = 'Hello'
-        o.docstring.should == 'Hello'
+        expect(o.docstring).to eq 'Hello'
 
         fr_locale.stub!(:translate).with('Hello').and_return('Bonjour')
-        o.docstring('fr').should == "Bonjour"
+        expect(o.docstring('fr')).to eq "Bonjour"
 
         o.docstring = 'World'
         fr_locale.stub!(:translate).with('World').and_return('Monde')
-        o.docstring('fr').should == "Monde"
-        o.docstring.should == 'World'
+        expect(o.docstring('fr')).to eq "Monde"
+        expect(o.docstring).to eq 'World'
       end
     end
   end
@@ -370,11 +370,11 @@ describe YARD::CodeObjects::Base do
     it "should only add a file/line combination once" do
       o = ClassObject.new(:root, :Me)
       o.add_file('filename', 12)
-      o.files.should == [['filename', 12]]
+      expect(o.files).to eq [['filename', 12]]
       o.add_file('filename', 12)
-      o.files.should == [['filename', 12]]
+      expect(o.files).to eq [['filename', 12]]
       o.add_file('filename', 40) # different line
-      o.files.should == [['filename', 12], ['filename', 40]]
+      expect(o.files).to eq [['filename', 12], ['filename', 40]]
     end
   end
 
@@ -390,24 +390,24 @@ describe YARD::CodeObjects::Base do
       eof
       foo_c = MethodObject.new(:root, :foo, :class)
       Registry.at('#foo').copy_to(foo_c)
-      foo_c.scope.should == :class
-      foo_c.visibility.should == :private
-      foo_c.type.should == :method
-      foo_c.class.should == MethodObject
-      foo_c.path.should == '::foo'
-      foo_c.docstring.should == "A docstring"
-      foo_c.tag(:return).types.should == ['String']
-      foo_c.file.should == '(stdin)'
-      foo_c.line.should == 4
-      foo_c.source.should =~ /source_code_here/
-      foo_c.signature.should == 'def foo(a, b, c)'
-      foo_c.parameters.should == [['a', nil], ['b', nil], ['c', nil]]
+      expect(foo_c.scope).to eq :class
+      expect(foo_c.visibility).to eq :private
+      expect(foo_c.type).to eq :method
+      expect(foo_c.class).to eq MethodObject
+      expect(foo_c.path).to eq '::foo'
+      expect(foo_c.docstring).to eq "A docstring"
+      expect(foo_c.tag(:return).types).to eq ['String']
+      expect(foo_c.file).to eq '(stdin)'
+      expect(foo_c.line).to eq 4
+      expect(foo_c.source).to match( /source_code_here/ )
+      expect(foo_c.signature).to eq 'def foo(a, b, c)'
+      expect(foo_c.parameters).to eq [['a', nil], ['b', nil], ['c', nil]]
     end
 
     it "should return copied object" do
       YARD.parse_string 'def foo; end'
       foo_c = MethodObject.new(:root, :foo, :class)
-      Registry.at('#foo').copy_to(foo_c).should == foo_c
+      expect(Registry.at('#foo').copy_to(foo_c)).to eq foo_c
     end
 
     it "should copy docstring and rewrite tags for new object" do
@@ -418,20 +418,20 @@ describe YARD::CodeObjects::Base do
       foo_c = MethodObject.new(:root, :foo, :class)
       foo_i = Registry.at('#foo')
       foo_i.copy_to(foo_c)
-      foo_i.tags.should_not == foo_c.tags
-      foo_c.tags.first.object.should == foo_c
+      expect(foo_i.tags).to_not eq foo_c.tags
+      expect(foo_c.tags.first.object).to eq foo_c
     end
 
     it "should only copy #copyable_attributes" do
       foo = MethodObject.new(:root, :foo)
-      foo.should_receive(:copyable_attributes).and_return %w(a b c)
-      foo.should_receive(:instance_variable_get).with('@a').and_return(1)
-      foo.should_receive(:instance_variable_get).with('@b').and_return(2)
-      foo.should_receive(:instance_variable_get).with('@c').and_return(3)
+      expect(foo).to receive(:copyable_attributes).and_return %w(a b c)
+      expect(foo).to receive(:instance_variable_get).with('@a').and_return(1)
+      expect(foo).to receive(:instance_variable_get).with('@b').and_return(2)
+      expect(foo).to receive(:instance_variable_get).with('@c').and_return(3)
       bar = MethodObject.new(:root, :bar)
-      bar.should_receive(:instance_variable_set).with('@a', 1)
-      bar.should_receive(:instance_variable_set).with('@b', 2)
-      bar.should_receive(:instance_variable_set).with('@c', 3)
+      expect(bar).to receive(:instance_variable_set).with('@a', 1)
+      expect(bar).to receive(:instance_variable_set).with('@b', 2)
+      expect(bar).to receive(:instance_variable_set).with('@c', 3)
       foo.copy_to(bar)
     end
   end

--- a/spec/code_objects/class_object_spec.rb
+++ b/spec/code_objects/class_object_spec.rb
@@ -20,11 +20,11 @@ describe YARD::CodeObjects::ClassObject do
     end
 
     it "should show the proper inheritance tree" do
-      @yard.inheritance_tree.should == [@yard, @superyard, P(:String)]
+      expect(@yard.inheritance_tree).to eq [@yard, @superyard, P(:String)]
     end
 
     it "should show proper inheritance tree when mixins are included" do
-      @yard.inheritance_tree(true).should == [@yard, @mixin, @superyard, @mixin4, @mixin2, @mixin3, P(:String)]
+      expect(@yard.inheritance_tree(true)).to eq [@yard, @mixin, @superyard, @mixin4, @mixin2, @mixin3, P(:String)]
     end
 
     it "should not modify the object's mixin list when mixins are included" do
@@ -33,14 +33,14 @@ describe YARD::CodeObjects::ClassObject do
       @class2.superclass = @class1
 
       @class2.inheritance_tree(true)
-      @class2.mixins.should == []
+      expect(@class2.mixins).to eq []
     end
 
     it "should list class mixins in inheritance tree" do
       mod = ModuleObject.new(:root, :ClassMethods)
       klass = ClassObject.new(:root, :ReceivingClass)
       klass.class_mixins << mod
-      klass.inheritance_tree(true).should == [klass, mod]
+      expect(klass.inheritance_tree(true)).to eq [klass, mod]
     end
   end
 
@@ -80,43 +80,43 @@ describe YARD::CodeObjects::ClassObject do
 
     it "should show inherited methods by default" do
       meths = P(:YARD).meths
-      meths.should include(P("YARD#mymethod"))
-      meths.should include(P("SuperYard#foo"))
-      meths.should include(P("SuperYard#foo2"))
-      meths.should include(P("SuperYard.bar"))
+      expect(meths).to include(P("YARD#mymethod"))
+      expect(meths).to include(P("SuperYard#foo"))
+      expect(meths).to include(P("SuperYard#foo2"))
+      expect(meths).to include(P("SuperYard.bar"))
     end
 
     it "should allow :inherited to be set to false" do
       meths = P(:YARD).meths(:inherited => false)
-      meths.should include(P("YARD#mymethod"))
-      meths.should_not include(P("SuperYard#foo"))
-      meths.should_not include(P("SuperYard#foo2"))
-      meths.should_not include(P("SuperYard.bar"))
+      expect(meths).to include(P("YARD#mymethod"))
+      expect(meths).to_not include(P("SuperYard#foo"))
+      expect(meths).to_not include(P("SuperYard#foo2"))
+      expect(meths).to_not include(P("SuperYard.bar"))
     end
 
     it "should not show overridden methods" do
       meths = P(:YARD).meths
-      meths.should include(P("YARD#bar"))
-      meths.should_not include(P("SuperYard#bar"))
+      expect(meths).to include(P("YARD#bar"))
+      expect(meths).to_not include(P("SuperYard#bar"))
 
       meths = P(:YARD).inherited_meths
-      meths.should_not include(P("YARD#bar"))
-      meths.should_not include(P("YARD#mymethod"))
-      meths.should include(P("SuperYard#foo"))
-      meths.should include(P("SuperYard#foo2"))
-      meths.should include(P("SuperYard.bar"))
+      expect(meths).to_not include(P("YARD#bar"))
+      expect(meths).to_not include(P("YARD#mymethod"))
+      expect(meths).to include(P("SuperYard#foo"))
+      expect(meths).to include(P("SuperYard#foo2"))
+      expect(meths).to include(P("SuperYard.bar"))
     end
 
     it "should not show inherited methods overridden by other subclasses" do
       meths = P(:YARD).inherited_meths
-      meths.should include(P('MiddleYard#middle'))
-      meths.should_not include(P('SuperYard#middle'))
+      expect(meths).to include(P('MiddleYard#middle'))
+      expect(meths).to_not include(P('SuperYard#middle'))
     end
 
     it "should show mixed in methods before superclass method" do
       meths = P(:FinalYard).meths
-      meths.should include(P('IncludedYard#foo'))
-      meths.should_not include(P('SuperYard#foo'))
+      expect(meths).to include(P('IncludedYard#foo'))
+      expect(meths).to_not include(P('SuperYard#foo'))
     end
   end
 
@@ -144,50 +144,50 @@ describe YARD::CodeObjects::ClassObject do
 
     it "should list inherited constants by default" do
       consts = P(:SubYard).constants
-      consts.should include(P("YARD::CONST1"))
-      consts.should include(P("SubYard::CONST3"))
+      expect(consts).to include(P("YARD::CONST1"))
+      expect(consts).to include(P("SubYard::CONST3"))
 
       consts = P(:SubYard).inherited_constants
-      consts.should include(P("YARD::CONST1"))
-      consts.should_not include(P("YARD::CONST2"))
-      consts.should_not include(P("SubYard::CONST2"))
-      consts.should_not include(P("SubYard::CONST3"))
+      expect(consts).to include(P("YARD::CONST1"))
+      expect(consts).to_not include(P("YARD::CONST2"))
+      expect(consts).to_not include(P("SubYard::CONST2"))
+      expect(consts).to_not include(P("SubYard::CONST3"))
     end
 
     it "should not list inherited constants if turned off" do
       consts = P(:SubYard).constants(:inherited => false)
-      consts.should_not include(P("YARD::CONST1"))
-      consts.should include(P("SubYard::CONST3"))
+      expect(consts).to_not include(P("YARD::CONST1"))
+      expect(consts).to include(P("SubYard::CONST3"))
     end
 
     it "should not include an inherited constant if it is overridden by the object" do
       consts = P(:SubYard).constants
-      consts.should include(P("SubYard::CONST2"))
-      consts.should_not include(P("YARD::CONST2"))
+      expect(consts).to include(P("SubYard::CONST2"))
+      expect(consts).to_not include(P("YARD::CONST2"))
     end
 
     it "should not include an inherited constant if it is overridden by another subclass" do
       consts = P(:SubYard).inherited_constants
-      consts.should include(P("SUPERYARD::CONST4"))
-      consts.should_not include(P("YARD::CONST4"))
+      expect(consts).to include(P("SUPERYARD::CONST4"))
+      expect(consts).to_not include(P("YARD::CONST4"))
     end
 
     it "should not set a superclass on BasicObject class" do
       o = ClassObject.new(:root, :Object)
-      o.superclass.should == P(:BasicObject)
+      expect(o.superclass).to eq P(:BasicObject)
     end
 
     it "should set superclass of Object to BasicObject" do
       o = ClassObject.new(:root, :BasicObject)
-      o.superclass.should be_nil
+      expect(o.superclass).to be_nil
     end
 
     it "should raise ArgumentError if superclass == self" do
-      lambda do
+      expect(lambda do
         o = ClassObject.new(:root, :Object) do |o|
           o.superclass = :Object
         end
-      end.should raise_error(ArgumentError)
+      end).to raise_error(ArgumentError)
     end
 
     it "should tell the world if it is an exception class" do
@@ -199,27 +199,27 @@ describe YARD::CodeObjects::ClassObject do
       o4 = ClassObject.new(:root, :Object)
 
       o.superclass = :Object
-      o.is_exception?.should == false
+      expect(o.is_exception?).to eq false
 
       o.superclass = :Exception
-      o.is_exception?.should == true
+      expect(o.is_exception?).to eq true
 
       o.superclass = :NoMethodError
-      o.is_exception?.should == true
+      expect(o.is_exception?).to eq true
 
       o.superclass = o2
-      o.is_exception?.should == true
+      expect(o.is_exception?).to eq true
 
       o.superclass = o3
-      o.is_exception?.should == true
+      expect(o.is_exception?).to eq true
     end
 
     it "should not raise ArgumentError if superclass is proxy in different namespace" do
-      lambda do
+      expect(lambda do
         o = ClassObject.new(:root, :X) do |o|
           o.superclass = P('OTHER::X')
         end
-      end.should_not raise_error(ArgumentError)
+      end).to_not raise_error(ArgumentError)
     end
   end
 end

--- a/spec/code_objects/code_object_list_spec.rb
+++ b/spec/code_objects/code_object_list_spec.rb
@@ -5,17 +5,17 @@ describe YARD::CodeObjects::CodeObjectList do
 
   it "pushing a value should only allow CodeObjects::Base, String or Symbol" do
     list = CodeObjectList.new(nil)
-    lambda { list.push(:hash => 1) }.should raise_error(ArgumentError)
+    expect{ list.push(:hash => 1) }.to raise_error(ArgumentError)
     list << "Test"
     list << :Test2
     list << ModuleObject.new(nil, :YARD)
-    list.size.should == 3
+    expect(list.size).to eq 3
   end
 
   it "added value should be a proxy if parameter was String or Symbol" do
     list = CodeObjectList.new(nil)
     list << "Test"
-    list.first.class.should == Proxy
+    expect(list.first.class).to eq Proxy
   end
 
   it "should contain a unique list of objects" do
@@ -24,10 +24,10 @@ describe YARD::CodeObjects::CodeObjectList do
 
     list << P(:YARD)
     list << obj
-    list.size.should == 1
+    expect(list.size).to eq 1
 
     list << :Test
     list << "Test"
-    list.size.should == 2
+    expect(list.size).to eq 2
   end
 end

--- a/spec/code_objects/constants_spec.rb
+++ b/spec/code_objects/constants_spec.rb
@@ -2,47 +2,47 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 describe YARD::CodeObjects, "CONSTANTMATCH" do
   it "should match a constant" do
-    "Constant"[CodeObjects::CONSTANTMATCH].should == "Constant"
-    "identifier"[CodeObjects::CONSTANTMATCH].should be_nil
-    "File.new"[CodeObjects::CONSTANTMATCH].should == "File"
+    expect("Constant"[CodeObjects::CONSTANTMATCH]).to eq "Constant"
+    expect("identifier"[CodeObjects::CONSTANTMATCH]).to be_nil
+    expect("File.new"[CodeObjects::CONSTANTMATCH]).to eq "File"
   end
 end
 
 describe YARD::CodeObjects, "NAMESPACEMATCH" do
   it "should match a namespace (multiple constants with ::)" do
-    "Constant"[CodeObjects::NAMESPACEMATCH].should == "Constant"
-    "A::B::C.new"[CodeObjects::NAMESPACEMATCH].should == "A::B::C"
+    expect("Constant"[CodeObjects::NAMESPACEMATCH]).to eq "Constant"
+    expect("A::B::C.new"[CodeObjects::NAMESPACEMATCH]).to eq "A::B::C"
   end
 end
 
 describe YARD::CodeObjects, "METHODNAMEMATCH" do
   it "should match a method name" do
-    "method"[CodeObjects::METHODNAMEMATCH].should == "method"
-    "[]()"[CodeObjects::METHODNAMEMATCH].should == "[]"
-    "-@"[CodeObjects::METHODNAMEMATCH].should == "-@"
-    "method?"[CodeObjects::METHODNAMEMATCH].should == "method?"
-    "method!!"[CodeObjects::METHODNAMEMATCH].should == "method!"
+    expect("method"[CodeObjects::METHODNAMEMATCH]).to eq "method"
+    expect("[]()"[CodeObjects::METHODNAMEMATCH]).to eq "[]"
+    expect("-@"[CodeObjects::METHODNAMEMATCH]).to eq "-@"
+    expect("method?"[CodeObjects::METHODNAMEMATCH]).to eq "method?"
+    expect("method!!"[CodeObjects::METHODNAMEMATCH]).to eq "method!"
   end
 end
 
 describe YARD::CodeObjects, "METHODMATCH" do
   it "should match a full class method path" do
-    "method"[CodeObjects::METHODMATCH].should == "method"
-    "A::B::C.method?"[CodeObjects::METHODMATCH].should == "A::B::C.method?"
-    "A::B::C :: method"[CodeObjects::METHODMATCH].should == "A::B::C :: method"
-    "SomeClass . method"[CodeObjects::METHODMATCH].should == "SomeClass . method"
+    expect("method"[CodeObjects::METHODMATCH]).to eq "method"
+    expect("A::B::C.method?"[CodeObjects::METHODMATCH]).to eq "A::B::C.method?"
+    expect("A::B::C :: method"[CodeObjects::METHODMATCH]).to eq "A::B::C :: method"
+    expect("SomeClass . method"[CodeObjects::METHODMATCH]).to eq "SomeClass . method"
   end
 
   it "should match self.method" do
-    "self :: method!"[CodeObjects::METHODMATCH].should == "self :: method!"
-    "self.is_a?"[CodeObjects::METHODMATCH].should == "self.is_a?"
+    expect("self :: method!"[CodeObjects::METHODMATCH]).to eq "self :: method!"
+    expect("self.is_a?"[CodeObjects::METHODMATCH]).to eq "self.is_a?"
   end
 end
 
 describe YARD::CodeObjects, "BUILTIN_EXCEPTIONS" do
   it "should include all base exceptions" do
     YARD::CodeObjects::BUILTIN_EXCEPTIONS.each do |name|
-      eval(name).should <= Exception
+      expect(eval(name)).to be <= Exception
     end
   end
 end
@@ -52,13 +52,13 @@ describe YARD::CodeObjects, "BUILTIN_CLASSES" do
     YARD::CodeObjects::BUILTIN_CLASSES.each do |name|
       next if name == "MatchingData" && !defined?(::MatchingData)
       next if name == "Continuation"
-      eval(name).should be_instance_of(Class)
+      expect(eval(name)).to be_instance_of(Class)
     end
   end
 
   it "should include all exceptions" do
     YARD::CodeObjects::BUILTIN_EXCEPTIONS.each do |name|
-      YARD::CodeObjects::BUILTIN_CLASSES.should include(name)
+      expect(YARD::CodeObjects::BUILTIN_CLASSES).to include(name)
     end
   end
 end
@@ -68,7 +68,7 @@ describe YARD::CodeObjects, "BUILTIN_ALL" do
     a = YARD::CodeObjects::BUILTIN_ALL
     b = YARD::CodeObjects::BUILTIN_CLASSES
     c = YARD::CodeObjects::BUILTIN_MODULES
-    a.should == b+c
+    expect(a).to eq b+c
   end
 end
 
@@ -76,7 +76,7 @@ describe YARD::CodeObjects, "BUILTIN_MODULES" do
   it "should include all base modules" do
     YARD::CodeObjects::BUILTIN_MODULES.each do |name|
       next if YARD.ruby19? && ["Precision"].include?(name)
-      eval(name).should be_instance_of(Module)
+      expect(eval(name)).to be_instance_of(Module)
     end
   end
 end

--- a/spec/code_objects/extra_file_object_spec.rb
+++ b/spec/code_objects/extra_file_object_spec.rb
@@ -3,12 +3,12 @@ require File.dirname(__FILE__) + '/spec_helper'
 describe YARD::CodeObjects::ExtraFileObject do
   describe '#initialize' do
     it "should attempt to read contents from filesystem if contents=nil" do
-      File.should_receive(:read).with('file.txt').and_return('')
+      expect(File).to receive(:read).with('file.txt').and_return('')
       ExtraFileObject.new('file.txt')
     end
 
     it "should raise Errno::ENOENT if contents=nil and file does not exist" do
-      lambda { ExtraFileObject.new('file.txt') }.should raise_error(Errno::ENOENT)
+      expect{ ExtraFileObject.new('file.txt') }.to raise_error(Errno::ENOENT)
     end
 
     it "should not attempt to read from disk if contents are provided" do
@@ -17,103 +17,103 @@ describe YARD::CodeObjects::ExtraFileObject do
 
     it "should set filename to filename" do
       file = ExtraFileObject.new('a/b/c/file.txt', 'CONTENTS')
-      file.filename.should == "a/b/c/file.txt"
+      expect(file.filename).to eq "a/b/c/file.txt"
     end
 
     it "should parse out attributes at top of the file" do
       file = ExtraFileObject.new('file.txt', "# @title X\n# @some_attribute Y\nFOO BAR")
-      file.attributes[:title].should == "X"
-      file.attributes[:some_attribute].should == "Y"
-      file.contents.should == "FOO BAR"
+      expect(file.attributes[:title]).to eq "X"
+      expect(file.attributes[:some_attribute]).to eq "Y"
+      expect(file.contents).to eq "FOO BAR"
     end
 
     it "should allow whitespace prior to '#' marker when parsing attributes" do
       file = ExtraFileObject.new('file.txt', " \t # @title X\nFOO BAR")
-      file.attributes[:title].should == "X"
-      file.contents.should == "FOO BAR"
+      expect(file.attributes[:title]).to eq "X"
+      expect(file.contents).to eq "FOO BAR"
     end
 
     it "should parse out old-style #!markup shebang format" do
       file = ExtraFileObject.new('file.txt', "#!foobar\nHello")
-      file.attributes[:markup].should == "foobar"
+      expect(file.attributes[:markup]).to eq "foobar"
     end
 
     it "should not parse old-style #!markup if any whitespace is found" do
       file = ExtraFileObject.new('file.txt', " #!foobar\nHello")
-      file.attributes[:markup].should be_nil
-      file.contents.should == " #!foobar\nHello"
+      expect(file.attributes[:markup]).to be_nil
+      expect(file.contents).to eq " #!foobar\nHello"
     end
 
     it "should not parse out attributes if there are newlines prior to attributes" do
       file = ExtraFileObject.new('file.txt', "\n# @title\nFOO BAR")
-      file.attributes.should be_empty
-      file.contents.should == "\n# @title\nFOO BAR"
+      expect(file.attributes).to be_empty
+      expect(file.contents).to eq "\n# @title\nFOO BAR"
     end
 
     it "should set contents to data after attributes" do
       file = ExtraFileObject.new('file.txt', "# @title\nFOO BAR")
-      file.contents.should == "FOO BAR"
+      expect(file.contents).to eq "FOO BAR"
     end
 
     it "should preserve newlines" do
       file = ExtraFileObject.new('file.txt', "FOO\r\nBAR\nBAZ")
-      file.contents.should == "FOO\r\nBAR\nBAZ"
+      expect(file.contents).to eq "FOO\r\nBAR\nBAZ"
     end
 
     it "should not include newlines in attribute data" do
       file = ExtraFileObject.new('file.txt', "# @title FooBar\r\nHello world")
-      file.attributes[:title].should == "FooBar"
+      expect(file.attributes[:title]).to eq "FooBar"
     end
 
     it "should force encoding to @encoding attribute if present" do
-      log.should_not_receive(:warn)
+      expect(log).to_not receive(:warn)
       data = "# @encoding sjis\nFOO"
       data.force_encoding('binary')
       file = ExtraFileObject.new('file.txt', data)
-      ['Shift_JIS', 'Windows-31J'].should include(file.contents.encoding.to_s)
+      expect(['Shift_JIS', 'Windows-31J']).to include(file.contents.encoding.to_s)
     end if YARD.ruby19?
 
     it "should warn if @encoding is invalid" do
-      log.should_receive(:warn).with("Invalid encoding `INVALID' in file.txt")
+      expect(log).to receive(:warn).with("Invalid encoding `INVALID' in file.txt")
       data = "# @encoding INVALID\nFOO"
       encoding = data.encoding
       file = ExtraFileObject.new('file.txt', data)
-      file.contents.encoding.should == encoding
+      expect(file.contents.encoding).to eq encoding
     end if YARD.ruby19?
 
     it "should ignore encoding in 1.8.x (or encoding-unaware platforms)" do
-      log.should_not_receive(:warn)
+      expect(log).to_not receive(:warn)
       file = ExtraFileObject.new('file.txt', "# @encoding INVALID\nFOO")
     end if YARD.ruby18?
 
     it "should attempt to re-parse data as 8bit ascii if parsing fails" do
-      log.should_not_receive(:warn)
+      expect(log).to_not receive(:warn)
       str, out = *(["\xB0"] * 2)
       if str.respond_to?(:force_encoding)
         str.force_encoding('utf-8')
         out.force_encoding('binary')
       end
       file = ExtraFileObject.new('file.txt', str)
-      file.contents.should == out
+      expect(file.contents).to eq out
     end
   end
 
   describe '#name' do
     it "should be set to basename (not extension) of filename" do
       file = ExtraFileObject.new('file.txt', '')
-      file.name.should == 'file'
+      expect(file.name).to eq 'file'
     end
   end
 
   describe '#title' do
     it "should return @title attribute if present" do
       file = ExtraFileObject.new('file.txt', '# @title FOO')
-      file.title.should == 'FOO'
+      expect(file.title).to eq 'FOO'
     end
 
     it "should return #name if no @title attribute exists" do
       file = ExtraFileObject.new('file.txt', '')
-      file.title.should == 'file'
+      expect(file.title).to eq 'file'
     end
   end
 
@@ -124,8 +124,8 @@ describe YARD::CodeObjects::ExtraFileObject do
       fr_locale = I18n::Locale.new('fr')
       fr_messages = fr_locale.instance_variable_get(:@messages)
       fr_messages["Hello"] = 'Bonjour'
-      Registry.should_receive(:locale).with('fr').and_return(fr_locale)
-      file.contents.should == 'Bonjour'
+      expect(Registry).to receive(:locale).with('fr').and_return(fr_locale)
+      expect(file.contents).to eq 'Bonjour'
     end
   end
 
@@ -133,14 +133,14 @@ describe YARD::CodeObjects::ExtraFileObject do
     it "should define equality on filename alone" do
       file1 = ExtraFileObject.new('file.txt', 'A')
       file2 = ExtraFileObject.new('file.txt', 'B')
-      file1.should == file2
-      file1.should be_eql(file2)
-      file1.should be_equal(file2)
+      expect(file1).to eq file2
+      expect(file1).to be_eql(file2)
+      expect(file1).to be_equal(file2)
 
       # Another way to test the equality interface
       a = [file1]
       a |= [file2]
-      a.size.should == 1
+      expect(a.size).to eq 1
     end
 
   end

--- a/spec/code_objects/macro_object_spec.rb
+++ b/spec/code_objects/macro_object_spec.rb
@@ -11,24 +11,24 @@ describe YARD::CodeObjects::MacroObject do
     it "should create an object" do
       create('foo', '')
       obj = Registry.at('.macro.foo')
-      obj.should_not be_nil
+      expect(obj).to_not be_nil
     end
 
     it "should use identity map" do
       obj1 = create('foo', '')
       obj2 = create('foo', '')
-      obj1.object_id.should == obj2.object_id
+      expect(obj1.object_id).to eq obj2.object_id
     end
 
     it "should allow specifying of macro data" do
       obj = create('foo', 'MACRODATA')
-      obj.macro_data.should == 'MACRODATA'
+      expect(obj.macro_data).to eq 'MACRODATA'
     end
 
     it "should attach if a method object is provided" do
       obj = create('foo', 'MACRODATA', P('Foo.property'))
-      obj.method_object.should == P('Foo.property')
-      obj.should be_attached
+      expect(obj.method_object).to eq P('Foo.property')
+      expect(obj).to be_attached
     end
   end
 
@@ -36,11 +36,11 @@ describe YARD::CodeObjects::MacroObject do
     before { MacroObject.create('foo', 'DATA') }
 
     it "should search for an object by name" do
-      MacroObject.find('foo').macro_data.should == 'DATA'
+      expect(MacroObject.find('foo').macro_data).to eq 'DATA'
     end
 
     it "should accept Symbol" do
-      MacroObject.find(:foo).macro_data.should == 'DATA'
+      expect(MacroObject.find(:foo).macro_data).to eq 'DATA'
     end
   end
 
@@ -48,12 +48,12 @@ describe YARD::CodeObjects::MacroObject do
     it "should look up name if @!macro is present and find object" do
       macro1 = MacroObject.create('foo', 'FOO')
       macro2 = MacroObject.find_or_create('foo', "a b c")
-      macro1.should == macro2
+      expect(macro1).to eq macro2
     end
 
     it "should create new macro if macro by that name does not exist" do
       MacroObject.find_or_create('foo', "@!method $1")
-      MacroObject.find('foo').macro_data.should == "@!method $1"
+      expect(MacroObject.find('foo').macro_data).to eq "@!method $1"
     end
   end
 
@@ -67,35 +67,35 @@ describe YARD::CodeObjects::MacroObject do
     end
 
     it "should only expand macros if @macro is present" do
-      apply("$1$2$3").should == "$1$2$3"
+      expect(apply("$1$2$3")).to eq "$1$2$3"
     end
 
     it "should handle macro text inside block" do
-      apply("@!macro\n  foo$1$2$3\nfoobaz").should == "fooabc\nfoobaz"
+      expect(apply("@!macro\n  foo$1$2$3\nfoobaz")).to eq "fooabc\nfoobaz"
     end
 
     it "should append docstring to existing macro" do
       macro = MacroObject.create('name', '$3$2$1')
       result = MacroObject.apply("@!macro name\nfoobar", @args)
-      result.should == "cba\nfoobar"
+      expect(result).to eq "cba\nfoobar"
     end
 
     it "should use only non macro data if docstring is an existing macro" do
       data = "@!macro name\n  $3$2$1\nEXTRA"
       result = MacroObject.apply(data, @args, 'SOURCE')
-      result.should == "cba\nEXTRA"
-      MacroObject.apply("@!macro name\nFOO", @args).should == "cba\nFOO"
+      expect(result).to eq "cba\nEXTRA"
+      expect(MacroObject.apply("@!macro name\nFOO", @args)).to eq "cba\nFOO"
     end
 
     it "should create macros if they don't exist" do
       result = MacroObject.apply("@!macro name\n  foo!$1", @args, 'SOURCE')
-      result.should == "foo!a"
-      MacroObject.find('name').macro_data.should == 'foo!$1'
+      expect(result).to eq "foo!a"
+      expect(MacroObject.find('name').macro_data).to eq 'foo!$1'
     end
 
     it "should keep other tags" do
-      apply("@!macro\n  foo$1$2$3\n@param name foo\nfoo").should ==
-        "fooabc\nfoo\n@param name\n  foo"
+      expect(apply("@!macro\n  foo$1$2$3\n@param name foo\nfoo"))
+        .to eq "fooabc\nfoo\n@param name\n  foo"
     end
   end
 
@@ -107,42 +107,42 @@ describe YARD::CodeObjects::MacroObject do
     end
 
     it "should allow escaping of macro syntax" do
-      expand("$1\\$2$3").should == "a$2c"
+      expect(expand("$1\\$2$3")).to eq "a$2c"
     end
 
     it "should replace $* with the whole statement" do
-      expand("$* ${*}").should == "foo :bar, :baz foo :bar, :baz"
+      expect(expand("$* ${*}")).to eq "foo :bar, :baz foo :bar, :baz"
     end
 
     it "should replace $0 with method name" do
-      expand("$0 ${0}").should == "foo foo"
+      expect(expand("$0 ${0}")).to eq "foo foo"
     end
 
     it "should replace all $N values with the Nth argument in the method call" do
-      expand("$1$2$3${3}\nfoobar").should == "abcc\nfoobar"
+      expect(expand("$1$2$3${3}\nfoobar")).to eq "abcc\nfoobar"
     end
 
     it "should replace ${N-M} ranges with N-M arguments (incl. commas)" do
-      expand("${1-2}x").should == "a, bx"
+      expect(expand("${1-2}x")).to eq "a, bx"
     end
 
     it "should handle open ended ranges (${N-})" do
-      expand("${2-}").should == "b, c"
+      expect(expand("${2-}")).to eq "b, c"
     end
 
     it "should handle negative indexes ($-N)" do
-      expand("$-1 ${-2-} ${-2--2}").should == "c b, c b"
+      expect(expand("$-1 ${-2-} ${-2--2}")).to eq "c b, c b"
     end
 
     it "should accept Docstring objects" do
-      expand(Docstring.new("$1\n@param name foo")).should == "a\n@param name foo"
+      expect(expand(Docstring.new("$1\n@param name foo"))).to eq "a\n@param name foo"
     end
   end
 
   describe '#expand' do
     it "should expand macro given its data" do
       macro = MacroObject.create_docstring('foo', '$1 $2 THREE!')
-      macro.expand(['NAME', 'ONE', 'TWO']).should == "ONE TWO THREE!"
+      expect(macro.expand(['NAME', 'ONE', 'TWO'])).to eq "ONE TWO THREE!"
     end
   end
 end

--- a/spec/code_objects/method_object_spec.rb
+++ b/spec/code_objects/method_object_spec.rb
@@ -8,74 +8,74 @@ describe YARD::CodeObjects::MethodObject do
 
   it "should have a path of testing for an instance method in the root" do
     meth = MethodObject.new(:root, :testing)
-    meth.path.should == "#testing"
+    expect(meth.path).to eq "#testing"
   end
 
   it "should have a path of YARD#testing for an instance method in YARD" do
     meth = MethodObject.new(@yard, :testing)
-    meth.path.should == "YARD#testing"
+    expect(meth.path).to eq "YARD#testing"
   end
 
   it "should have a path of YARD.testing for a class method in YARD" do
     meth = MethodObject.new(@yard, :testing, :class)
-    meth.path.should == "YARD.testing"
+    expect(meth.path).to eq "YARD.testing"
   end
 
   it "should have a path of ::testing (note the ::) for a class method added to root namespace" do
     meth = MethodObject.new(:root, :testing, :class)
-    meth.path.should == "::testing"
+    expect(meth.path).to eq "::testing"
   end
 
   it "should exist in the registry after successful creation" do
     obj = MethodObject.new(@yard, :something, :class)
-    Registry.at("YARD.something").should_not be_nil
-    Registry.at("YARD#something").should be_nil
-    Registry.at("YARD::something").should be_nil
+    expect(Registry.at("YARD.something")).to_not be_nil
+    expect(Registry.at("YARD#something")).to be_nil
+    expect(Registry.at("YARD::something")).to be_nil
     obj = MethodObject.new(@yard, :somethingelse)
-    Registry.at("YARD#somethingelse").should_not be_nil
+    expect(Registry.at("YARD#somethingelse")).to_not be_nil
   end
 
   it "should allow #scope to be changed after creation" do
     obj = MethodObject.new(@yard, :something, :class)
-    Registry.at("YARD.something").should_not be_nil
+    expect(Registry.at("YARD.something")).to_not be_nil
     obj.scope = :instance
-    Registry.at("YARD.something").should be_nil
-    Registry.at("YARD#something").should_not be_nil
+    expect(Registry.at("YARD.something")).to be_nil
+    expect(Registry.at("YARD#something")).to_not be_nil
   end
 
   it "should create object in :class scope if scope is :module" do
     obj = MethodObject.new(@yard, :module_func, :module)
-    obj.scope.should == :class
-    obj.visibility.should == :public
-    Registry.at('YARD.module_func').should_not be_nil
+    expect(obj.scope).to eq :class
+    expect(obj.visibility).to eq :public
+    expect(Registry.at('YARD.module_func')).to_not be_nil
   end
 
   it "should create second private instance method if scope is :module" do
     MethodObject.new(@yard, :module_func, :module)
     obj = Registry.at('YARD#module_func')
-    obj.should_not be_nil
-    obj.visibility.should == :private
-    obj.scope.should == :instance
+    expect(obj).to_not be_nil
+    expect(obj.visibility).to eq :private
+    expect(obj.scope).to eq :instance
   end
 
   it "should yield block to second method if scope is :module" do
     MethodObject.new(@yard, :module_func, :module) do |o|
       o.docstring = 'foo'
     end
-    Registry.at('YARD.module_func').docstring.should == 'foo'
-    Registry.at('YARD#module_func').docstring.should == 'foo'
+    expect(Registry.at('YARD.module_func').docstring).to eq 'foo'
+    expect(Registry.at('YARD#module_func').docstring).to eq 'foo'
   end
 
   describe '#name' do
     it "should show a prefix for an instance method when prefix=true" do
       obj = MethodObject.new(nil, :something)
-      obj.name(true).should == "#something"
+      expect(obj.name(true)).to eq "#something"
     end
 
     it "should never show a prefix for a class method" do
       obj = MethodObject.new(nil, :something, :class)
-      obj.name.should == :"something"
-      obj.name(true).should == "something"
+      expect(obj.name).to eq :"something"
+      expect(obj.name(true)).to eq "something"
     end
   end
 
@@ -83,8 +83,8 @@ describe YARD::CodeObjects::MethodObject do
     it "should only return true if attribute is set in namespace for read/write" do
       obj = MethodObject.new(@yard, :foo)
       @yard.attributes[:instance][:foo] = {:read => obj, :write => nil}
-      obj.is_attribute?.should be_true
-      MethodObject.new(@yard, :foo=).is_attribute?.should be_false
+      expect(obj.is_attribute?).to be_true
+      expect(MethodObject.new(@yard, :foo=).is_attribute?).to be_false
     end
   end
 
@@ -92,16 +92,16 @@ describe YARD::CodeObjects::MethodObject do
     it "should return attribute info if namespace is available" do
       obj = MethodObject.new(@yard, :foo)
       @yard.attributes[:instance][:foo] = {:read => obj, :write => nil}
-      obj.attr_info.should == @yard.attributes[:instance][:foo]
+      expect(obj.attr_info).to eq @yard.attributes[:instance][:foo]
     end
 
     it "should return nil if namespace is proxy" do
       obj = MethodObject.new(P(:ProxyClass), :foo)
-      MethodObject.new(@yard, :foo).attr_info.should == nil
+      expect(MethodObject.new(@yard, :foo).attr_info).to eq nil
     end
 
     it "should return nil if meth is not an attribute" do
-      MethodObject.new(@yard, :notanattribute).attr_info.should == nil
+      expect(MethodObject.new(@yard, :notanattribute).attr_info).to eq nil
     end
   end
 
@@ -109,8 +109,8 @@ describe YARD::CodeObjects::MethodObject do
     it "should return true if method is a writer attribute" do
       obj = MethodObject.new(@yard, :foo=)
       @yard.attributes[:instance][:foo] = {:read => nil, :write => obj}
-      obj.writer?.should == true
-      MethodObject.new(@yard, :NOTfoo=).writer?.should == false
+      expect(obj.writer?).to eq true
+      expect(MethodObject.new(@yard, :NOTfoo=).writer?).to eq false
     end
   end
 
@@ -118,8 +118,8 @@ describe YARD::CodeObjects::MethodObject do
     it "should return true if method is a reader attribute" do
       obj = MethodObject.new(@yard, :foo)
       @yard.attributes[:instance][:foo] = {:read => obj, :write => nil}
-      obj.reader?.should == true
-      MethodObject.new(@yard, :NOTfoo).reader?.should == false
+      expect(obj.reader?).to eq true
+      expect(MethodObject.new(@yard, :NOTfoo).reader?).to eq false
     end
   end
 
@@ -131,11 +131,11 @@ describe YARD::CodeObjects::MethodObject do
     end
 
     it "should not mark Klass.initialize as constructor" do
-      MethodObject.new(@class, :initialize, :class).constructor?.should be_false
+      expect(MethodObject.new(@class, :initialize, :class).constructor?).to be_false
     end
 
     it "should not mark module method #initialize as constructor" do
-      MethodObject.new(@yard, :initialize).constructor?.should be_false
+      expect(MethodObject.new(@yard, :initialize).constructor?).to be_false
     end
   end
 
@@ -148,7 +148,7 @@ describe YARD::CodeObjects::MethodObject do
         class A; def foo; end end
         class B < A; include C; def foo; end end
       eof
-      Registry.at('B#foo').overridden_method.should == Registry.at('C#foo')
+      expect(Registry.at('B#foo').overridden_method).to eq Registry.at('C#foo')
     end
 
     it "should return overridden method from superclass" do
@@ -156,7 +156,7 @@ describe YARD::CodeObjects::MethodObject do
         class A; def foo; end end
         class B < A; def foo; end end
       eof
-      Registry.at('B#foo').overridden_method.should == Registry.at('A#foo')
+      expect(Registry.at('B#foo').overridden_method).to eq Registry.at('A#foo')
     end
 
     it "should return nil if none is found" do
@@ -164,12 +164,12 @@ describe YARD::CodeObjects::MethodObject do
         class A; end
         class B < A; def foo; end end
       eof
-      Registry.at('B#foo').overridden_method.should be_nil
+      expect(Registry.at('B#foo').overridden_method).to be_nil
     end
 
     it "should return nil if namespace is a proxy" do
       YARD.parse_string "def ARGV.foo; end"
-      Registry.at('ARGV.foo').overridden_method.should be_nil
+      expect(Registry.at('ARGV.foo').overridden_method).to be_nil
     end
   end
 end

--- a/spec/code_objects/module_object_spec.rb
+++ b/spec/code_objects/module_object_spec.rb
@@ -39,63 +39,63 @@ describe YARD::CodeObjects::ModuleObject do
 
     it "should list all methods (including mixin methods) via #meths" do
       meths = @yard.meths
-      meths.should include(P("YARD#foo"))
-      meths.should include(P("YARD#foo2"))
-      meths.should include(P("YARD.bar"))
-      meths.should include(P("SomeMod#mixmethod"))
-      meths.should include(P("AnotherMod#fizz"))
+      expect(meths).to include(P("YARD#foo"))
+      expect(meths).to include(P("YARD#foo2"))
+      expect(meths).to include(P("YARD.bar"))
+      expect(meths).to include(P("SomeMod#mixmethod"))
+      expect(meths).to include(P("AnotherMod#fizz"))
     end
 
     it "should allow :visibility to be set" do
       meths = @yard.meths(:visibility => :public)
-      meths.should_not include(P("YARD.bar"))
+      expect(meths).to_not include(P("YARD.bar"))
       meths = @yard.meths(:visibility => [:public, :private])
-      meths.should include(P("YARD#foo"))
-      meths.should include(P("YARD.bar"))
-      meths.should_not include(P("YARD#foo2"))
+      expect(meths).to include(P("YARD#foo"))
+      expect(meths).to include(P("YARD.bar"))
+      expect(meths).to_not include(P("YARD#foo2"))
     end
 
     it "should only display class methods for :scope => :class" do
       meths = @yard.meths(:scope => :class)
-      meths.should_not include(P("YARD#foo"))
-      meths.should_not include(P("YARD#foo2"))
-      meths.should_not include(P("SomeMod#mixmethod"))
-      meths.should_not include(P("SomeMod.baz"))
-      meths.should_not include(P("AnotherMod#fazz"))
-      meths.should include(P("YARD.bar"))
-      meths.should include(P("AnotherMod#fizz"))
+      expect(meths).to_not include(P("YARD#foo"))
+      expect(meths).to_not include(P("YARD#foo2"))
+      expect(meths).to_not include(P("SomeMod#mixmethod"))
+      expect(meths).to_not include(P("SomeMod.baz"))
+      expect(meths).to_not include(P("AnotherMod#fazz"))
+      expect(meths).to include(P("YARD.bar"))
+      expect(meths).to include(P("AnotherMod#fizz"))
     end
 
     it "should only display instance methods for :scope => :class" do
       meths = @yard.meths(:scope => :instance)
-      meths.should include(P("YARD#foo"))
-      meths.should include(P("YARD#foo2"))
-      meths.should include(P("SomeMod#mixmethod"))
-      meths.should_not include(P("YARD.bar"))
-      meths.should_not include(P("AnotherMod#fizz"))
+      expect(meths).to include(P("YARD#foo"))
+      expect(meths).to include(P("YARD#foo2"))
+      expect(meths).to include(P("SomeMod#mixmethod"))
+      expect(meths).to_not include(P("YARD.bar"))
+      expect(meths).to_not include(P("AnotherMod#fizz"))
     end
 
     it "should allow :included to be set" do
       meths = @yard.meths(:included => false)
-      meths.should_not include(P("SomeMod#mixmethod"))
-      meths.should_not include(P("AnotherMod#fizz"))
-      meths.should include(P("YARD#foo"))
-      meths.should include(P("YARD#foo2"))
-      meths.should include(P("YARD.bar"))
+      expect(meths).to_not include(P("SomeMod#mixmethod"))
+      expect(meths).to_not include(P("AnotherMod#fizz"))
+      expect(meths).to include(P("YARD#foo"))
+      expect(meths).to include(P("YARD#foo2"))
+      expect(meths).to include(P("YARD.bar"))
     end
 
     it "should choose the method defined in the class over an included module" do
       meths = @yard.meths
-      meths.should_not include(P("SomeMod#xyz"))
-      meths.should include(P("YARD#xyz"))
-      meths.should_not include(P("AnotherMod#bar"))
-      meths.should include(P("YARD.bar"))
+      expect(meths).to_not include(P("SomeMod#xyz"))
+      expect(meths).to include(P("YARD#xyz"))
+      expect(meths).to_not include(P("AnotherMod#bar"))
+      expect(meths).to include(P("YARD.bar"))
 
       meths = @other.meths
-      meths.should include(P("SomeMod#xyz"))
+      expect(meths).to include(P("SomeMod#xyz"))
 
       meths = @another.meths
-      meths.should include(P("AnotherMod#bar"))
+      expect(meths).to include(P("AnotherMod#bar"))
     end
   end
 
@@ -119,23 +119,23 @@ describe YARD::CodeObjects::ModuleObject do
     end
 
     it "should show only itself for an inheritance tree without included modules" do
-      @mod1.inheritance_tree.should == [@mod1]
+      expect(@mod1.inheritance_tree).to eq [@mod1]
     end
 
     it "should show proper inheritance three when modules are included" do
-      @mod1.inheritance_tree(true).should == [@mod1, @mod2, @mod3, @mod4]
+      expect(@mod1.inheritance_tree(true)).to eq [@mod1, @mod2, @mod3, @mod4]
     end
 
     it "should not list inheritance tree of proxy objects in inheritance tree" do
-      @proxy.should_not_receive(:inheritance_tree)
-      @mod5.instance_mixins.should == [@proxy]
+      expect(@proxy).to_not receive(:inheritance_tree)
+      expect(@mod5.instance_mixins).to eq [@proxy]
     end
 
     it "should list class mixins in inheritance tree" do
       mod = ModuleObject.new(:root, :ClassMethods)
       recvmod = ModuleObject.new(:root, :ReceivingModule)
       recvmod.class_mixins << mod
-      recvmod.inheritance_tree(true).should == [recvmod, mod]
+      expect(recvmod.inheritance_tree(true)).to eq [recvmod, mod]
     end
   end
 end

--- a/spec/code_objects/namespace_object_spec.rb
+++ b/spec/code_objects/namespace_object_spec.rb
@@ -7,8 +7,8 @@ describe YARD::CodeObjects::NamespaceObject do
     it "should return the object matching the name passed in if argument is a Symbol" do
       obj = NamespaceObject.new(nil, :YARD)
       other = NamespaceObject.new(obj, :Other)
-      obj.child(:Other).should == other
-      obj.child('Other').should == other
+      expect(obj.child(:Other)).to eq other
+      expect(obj.child('Other')).to eq other
     end
 
     it "should look for attributes matching the object if the argument is a Hash" do
@@ -16,14 +16,14 @@ describe YARD::CodeObjects::NamespaceObject do
       NamespaceObject.new(obj, :NotOther)
       other = NamespaceObject.new(obj, :Other)
       other.somevalue = 2
-      obj.child(:somevalue => 2).should == other
+      expect(obj.child(:somevalue => 2)).to eq other
     end
   end
 
   describe '#meths' do
     it "should return #meths even if parent is a Proxy" do
       obj = NamespaceObject.new(P(:String), :YARD)
-      obj.meths.should be_empty
+      expect(obj.meths).to be_empty
     end
 
     it "should not list included methods that are already defined in the namespace using #meths" do
@@ -38,16 +38,16 @@ describe YARD::CodeObjects::NamespaceObject do
       c.class_mixins << b
 
       meths = c.meths
-      meths.should include(bmeth)
-      meths.should include(cmeth)
-      meths.should include(cmeth2)
-      meths.should_not include(ameth)
+      expect(meths).to include(bmeth)
+      expect(meths).to include(cmeth)
+      expect(meths).to include(cmeth2)
+      expect(meths).to_not include(ameth)
 
       meths = c.included_meths
-      meths.should include(bmeth)
-      meths.should_not include(ameth)
-      meths.should_not include(cmeth)
-      meths.should_not include(cmeth2)
+      expect(meths).to include(bmeth)
+      expect(meths).to_not include(ameth)
+      expect(meths).to_not include(cmeth)
+      expect(meths).to_not include(cmeth2)
     end
   end
 
@@ -59,9 +59,9 @@ describe YARD::CodeObjects::NamespaceObject do
       c = NamespaceObject.new(nil, :YARD)
       c.class_mixins << b
 
-      [bmeth, bmeth2].each {|o| o.scope.should == :instance }
+      [bmeth, bmeth2].each {|o| expect(o.scope).to eq :instance }
       meths = c.included_meths(:scope => :class)
-      meths.each {|o| o.scope.should == :class }
+      meths.each {|o| expect(o.scope).to eq :class }
     end
 
     it "should not list methods overridden by another included module" do
@@ -76,12 +76,12 @@ describe YARD::CodeObjects::NamespaceObject do
       c.class_mixins.unshift a
 
       meths = c.included_meths(:scope => :instance)
-      meths.should_not include(ameth)
-      meths.should include(bmeth)
+      expect(meths).to_not include(ameth)
+      expect(meths).to include(bmeth)
 
       meths = c.included_meths(:scope => :class)
-      meths.should include(ameth)
-      meths.should_not include(bmeth)
+      expect(meths).to include(ameth)
+      expect(meths).to_not include(bmeth)
     end
   end
 
@@ -91,8 +91,8 @@ describe YARD::CodeObjects::NamespaceObject do
       a.attributes[:instance][:a] = { :read => MethodObject.new(a, :a), :write => nil }
       a.attributes[:instance][:b] = { :read => MethodObject.new(a, :b), :write => nil }
       a.attributes[:class][:a] = { :read => MethodObject.new(a, :a, :class), :write => nil }
-      a.class_attributes.keys.should include(:a)
-      a.class_attributes.keys.should_not include(:b)
+      expect(a.class_attributes.keys).to include(:a)
+      expect(a.class_attributes.keys).to_not include(:b)
     end
   end
 
@@ -102,8 +102,8 @@ describe YARD::CodeObjects::NamespaceObject do
       a.attributes[:instance][:a] = { :read => MethodObject.new(a, :a), :write => nil }
       a.attributes[:instance][:b] = { :read => MethodObject.new(a, :b), :write => nil }
       a.attributes[:class][:a] = { :read => MethodObject.new(a, :a, :class), :write => nil }
-      a.instance_attributes.keys.should include(:a)
-      a.instance_attributes.keys.should include(:b)
+      expect(a.instance_attributes.keys).to include(:a)
+      expect(a.instance_attributes.keys).to include(:b)
     end
   end
 
@@ -134,26 +134,26 @@ describe YARD::CodeObjects::NamespaceObject do
 
     it "should list all included constants by default" do
       consts = P(:C).constants
-      consts.should include(P('A::CONST1'))
-      consts.should include(P('C::CONST4'))
+      expect(consts).to include(P('A::CONST1'))
+      expect(consts).to include(P('C::CONST4'))
     end
 
     it "should allow :included to be set to false to ignore included constants" do
       consts = P(:C).constants(:included => false)
-      consts.should_not include(P('A::CONST1'))
-      consts.should include(P('C::CONST4'))
+      expect(consts).to_not include(P('A::CONST1'))
+      expect(consts).to include(P('C::CONST4'))
     end
 
     it "should not list an included constant if it is defined in the object" do
       consts = P(:C).constants
-      consts.should include(P('C::CONST3'))
-      consts.should_not include(P('B::CONST3'))
+      expect(consts).to include(P('C::CONST3'))
+      expect(consts).to_not include(P('B::CONST3'))
     end
 
     it "should not list an included constant if it is shadowed by another included constant" do
       consts = P(:C).included_constants
-      consts.should include(P('B::CONST2'))
-      consts.should_not include(P('A::CONST2'))
+      expect(consts).to include(P('B::CONST2'))
+      expect(consts).to_not include(P('A::CONST2'))
     end
   end
 
@@ -164,7 +164,7 @@ describe YARD::CodeObjects::NamespaceObject do
         module C; def bar; end end
         class A; include B; include C; def foo; end; def bar; end end
       eof
-      Registry.at('A').included_meths(:all => true).should == [P('C#bar'), P('B#foo')]
+      expect(Registry.at('A').included_meths(:all => true)).to eq [P('C#bar'), P('B#foo')]
     end
   end
 end

--- a/spec/code_objects/proxy_spec.rb
+++ b/spec/code_objects/proxy_spec.rb
@@ -6,81 +6,81 @@ describe YARD::CodeObjects::Proxy do
   it "should return the object if it's in the Registry" do
     pathobj = ModuleObject.new(:root, :YARD)
     proxyobj = P(:root, :YARD)
-    proxyobj.type.should == :module
-    Proxy.should_not === proxyobj
+    expect(proxyobj.type).to eq :module
+    expect(Proxy).to_not eq proxyobj
   end
 
   it "should handle complex string namespaces" do
     ModuleObject.new(:root, :A)
     pathobj = ModuleObject.new(P(nil, :A), :B)
-    P(:root, "A::B").should be_instance_of(ModuleObject)
+    expect(P(:root, "A::B")).to be_instance_of(ModuleObject)
   end
 
   it "should not return true to Proxy === obj if obj is a Proxy class holding a resolved object" do
-    Proxy.should === P(:root, 'a')
-    Proxy.should_not === P(:root)
+    expect(Proxy === P(:root, 'a')).to be_true
+    expect(Proxy).to_not eq P(:root)
     MethodObject.new(:root, 'a')
-    Proxy.should_not === P(:root, 'a')
+    expect(Proxy).to_not eq P(:root, 'a')
     x = Proxy.new(:root, 'a')
-    Proxy.should_not === x
+    expect(Proxy).to_not eq x
   end
 
   it "should return the object if it's an included Module" do
     yardobj = ModuleObject.new(:root, :YARD)
     pathobj = ClassObject.new(:root, :TestClass)
     pathobj.instance_mixins << yardobj
-    P(P(nil, :TestClass), :YARD).should be_instance_of(ModuleObject)
+    expect(P(P(nil, :TestClass), :YARD)).to be_instance_of(ModuleObject)
   end
 
   it "should respond_to respond_to?" do
     obj = ClassObject.new(:root, :Object)
     yardobj = ModuleObject.new(:root, :YARD)
-    P(:YARD).respond_to?(:children).should == true
-    P(:NOTYARD).respond_to?(:children).should == false
+    expect(P(:YARD).respond_to?(:children)).to eq true
+    expect(P(:NOTYARD).respond_to?(:children)).to eq false
 
-    P(:YARD).respond_to?(:initialize).should == false
-    P(:YARD).respond_to?(:initialize, true).should == true
-    P(:NOTYARD).respond_to?(:initialize).should == false
-    P(:NOTYARD).respond_to?(:initialize, true).should == true
+    expect(P(:YARD).respond_to?(:initialize)).to eq false
+    expect(P(:YARD).respond_to?(:initialize, true)).to eq true
+    expect(P(:NOTYARD).respond_to?(:initialize)).to eq false
+    expect(P(:NOTYARD).respond_to?(:initialize, true)).to eq true
   end
 
   it "should make itself obvious that it's a proxy" do
     pathobj = P(:root, :YARD)
-    pathobj.class.should == Proxy
-    (Proxy === pathobj).should == true
+    expect(pathobj.class).to eq Proxy
+    expect((Proxy === pathobj)).to eq true
   end
 
   it "should pretend it's the object's type if it can resolve" do
     pathobj = ModuleObject.new(:root, :YARD)
     proxyobj = P(:root, :YARD)
-    proxyobj.should be_instance_of(ModuleObject)
+    expect(proxyobj).to be_instance_of(ModuleObject)
   end
 
   it "should handle instance method names" do
     obj = P(nil, '#test')
-    obj.name.should == :test
-    obj.path.should == "#test"
-    obj.namespace.should == Registry.root
+    expect(obj.name).to eq :test
+    expect(obj.path).to eq "#test"
+    expect(obj.namespace).to eq Registry.root
   end
 
   it "should handle instance method names under a namespace" do
     pathobj = ModuleObject.new(:root, :YARD)
     obj = P(pathobj, "A::B#test")
-    obj.name.should == :test
-    obj.path.should == "A::B#test"
+    expect(obj.name).to eq :test
+    expect(obj.path).to eq "A::B#test"
   end
 
   it "should allow type to be changed" do
     obj = P("InvalidClass")
-    obj.type.should == :proxy
-    Proxy.should === obj
+    expect(obj.type).to eq :proxy
+    expect(Proxy === obj).to be_true
     obj.type = :class
-    obj.type.should == :class
+    expect(obj.type).to eq :class
   end
 
   it "should NOT retain a type change between Proxy objects" do
     P("InvalidClass").type = :class
-    P("InvalidClass").type.should == :proxy
+    expect(P("InvalidClass").type).to eq :proxy
   end
 
   it "should use type to ensure resolved object is of intended type" do
@@ -92,26 +92,26 @@ describe YARD::CodeObjects::Proxy do
     eof
     proxy = Proxy.new(P('Foo'), 'Bar')
     proxy.type = :method
-    proxy.path.should == 'Foo.Bar'
+    expect(proxy.path).to eq 'Foo.Bar'
   end
 
   it "should allow type in initializer" do
-    Proxy.new(Registry.root, 'Foo', :method).type.should == :method
-    P(Registry.root, 'Foo', :method).type.should == :method
+    expect(Proxy.new(Registry.root, 'Foo', :method).type).to eq :method
+    expect(P(Registry.root, 'Foo', :method).type).to eq :method
   end
 
   it "should never equal Registry.root" do
-    P("MYPROXY").should_not == Registry.root
-    P("X::A").should_not == Registry.root
+    expect(P("MYPROXY")).to_not eq Registry.root
+    expect(P("X::A")).to_not eq Registry.root
   end
 
   it "should reset namespace and name when object is resolved" do
     obj1 = ModuleObject.new(:root, :YARD)
     obj2 = ModuleObject.new(:root, :NOTYARD)
     resolved = Proxy.new(obj2, :YARD)
-    resolved.should == obj1
-    resolved.namespace.should == Registry.root
-    resolved.name.should == :YARD
+    expect(resolved).to eq obj1
+    expect(resolved.namespace).to eq Registry.root
+    expect(resolved.name).to eq :YARD
   end
 
   it "should ensure that the correct object was resolved" do
@@ -121,13 +121,13 @@ describe YARD::CodeObjects::Proxy do
 
     # Remember, we're looking for Qux::Bar, not just 'Bar'
     proxy = Proxy.new(foobar, 'Foo::Qux::Bar')
-    proxy.type.should == :proxy
+    expect(proxy.type).to eq :proxy
 
     qux = ModuleObject.new(foo, :Qux)
     quxbar = ModuleObject.new(qux, :Bar)
 
     # Now it should resolve
-    proxy.type.should == :module
+    expect(proxy.type).to eq :module
   end
 
   it "should handle constant names in namespaces" do
@@ -135,6 +135,6 @@ describe YARD::CodeObjects::Proxy do
       module A; end; B = A
       module B::C; def foo; end end
     eof
-    Proxy.new(:root, 'B::C').should == Registry.at('A::C')
+    expect(Proxy.new(:root, 'B::C')).to eq Registry.at('A::C')
   end
 end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -5,40 +5,40 @@ require 'yaml'
 describe YARD::Config do
   describe '.load' do
     before do
-      File.should_receive(:file?).twice.with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).and_return(false)
+      expect(File).to receive(:file?).twice.with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).and_return(false)
     end
 
     it "should use default options if no ~/.yard/config is found" do
-      File.should_receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(false)
-      File.should_receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(false)
+      expect(File).to receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(false)
+      expect(File).to receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(false)
       YARD::Config.load
-      YARD::Config.options.should == YARD::Config::DEFAULT_CONFIG_OPTIONS
+      expect(YARD::Config.options).to eq YARD::Config::DEFAULT_CONFIG_OPTIONS
     end
 
     it "should overwrite options with data in ~/.yard/config" do
-      File.should_receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(true)
-      File.should_receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(false)
-      YAML.should_receive(:load_file).with(YARD::Config::CONFIG_FILE).and_return({'test' => true})
+      expect(File).to receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(true)
+      expect(File).to receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(false)
+      expect(YAML).to receive(:load_file).with(YARD::Config::CONFIG_FILE).and_return({'test' => true})
       YARD::Config.load
-      YARD::Config.options[:test].should be_true
+      expect(YARD::Config.options[:test]).to be_true
     end
 
     it "should ignore any plugins specified in '~/.yard/ignored_plugins'" do
-      File.should_receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(false)
-      File.should_receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(true)
-      File.should_receive(:read).with(YARD::Config::IGNORED_PLUGINS).and_return('yard-plugin plugin2')
+      expect(File).to receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(false)
+      expect(File).to receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(true)
+      expect(File).to receive(:read).with(YARD::Config::IGNORED_PLUGINS).and_return('yard-plugin plugin2')
       YARD::Config.load
-      YARD::Config.options[:ignored_plugins].should == ['yard-plugin', 'yard-plugin2']
-      YARD::Config.should_not_receive(:require).with('yard-plugin2')
-      YARD::Config.load_plugin('yard-plugin2').should == false
+      expect(YARD::Config.options[:ignored_plugins]).to eq ['yard-plugin', 'yard-plugin2']
+      expect(YARD::Config).to_not receive(:require).with('yard-plugin2')
+      expect(YARD::Config.load_plugin('yard-plugin2')).to eq false
     end
 
     it "should load safe_mode setting from --safe command line option" do
-      File.should_receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(false)
-      File.should_receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(false)
+      expect(File).to receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(false)
+      expect(File).to receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(false)
       ARGV.replace(['--safe'])
       YARD::Config.load
-      YARD::Config.options[:safe_mode].should be_true
+      expect(YARD::Config.options[:safe_mode]).to be_true
       ARGV.replace([''])
     end
   end
@@ -47,53 +47,53 @@ describe YARD::Config do
     it "should save options to config file" do
       YARD::Config.stub!(:options).and_return(:a => 1, :b => %w(a b c))
       file = mock(:file)
-      File.should_receive(:open).with(YARD::Config::CONFIG_FILE, 'w').and_yield(file)
-      file.should_receive(:write).with(YAML.dump(:a => 1, :b => %w(a b c)))
+      expect(File).to receive(:open).with(YARD::Config::CONFIG_FILE, 'w').and_yield(file)
+      expect(file).to receive(:write).with(YAML.dump(:a => 1, :b => %w(a b c)))
       YARD::Config.save
     end
   end
 
   describe '.load_plugin' do
     it "should load a plugin by 'name' as 'yard-name'" do
-      YARD::Config.should_receive(:require).with('yard-foo')
-      log.should_receive(:debug).with(/Loading plugin 'yard-foo'/).once
-      YARD::Config.load_plugin('foo').should == true
+      expect(YARD::Config).to receive(:require).with('yard-foo')
+      expect(log).to receive(:debug).with(/Loading plugin 'yard-foo'/).once
+      expect(YARD::Config.load_plugin('foo')).to eq true
     end
 
     it "should not load plugins like 'doc-*'" do
-      YARD::Config.should_not_receive(:require).with('yard-doc-core')
+      expect(YARD::Config).to_not receive(:require).with('yard-doc-core')
       YARD::Config.load_plugin('doc-core')
       YARD::Config.load_plugin('yard-doc-core')
     end
 
     it "should load plugin by 'yard-name' as 'yard-name'" do
-      YARD::Config.should_receive(:require).with('yard-foo')
-      log.should_receive(:debug).with(/Loading plugin 'yard-foo'/).once
-      YARD::Config.load_plugin('yard-foo').should == true
+      expect(YARD::Config).to receive(:require).with('yard-foo')
+      expect(log).to receive(:debug).with(/Loading plugin 'yard-foo'/).once
+      expect(YARD::Config.load_plugin('yard-foo')).to eq true
     end
 
     it "should load plugin by 'yard_name' as 'yard_name'" do
-      YARD::Config.should_receive(:require).with('yard_foo')
-      log.should_receive(:debug).with(/Loading plugin 'yard_foo'/).once
+      expect(YARD::Config).to receive(:require).with('yard_foo')
+      expect(log).to receive(:debug).with(/Loading plugin 'yard_foo'/).once
       log.show_backtraces = false
-      YARD::Config.load_plugin('yard_foo').should == true
+      expect(YARD::Config.load_plugin('yard_foo')).to eq true
     end
 
     it "should log error if plugin is not found" do
-      YARD::Config.should_receive(:require).with('yard-foo').and_raise(LoadError)
-      log.should_receive(:warn).with(/Error loading plugin 'yard-foo'/).once
-      YARD::Config.load_plugin('yard-foo').should == false
+      expect(YARD::Config).to receive(:require).with('yard-foo').and_raise(LoadError)
+      expect(log).to receive(:warn).with(/Error loading plugin 'yard-foo'/).once
+      expect(YARD::Config.load_plugin('yard-foo')).to eq false
     end
 
     it "should sanitize plugin name (remove /'s)" do
-      YARD::Config.should_receive(:require).with('yard-foofoo')
-      YARD::Config.load_plugin('foo/foo').should == true
+      expect(YARD::Config).to receive(:require).with('yard-foofoo')
+      expect(YARD::Config.load_plugin('foo/foo')).to eq true
     end
 
     it "should ignore plugins in :ignore_plugins" do
       YARD::Config.stub!(:options).and_return(:ignored_plugins => ['yard-foo', 'yard-bar'])
-      YARD::Config.load_plugin('foo').should == false
-      YARD::Config.load_plugin('bar').should == false
+      expect(YARD::Config.load_plugin('foo')).to eq false
+      expect(YARD::Config.load_plugin('bar')).to eq false
     end
   end
 
@@ -101,41 +101,41 @@ describe YARD::Config do
     it "should load gem plugins if :load_plugins is true" do
       YARD::Config.stub!(:options).and_return(:load_plugins => true, :ignored_plugins => [], :autoload_plugins => [])
       YARD::Config.stub!(:load_plugin)
-      YARD::Config.should_receive(:require).with('rubygems')
+      expect(YARD::Config).to receive(:require).with('rubygems')
       YARD::Config.load_plugins
     end
 
     it "should ignore gem loading if RubyGems cannot load" do
       YARD::Config.stub!(:options).and_return(:load_plugins => true, :ignored_plugins => [], :autoload_plugins => [])
-      YARD::Config.should_receive(:require).with('rubygems').and_raise(LoadError)
-      YARD::Config.load_plugins.should == false
+      expect(YARD::Config).to receive(:require).with('rubygems').and_raise(LoadError)
+      expect(YARD::Config.load_plugins).to eq false
     end
 
     it "should load certain plugins automatically when specified in :autoload_plugins" do
-      File.should_receive(:file?).with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).and_return(false)
+      expect(File).to receive(:file?).with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).and_return(false)
       YARD::Config.stub!(:options).and_return(:load_plugins => false, :ignored_plugins => [], :autoload_plugins => ['yard-plugin'])
-      YARD::Config.should_receive(:require).with('yard-plugin').and_return(true)
-      YARD::Config.load_plugins.should == true
+      expect(YARD::Config).to receive(:require).with('yard-plugin').and_return(true)
+      expect(YARD::Config.load_plugins).to eq true
     end
 
     it "should parse --plugin from command line arguments" do
-      YARD::Config.should_receive(:arguments).at_least(1).times.and_return(%w(--plugin foo --plugin bar a b c))
-      YARD::Config.should_receive(:load_plugin).with('foo').and_return(true)
-      YARD::Config.should_receive(:load_plugin).with('bar').and_return(true)
-      YARD::Config.load_plugins.should == true
+      expect(YARD::Config).to receive(:arguments).at_least(1).times.and_return(%w(--plugin foo --plugin bar a b c))
+      expect(YARD::Config).to receive(:load_plugin).with('foo').and_return(true)
+      expect(YARD::Config).to receive(:load_plugin).with('bar').and_return(true)
+      expect(YARD::Config.load_plugins).to eq true
     end
 
     it "should load --plugin arguments from .yardopts" do
-      File.should_receive(:file?).with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).twice.and_return(true)
-      File.should_receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(false)
-      File.should_receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(false)
-      File.should_receive(:read_binary).with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).twice.and_return('--plugin foo')
-      YARD::Config.should_receive(:load_plugin).with('foo')
+      expect(File).to receive(:file?).with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).twice.and_return(true)
+      expect(File).to receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(false)
+      expect(File).to receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(false)
+      expect(File).to receive(:read_binary).with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).twice.and_return('--plugin foo')
+      expect(YARD::Config).to receive(:load_plugin).with('foo')
       YARD::Config.load
     end
 
     it "should load any gem plugins starting with 'yard_' or 'yard-'" do
-      File.should_receive(:file?).with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).and_return(false)
+      expect(File).to receive(:file?).with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).and_return(false)
       YARD::Config.stub!(:options).and_return(:load_plugins => true, :ignored_plugins => ['yard_plugin'], :autoload_plugins => [])
       plugins = {
         'yard' => mock('yard'),
@@ -145,15 +145,15 @@ describe YARD::Config do
         'rspec' => mock('rspec'),
       }
       plugins.each do |k, v|
-        v.should_receive(:name).at_least(1).times.and_return(k)
+        expect(v).to receive(:name).at_least(1).times.and_return(k)
       end
 
       source_mock = mock(:source_index)
-      source_mock.should_receive(:find_name).with('').and_return(plugins.values)
-      Gem.should_receive(:source_index).and_return(source_mock)
-      YARD::Config.should_receive(:load_plugin).with('yard_plugin').and_return(false)
-      YARD::Config.should_receive(:load_plugin).with('yard-plugin').and_return(true)
-      YARD::Config.load_plugins.should == true
+      expect(source_mock).to receive(:find_name).with('').and_return(plugins.values)
+      expect(Gem).to receive(:source_index).and_return(source_mock)
+      expect(YARD::Config).to receive(:load_plugin).with('yard_plugin').and_return(false)
+      expect(YARD::Config).to receive(:load_plugin).with('yard-plugin').and_return(true)
+      expect(YARD::Config.load_plugins).to eq true
     end
 
     it "should log an error if a gem raises an error" do
@@ -162,15 +162,15 @@ describe YARD::Config do
         'yard-plugin' => mock('yard-plugin')
       }
       plugins.each do |k, v|
-        v.should_receive(:name).at_least(1).times.and_return(k)
+        expect(v).to receive(:name).at_least(1).times.and_return(k)
       end
 
       source_mock = mock(:source_index)
-      source_mock.should_receive(:find_name).with('').and_return(plugins.values)
-      Gem.should_receive(:source_index).and_return(source_mock)
-      YARD::Config.should_receive(:load_plugin).with('yard-plugin').and_raise(Gem::LoadError)
-      log.should_receive(:warn).with(/Error loading plugin 'yard-plugin'/)
-      YARD::Config.load_plugins.should == false
+      expect(source_mock).to receive(:find_name).with('').and_return(plugins.values)
+      expect(Gem).to receive(:source_index).and_return(source_mock)
+      expect(YARD::Config).to receive(:load_plugin).with('yard-plugin').and_raise(Gem::LoadError)
+      expect(log).to receive(:warn).with(/Error loading plugin 'yard-plugin'/)
+      expect(YARD::Config.load_plugins).to eq false
     end
   end
 end

--- a/spec/core_ext/array_spec.rb
+++ b/spec/core_ext/array_spec.rb
@@ -3,11 +3,11 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe Array do
   describe '#place' do
     it "should create an Insertion object" do
-      [].place('x').should be_kind_of(Insertion)
+      expect([].place('x')).to be_kind_of(Insertion)
     end
 
     it "should allow multiple objects to be placed" do
-      [1, 2].place('x', 'y', 'z').before(2).should == [1, 'x', 'y', 'z', 2]
+      expect([1, 2].place('x', 'y', 'z').before(2)).to eq [1, 'x', 'y', 'z', 2]
     end
   end
 end

--- a/spec/core_ext/file_spec.rb
+++ b/spec/core_ext/file_spec.rb
@@ -3,65 +3,65 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe File do
   describe ".relative_path" do
     it "should return the relative path between two files" do
-      File.relative_path('a/b/c/d.html', 'a/b/d/q.html').should == '../d/q.html'
+      expect(File.relative_path('a/b/c/d.html', 'a/b/d/q.html')).to eq '../d/q.html'
     end
 
     it "should return the relative path between two directories" do
-      File.relative_path('a/b/c/d/', 'a/b/d/').should == '../d'
+      expect(File.relative_path('a/b/c/d/', 'a/b/d/')).to eq '../d'
     end
 
     it "should return only the to file if from file is in the same directory as the to file" do
-      File.relative_path('a/b/c/d', 'a/b/c/e').should == 'e'
+      expect(File.relative_path('a/b/c/d', 'a/b/c/e')).to eq 'e'
     end
 
     it "should handle non-normalized paths" do
-      File.relative_path('Hello/./I/Am/Fred', 'Hello/Fred').should == '../../Fred'
-      File.relative_path('A//B/C', 'Q/X').should == '../../Q/X'
+      expect(File.relative_path('Hello/./I/Am/Fred', 'Hello/Fred')).to eq '../../Fred'
+      expect(File.relative_path('A//B/C', 'Q/X')).to eq '../../Q/X'
     end
   end
 
   describe '.cleanpath' do
     it "should clean double brackets" do
-      File.cleanpath('A//B/C').should == "A/B/C"
+      expect(File.cleanpath('A//B/C')).to eq "A/B/C"
     end
 
     it "should clean a path with ." do
-      File.cleanpath('Hello/./I/.Am/Fred').should == "Hello/I/.Am/Fred"
+      expect(File.cleanpath('Hello/./I/.Am/Fred')).to eq "Hello/I/.Am/Fred"
     end
 
     it "should clean a path with .." do
-      File.cleanpath('Hello/../World').should == "World"
+      expect(File.cleanpath('Hello/../World')).to eq "World"
     end
 
     it "should clean a path with multiple .." do
-      File.cleanpath('A/B/C/../../D').should == "A/D"
+      expect(File.cleanpath('A/B/C/../../D')).to eq "A/D"
     end
 
     it "should clean a path ending in .." do
-      File.cleanpath('A/B/C/D/..').should == "A/B/C"
+      expect(File.cleanpath('A/B/C/D/..')).to eq "A/B/C"
     end
 
     it "should pass the initial directory" do
-      File.cleanpath('C/../../D').should == "../D"
+      expect(File.cleanpath('C/../../D')).to eq "../D"
     end
 
     it "should not remove multiple '../' at the beginning" do
-      File.cleanpath('../../A/B').should == '../../A/B'
+      expect(File.cleanpath('../../A/B')).to eq '../../A/B'
     end
   end
 
   describe '.open!' do
     it "should create the path before opening" do
-      File.should_receive(:directory?).with('/path/to').and_return(false)
-      FileUtils.should_receive(:mkdir_p).with('/path/to')
-      File.should_receive(:open).with('/path/to/file', 'w')
+      expect(File).to receive(:directory?).with('/path/to').and_return(false)
+      expect(FileUtils).to receive(:mkdir_p).with('/path/to')
+      expect(File).to receive(:open).with('/path/to/file', 'w')
       File.open!('/path/to/file', 'w')
     end
 
     it "should just open the file if the path exists" do
-      File.should_receive(:directory?).with('/path/to').and_return(true)
-      FileUtils.should_not_receive(:mkdir_p)
-      File.should_receive(:open).with('/path/to/file', 'w')
+      expect(File).to receive(:directory?).with('/path/to').and_return(true)
+      expect(FileUtils).to_not receive(:mkdir_p)
+      expect(File).to receive(:open).with('/path/to/file', 'w')
       File.open!('/path/to/file', 'w')
     end
   end

--- a/spec/core_ext/hash_spec.rb
+++ b/spec/core_ext/hash_spec.rb
@@ -4,11 +4,11 @@ describe Hash do
   describe '.[]' do
     it "should accept an Array argument (Ruby 1.8.6 and older)" do
       list = [['foo', 'bar'], ['foo2', 'bar2']]
-      Hash[list].should == {'foo' => 'bar', 'foo2' => 'bar2'}
+      expect(Hash[list]).to eq ({ 'foo' => 'bar', 'foo2' => 'bar2'} )
     end
 
     it "should accept an array as a key" do
-      Hash[['a', 'b'], 1].should == {['a', 'b'] => 1}
+      expect(Hash[['a', 'b'], 1]).to eq ({ ['a', 'b'] => 1} )
     end
   end
 end

--- a/spec/core_ext/insertion_spec.rb
+++ b/spec/core_ext/insertion_spec.rb
@@ -3,35 +3,35 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe Insertion do
   describe '#before' do
     it "should place an object before another" do
-      [1, 2].place(3).before(2).should == [1, 3, 2]
-      [1, 2].place(3).before(1).should == [3, 1, 2]
-      [1, [4], 2].place(3).before(2).should == [1, [4], 3, 2]
+      expect([1, 2].place(3).before(2)).to eq [1, 3, 2]
+      expect([1, 2].place(3).before(1)).to eq [3, 1, 2]
+      expect([1, [4], 2].place(3).before(2)).to eq [1, [4], 3, 2]
     end
   end
 
   describe '#after' do
     it "should place an object after another" do
-      [1, 2].place(3).after(2).should == [1, 2, 3]
+      expect([1, 2].place(3).after(2)).to eq [1, 2, 3]
     end
 
     it "should no longer place an object after another and its subsections (0.6)" do
-      [1, [2]].place(3).after(1).should == [1, 3, [2]]
+      expect([1, [2]].place(3).after(1)).to eq [1, 3, [2]]
     end
 
     it "should place an array after an object" do
-      [1, 2, 3].place([4]).after(1).should == [1, [4], 2, 3]
+      expect([1, 2, 3].place([4]).after(1)).to eq [1, [4], 2, 3]
     end
   end
 
   describe '#before_any' do
     it "should place an object before another anywhere inside list (including sublists)" do
-      [1, 2, [3]].place(4).before_any(3).should == [1, 2, [4, 3]]
+      expect([1, 2, [3]].place(4).before_any(3)).to eq [1, 2, [4, 3]]
     end
   end
 
   describe '#after_any' do
     it "should place an object after another anywhere inside list (including sublists)" do
-      [1, 2, [3]].place(4).after_any(3).should == [1, 2, [3, 4]]
+      expect([1, 2, [3]].place(4).after_any(3)).to eq [1, 2, [3, 4]]
     end
   end
 end

--- a/spec/core_ext/module_spec.rb
+++ b/spec/core_ext/module_spec.rb
@@ -3,13 +3,13 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe Module do
   describe '#class_name' do
     it "should return just the name of the class/module" do
-      YARD::CodeObjects::Base.class_name.should == "Base"
+      expect(YARD::CodeObjects::Base.class_name).to eq "Base"
     end
   end
 
   describe '#namespace' do
     it "should return everything before the class name" do
-      YARD::CodeObjects::Base.namespace_name.should == "YARD::CodeObjects"
+      expect(YARD::CodeObjects::Base.namespace_name).to eq "YARD::CodeObjects"
     end
   end
 end

--- a/spec/core_ext/string_spec.rb
+++ b/spec/core_ext/string_spec.rb
@@ -6,37 +6,37 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe String do
   describe '#shell_split' do
     it "should split simple non-quoted text" do
-      "a b c".shell_split.should == %w(a b c)
+      expect("a b c".shell_split).to eq %w(a b c)
     end
 
     it "should split double quoted text into single token" do
-      'a "b c d" e'.shell_split.should == ["a", "b c d", "e"]
+      expect('a "b c d" e'.shell_split).to eq ["a", "b c d", "e"]
     end
 
     it "should split single quoted text into single token" do
-      "a 'b c d' e".shell_split.should == ["a", "b c d", "e"]
+      expect("a 'b c d' e".shell_split).to eq ["a", "b c d", "e"]
     end
 
     it "should handle escaped quotations in quotes" do
-      "'a \\' b'".shell_split.should == ["a ' b"]
+      expect("'a \\' b'".shell_split).to eq ["a ' b"]
     end
 
     it "should handle escaped quotations outside quotes" do
-      "\\'a 'b'".shell_split.should == %w('a b)
+      expect("\\'a 'b'".shell_split).to eq %w('a b)
     end
 
     it "should handle escaped backslash" do
-      "\\\\'a b c'".shell_split.should == ['\a b c']
+      expect("\\\\'a b c'".shell_split).to eq ['\a b c']
     end
 
     it "should handle any whitespace as space" do
       text = "foo\tbar\nbaz\r\nfoo2 bar2"
-      text.shell_split.should == %w(foo bar baz foo2 bar2)
+      expect(text.shell_split).to eq %w(foo bar baz foo2 bar2)
     end
 
     it "should handle complex input" do
       text = "hello \\\"world \"1 2\\\" 3\" a 'b \"\\\\\\'' c"
-      text.shell_split.should == ["hello", "\"world", "1 2\" 3", "a", "b \"\\'", "c"]
+      expect(text.shell_split).to eq ["hello", "\"world", "1 2\" 3", "a", "b \"\\'", "c"]
     end
   end
 end

--- a/spec/core_ext/symbol_hash_spec.rb
+++ b/spec/core_ext/symbol_hash_spec.rb
@@ -5,32 +5,32 @@ describe SymbolHash do
   it "should allow access to keys as String or Symbol" do
     h = SymbolHash.new(false)
     h['test'] = true
-    h[:test].should == true
-    h['test'].should == true
+    expect(h[:test]).to eq true
+    expect(h['test']).to eq true
   end
 
   it "should #delete by key as String or Symbol" do
     h = SymbolHash.new
-    h.keys.length.should == 0
+    expect(h.keys.length).to eq 0
 
     h['test'] = true
-    h.keys.length.should == 1
+    expect(h.keys.length).to eq 1
 
     h.delete(:test)
-    h.keys.length.should == 0
+    expect(h.keys.length).to eq 0
 
     h[:test] = true
-    h.keys.length.should == 1
+    expect(h.keys.length).to eq 1
 
     h.delete('test')
-    h.keys.length.should == 0
+    expect(h.keys.length).to eq 0
   end
 
   it "should return same #has_key? for key as String or Symbol" do
     h = SymbolHash.new
     h[:test] = 1
-    h.has_key?(:test).should == true
-    h.has_key?('test').should == true
+    expect(h.has_key?(:test)).to eq true
+    expect(h.has_key?('test')).to eq true
   end
 
   it "should symbolize value if it is a String (and only a string)" do
@@ -39,40 +39,40 @@ describe SymbolHash do
     h = SymbolHash.new
     h['test1'] = "hello"
     h['test2'] = Substring.new("hello")
-    h['test1'].should == :hello
-    h['test2'].should == "hello"
+    expect(h['test1']).to eq :hello
+    expect(h['test2']).to eq "hello"
   end
 
   it "should not symbolize value if SymbolHash.new(false) is created" do
     h = SymbolHash.new(false)
     h['test'] = "hello"
-    h[:test].should == "hello"
+    expect(h[:test]).to eq "hello"
   end
 
   it "should not symbolize value if it is not a String" do
     h = SymbolHash.new
     h['test'] = [1,2,3]
-    h['test'].should == [1,2,3]
+    expect(h['test']).to eq [1,2,3]
   end
 
   it "should support symbolization using #update or #merge!" do
     h = SymbolHash.new
     h.update('test' => 'value')
-    h[:test].should == :value
+    expect(h[:test]).to eq :value
     h.merge!('test' => 'value2')
-    h[:test].should == :value2
+    expect(h[:test]).to eq :value2
   end
 
   it "should support symbolization non-destructively using #merge" do
     h = SymbolHash.new
-    h.merge('test' => 'value')[:test].should == :value
-    h.should == SymbolHash.new
+    expect(h.merge('test' => 'value')[:test]).to eq :value
+    expect(h).to eq SymbolHash.new
   end
 
   it "should support #initializing of a hash" do
     h = SymbolHash[:test => 1]
-    h[:test].should == 1
-    h[:somethingelse].should be_nil
+    expect(h[:test]).to eq 1
+    expect(h[:somethingelse]).to be_nil
   end
 
   it "should support reverse merge syntax" do
@@ -80,7 +80,7 @@ describe SymbolHash do
     opts = SymbolHash[
       'default' => 1
     ].update(opts)
-    opts.keys.should == [:default]
-    opts[:default].should == 1
+    expect(opts.keys).to eq [:default]
+    expect(opts[:default]).to eq 1
   end
 end

--- a/spec/docstring_parser_spec.rb
+++ b/spec/docstring_parser_spec.rb
@@ -29,12 +29,12 @@ describe YARD::DocstringParser do
   right here.
       eof
       tags = doc.tags(:param)
-      tags[0].name.should == "name"
-      tags[0].text.should == "Hello world\nhow are you?"
-      tags[1].name.should == "name2"
-      tags[1].text.should == "this is a new line"
-      tags[2].name.should == "name3"
-      tags[2].text.should == "and this\nis a new paragraph:\n\nright here."
+      expect(tags[0].name).to eq "name"
+      expect(tags[0].text).to eq "Hello world\nhow are you?"
+      expect(tags[1].name).to eq "name2"
+      expect(tags[1].text).to eq "this is a new line"
+      expect(tags[2].name).to eq "name3"
+      expect(tags[2].text).to eq "and this\nis a new paragraph:\n\nright here."
     end
 
     it "should end parsing a tag on de-dent" do
@@ -43,8 +43,8 @@ describe YARD::DocstringParser do
   one two three
 rest of docstring
       eof
-      doc.tag(:note).text.should == "test\none two three"
-      doc.should == "rest of docstring"
+      expect(doc.tag(:note).text).to eq "test\none two three"
+      expect(doc).to eq "rest of docstring"
     end
 
     it "should parse examples embedded in doc" do
@@ -59,8 +59,8 @@ test string here
 
 more stuff
 eof
-      doc.should == "test string here\nmore stuff"
-      doc.tag(:example).text.should == "\ndef foo(x, y, z)\nend\n\nclass A; end"
+      expect(doc).to eq "test string here\nmore stuff"
+      expect(doc.tag(:example).text).to eq "\ndef foo(x, y, z)\nend\n\nclass A; end"
     end
 
     it "should remove only original indentation from beginning of line in tags" do
@@ -70,7 +70,7 @@ eof
   foo bar
    baz
 eof
-      doc.tag(:param).text.should == "some value\nfoo bar\n baz"
+      expect(doc.tag(:param).text).to eq "some value\nfoo bar\n baz"
     end
 
     it "should allow numbers in tags" do
@@ -82,8 +82,8 @@ eof
 @foo2 bar2
 @foo3 bar3
 eof
-      doc.tag(:foo1).text.should == "bar1"
-      doc.tag(:foo2).text.should == "bar2"
+      expect(doc.tag(:foo1).text).to eq "bar1"
+      expect(doc.tag(:foo2).text).to eq "bar2"
     end
 
     it "should end tag on newline if next line is not indented" do
@@ -92,18 +92,18 @@ eof
 @api bar2
 Hello world
 eof
-      doc.tag(:author).text.should == "bar1"
-      doc.tag(:api).text.should == "bar2"
+      expect(doc.tag(:author).text).to eq "bar1"
+      expect(doc.tag(:api).text).to eq "bar2"
     end
 
     it "should warn about unknown tag" do
-      log.should_receive(:warn).with(/Unknown tag @hello$/)
+      expect(log).to receive(:warn).with(/Unknown tag @hello$/)
       docstring("@hello world")
     end
 
     it "should not add trailing whitespace to freeform tags" do
       doc = docstring("@api private   \t   ")
-      doc.tag(:api).text.should == "private"
+      expect(doc.tag(:api).text).to eq "private"
     end
   end
 
@@ -117,26 +117,26 @@ eof
       valid.each do |tag|
         TestLibrary.define_tag("Tag", tag)
         doc = docstring('@' + tag + ' foo bar')
-        doc.tag(tag).text.should == 'foo bar'
+        expect(doc.tag(tag).text).to eq 'foo bar'
       end
     end
 
     it "should not parse invalid tag names" do
       invalid = %w( @ @return@ @param, @x-y @.x.y.z )
       invalid.each do |tag|
-        docstring(tag + ' foo bar').should == tag + ' foo bar'
+        expect(docstring(tag + ' foo bar')).to eq tag + ' foo bar'
       end
     end
 
     it "should allow namespaced tags in the form @x.y.z" do
       TestLibrary.define_tag("Tag", 'x.y.z')
       doc = docstring("@x.y.z foo bar")
-      doc.tag('x.y.z').text.should == 'foo bar'
+      expect(doc.tag('x.y.z').text).to eq 'foo bar'
     end
 
     it "should ignore new directives without @! prefix syntax" do
       TestLibrary.define_directive('dir1', Tags::ScopeDirective)
-      log.should_receive(:warn).with(/@dir1/)
+      expect(log).to receive(:warn).with(/@dir1/)
       docstring("@dir1")
     end
 
@@ -144,21 +144,21 @@ eof
       it "should handle non prefixed @#{tag} syntax as directive, not tag" do
         TestLibrary.define_directive(tag, Tags::ScopeDirective)
         parse("@#{tag}")
-        @parser.directives.first.should be_a(Tags::ScopeDirective)
+        expect(@parser.directives.first).to be_a(Tags::ScopeDirective)
       end
     end
 
     it "should handle directives with @! prefix syntax" do
       TestLibrary.define_directive('dir1', Tags::ScopeDirective)
       docstring("@!dir1 class")
-      @parser.state.scope.should == :class
+      expect(@parser.state.scope).to eq :class
     end
   end
 
   describe '#text' do
     it "should only return text data" do
       parse("Foo\n@param foo x y z\nBar")
-      @parser.text.should == "Foo\nBar"
+      expect(@parser.text).to eq "Foo\nBar"
     end
   end
 
@@ -166,7 +166,7 @@ eof
     it "should return the entire original data" do
       data = "Foo\n@param foo x y z\nBar"
       parse(data)
-      @parser.raw_text.should == data
+      expect(@parser.raw_text).to eq data
     end
   end
 
@@ -174,8 +174,8 @@ eof
     it "should return the parsed tags" do
       data = "Foo\n@param foo x y z\nBar"
       parse(data)
-      @parser.tags.size.should == 1
-      @parser.tags.first.tag_name.should == 'param'
+      expect(@parser.tags.size).to eq 1
+      expect(@parser.tags.first.tag_name).to eq 'param'
     end
   end
 
@@ -185,17 +185,17 @@ eof
       parse(data)
       dirs = @parser.directives
       dirs.size == 2
-      dirs[0].should be_a(Tags::ScopeDirective)
-      dirs[0].tag.text.should == 'class'
-      dirs[1].should be_a(Tags::VisibilityDirective)
-      dirs[1].tag.text.should == 'private'
+      expect(dirs[0]).to be_a(Tags::ScopeDirective)
+      expect(dirs[0].tag.text).to eq 'class'
+      expect(dirs[1]).to be_a(Tags::VisibilityDirective)
+      expect(dirs[1].tag.text).to eq 'private'
     end
   end
 
   describe '#state' do
     it "should handle modified state" do
       parse("@!scope class")
-      @parser.state.scope.should == :class
+      expect(@parser.state.scope).to eq :class
     end
   end
 
@@ -205,11 +205,11 @@ eof
       the_yielded_obj = nil
       DocstringParser.after_parse {|obj| the_yielded_obj = obj }
       parser.parse("Some text")
-      the_yielded_obj.should == parser
+      expect(the_yielded_obj).to eq parser
     end
 
     it "should warn about invalid named parameters" do
-      log.should_receive(:warn).with(/@param tag has unknown parameter name: notaparam/)
+      expect(log).to receive(:warn).with(/@param tag has unknown parameter name: notaparam/)
       YARD.parse_string <<-eof
         # @param notaparam foo
         def foo(a) end
@@ -217,7 +217,7 @@ eof
     end
 
     it "should warn about duplicate named parameters" do
-      log.should_receive(:warn).with(/@param tag has duplicate parameter name: a/)
+      expect(log).to receive(:warn).with(/@param tag has duplicate parameter name: a/)
       YARD.parse_string <<-eof
         # @param a foo
         # @param a foo

--- a/spec/docstring_spec.rb
+++ b/spec/docstring_spec.rb
@@ -5,83 +5,83 @@ describe YARD::Docstring do
 
   describe '#initialize' do
     it "should handle docstrings with empty newlines" do
-      Docstring.new("\n\n").should == ""
+      expect(Docstring.new("\n\n")).to eq ""
     end
   end
 
   describe '#+' do
     it "should add another Docstring" do
       d = Docstring.new("FOO") + Docstring.new("BAR")
-      d.should == "FOO\nBAR"
+      expect(d).to eq "FOO\nBAR"
     end
 
     it "should copy over tags" do
       d1 = Docstring.new("FOO\n@api private\n")
       d2 = Docstring.new("BAR\n@param foo descr")
       d = (d1 + d2)
-      d.should have_tag(:api)
-      d.should have_tag(:param)
+      expect(d).to have_tag(:api)
+      expect(d).to have_tag(:param)
     end
 
     it "should add a String" do
       d = Docstring.new("FOO") + "BAR"
-      d.should == "FOOBAR"
+      expect(d).to eq "FOOBAR"
     end
   end
 
   describe '#line' do
     it "should return nil if #line_range is not set" do
-      Docstring.new('foo').line.should be_nil
+      expect(Docstring.new('foo').line).to be_nil
     end
 
     it "should return line_range.first if #line_range is set" do
       doc = Docstring.new('foo')
       doc.line_range = (1..10)
-      doc.line.should == doc.line_range.first
+      expect(doc.line).to eq doc.line_range.first
     end
   end
 
   describe '#summary' do
     it "should handle empty docstrings" do
       o1 = Docstring.new
-      o1.summary.should == ""
+      expect(o1.summary).to eq ""
     end
 
     it "should handle multiple calls" do
       o1 = Docstring.new("Hello. world")
-      5.times { o1.summary.should == "Hello." }
+      5.times { expect(o1.summary).to eq "Hello." }
     end
 
     it "should strip HTML before summarizing" do
       doc = Docstring.new("<p>Hello <b>world</b></p>.")
-      doc.summary.should == 'Hello world.'
+      expect(doc.summary).to eq 'Hello world.'
     end
 
     it "should strip newlines in first paragraph before summarizing" do
       doc = Docstring.new("Foo\n<code>==</code> bar.")
-      doc.summary.should == 'Foo == bar.'
+      expect(doc.summary).to eq 'Foo == bar.'
     end
 
     it "should return the first sentence" do
       o = Docstring.new("DOCSTRING. Another sentence")
-      o.summary.should == "DOCSTRING."
+      expect(o.summary).to eq "DOCSTRING."
     end
 
     it "should return the first paragraph" do
       o = Docstring.new("DOCSTRING, and other stuff\n\nAnother sentence.")
-      o.summary.should == "DOCSTRING, and other stuff."
+      expect(o.summary).to eq "DOCSTRING, and other stuff."
     end
 
     it "should return proper summary when docstring is changed" do
       o = Docstring.new "DOCSTRING, and other stuff\n\nAnother sentence."
-      o.summary.should == "DOCSTRING, and other stuff."
+      expect(o.summary).to eq "DOCSTRING, and other stuff."
       o = Docstring.new "DOCSTRING."
-      o.summary.should == "DOCSTRING."
+      expect(o.summary).to eq "DOCSTRING."
     end
 
     it "should not double the ending period" do
       o = Docstring.new("Returns a list of tags specified by +name+ or all tags if +name+ is not specified.\n\nTest")
-      o.summary.should == "Returns a list of tags specified by +name+ or all tags if +name+ is not specified."
+      expect(o.summary).to eq "Returns a list of tags specified by +name+ or all tags if +name+ is not specified."
 
       doc = Docstring.new(<<-eof)
 
@@ -90,51 +90,51 @@ describe YARD::Docstring do
         @param name the tag name to return data for, or nil for all tags
         @return [Array<Tags::Tag>] the list of tags by the specified tag name
       eof
-      doc.summary.should == "Returns a list of tags specified by +name+ or all tags if +name+ is not specified."
+      expect(doc.summary).to eq "Returns a list of tags specified by +name+ or all tags if +name+ is not specified."
     end
 
     it "should not attach period if entire summary is include" do
       YARD.parse_string "# docstring\ndef foo; end"
-      Docstring.new("{include:#foo}").summary.should == '{include:#foo}'
+      expect(Docstring.new("{include:#foo}").summary).to eq '{include:#foo}'
       Registry.clear
     end
 
     it "should handle references embedded in summary" do
-      Docstring.new("Aliasing {Test.test}. Done.").summary.should == "Aliasing {Test.test}."
+      expect(Docstring.new("Aliasing {Test.test}. Done.").summary).to eq "Aliasing {Test.test}."
     end
 
     it "should only end first sentence when outside parentheses" do
-      Docstring.new("Hello (the best.) world. Foo bar.").summary.should == "Hello (the best.) world."
-      Docstring.new("A[b.]c.").summary.should == "A[b.]c."
+      expect(Docstring.new("Hello (the best.) world. Foo bar.").summary).to eq "Hello (the best.) world."
+      expect(Docstring.new("A[b.]c.").summary).to eq "A[b.]c."
     end
 
     it "should only see '.' as period if whitespace (or eof) follows" do
-      Docstring.new("hello 1.5 times.").summary.should == "hello 1.5 times."
-      Docstring.new("hello... me").summary.should == "hello..."
-      Docstring.new("hello.").summary.should == "hello."
+      expect(Docstring.new("hello 1.5 times.").summary).to eq "hello 1.5 times."
+      expect(Docstring.new("hello... me").summary).to eq "hello..."
+      expect(Docstring.new("hello.").summary).to eq "hello."
     end
   end
 
   describe '#ref_tags' do
     it "should parse reference tag into ref_tags" do
       doc = Docstring.new("@return (see Foo#bar)")
-      doc.ref_tags.size.should == 1
-      doc.ref_tags.first.owner.should == P("Foo#bar")
-      doc.ref_tags.first.tag_name.should == "return"
-      doc.ref_tags.first.name.should be_nil
+      expect(doc.ref_tags.size).to eq 1
+      expect(doc.ref_tags.first.owner).to eq P("Foo#bar")
+      expect(doc.ref_tags.first.tag_name).to eq "return"
+      expect(doc.ref_tags.first.name).to be_nil
     end
 
     it "should parse named reference tag into ref_tags" do
       doc = Docstring.new("@param blah \n   (see Foo#bar )")
-      doc.ref_tags.size.should == 1
-      doc.ref_tags.first.owner.should == P("Foo#bar")
-      doc.ref_tags.first.tag_name.should == "param"
-      doc.ref_tags.first.name.should == "blah"
+      expect(doc.ref_tags.size).to eq 1
+      expect(doc.ref_tags.first.owner).to eq P("Foo#bar")
+      expect(doc.ref_tags.first.tag_name).to eq "param"
+      expect(doc.ref_tags.first.name).to eq "blah"
     end
 
     it "should fail to parse named reference tag into ref_tags" do
       doc = Docstring.new("@param blah THIS_BREAKS_REFTAG (see Foo#bar)")
-      doc.ref_tags.size.should == 0
+      expect(doc.ref_tags.size).to eq 0
     end
 
     it "should return all valid reference tags along with #tags" do
@@ -142,10 +142,10 @@ describe YARD::Docstring do
       o.docstring.add_tag Tags::Tag.new('return', 'testing')
       doc = Docstring.new("@return (see Foo#bar)")
       tags = doc.tags
-      tags.size.should == 1
-      tags.first.text.should == 'testing'
-      tags.first.should be_kind_of(Tags::RefTag)
-      tags.first.owner.should == o
+      expect(tags.size).to eq 1
+      expect(tags.first.text).to eq 'testing'
+      expect(tags.first).to be_kind_of(Tags::RefTag)
+      expect(tags.first.owner).to eq o
     end
 
     it "should return all valid named reference tags along with #tags(name)" do
@@ -154,16 +154,16 @@ describe YARD::Docstring do
       o.docstring.add_tag Tags::Tag.new('param', 'NOTtesting', nil, 'notargs')
       doc = Docstring.new("@param *args (see Foo#bar)")
       tags = doc.tags('param')
-      tags.size.should == 1
-      tags.first.text.should == 'testing'
-      tags.first.should be_kind_of(Tags::RefTag)
-      tags.first.owner.should == o
+      expect(tags.size).to eq 1
+      expect(tags.first.text).to eq 'testing'
+      expect(tags.first).to be_kind_of(Tags::RefTag)
+      expect(tags.first.owner).to eq o
     end
 
     it "should ignore invalid reference tags" do
       doc = Docstring.new("@param *args (see INVALID::TAG#tag)")
       tags = doc.tags('param')
-      tags.size.should == 0
+      expect(tags.size).to eq 0
     end
 
     it "resolves references to methods in the same class with #methname" do
@@ -174,10 +174,10 @@ describe YARD::Docstring do
       ref.docstring = "@param (see #bar)"
 
       tags = ref.docstring.tags("param")
-      tags.size.should == 1
-      tags.first.text.should == "testing"
-      tags.first.should be_kind_of(Tags::RefTag)
-      tags.first.owner.should == o
+      expect(tags.size).to eq 1
+      expect(tags.first.text).to eq "testing"
+      expect(tags.first).to be_kind_of(Tags::RefTag)
+      expect(tags.first.owner).to eq o
     end
   end
 
@@ -187,39 +187,39 @@ describe YARD::Docstring do
     end
 
     it "should be blank and empty if it has no content and no tags" do
-      Docstring.new.should be_blank
-      Docstring.new.should be_empty
+      expect(Docstring.new).to be_blank
+      expect(Docstring.new).to be_empty
     end
 
     it "shouldn't be empty or blank if it has content" do
       d = Docstring.new("foo bar")
-      d.should_not be_empty
-      d.should_not be_blank
+      expect(d).to_not be_empty
+      expect(d).to_not be_blank
     end
 
     it "should be empty but not blank if it has tags" do
       d = Docstring.new("@param foo")
-      d.should be_empty
-      d.should_not be_blank
+      expect(d).to be_empty
+      expect(d).to_not be_blank
     end
 
     it "should be empty but not blank if it has ref tags" do
       o = CodeObjects::MethodObject.new(:root, 'Foo#bar')
       o.docstring.add_tag Tags::Tag.new('return', 'testing')
       d = Docstring.new("@return (see Foo#bar)")
-      d.should be_empty
-      d.should_not be_blank
+      expect(d).to be_empty
+      expect(d).to_not be_blank
     end
 
     it "should be blank if it has no visible tags" do
       d = Docstring.new("@invisible_tag value")
-      d.should be_blank
+      expect(d).to be_blank
     end
 
     it "should not be blank if it has invisible tags and only_visible_tags = false" do
       d = Docstring.new("@invisible_tag value")
       d.add_tag Tags::Tag.new('invisible_tag', nil, nil)
-      d.blank?(false).should == false
+      expect(d.blank?(false)).to eq false
     end
   end
 
@@ -227,7 +227,7 @@ describe YARD::Docstring do
     it "should delete tags by a given tag name" do
       doc = Docstring.new("@param name x\n@param name2 y\n@return foo")
       doc.delete_tags(:param)
-      doc.tags.size.should == 1
+      expect(doc.tags.size).to eq 1
     end
   end
 
@@ -235,81 +235,81 @@ describe YARD::Docstring do
     it "should delete tags for a given block" do
       doc = Docstring.new("@param name x\n@param name2 y\n@return foo")
       doc.delete_tag_if {|t| t.name == 'name2' }
-      doc.tags.size.should == 2
+      expect(doc.tags.size).to eq 2
     end
   end
 
   describe '#to_raw' do
     it "should return a clean representation of tags" do
       doc = Docstring.new("Hello world\n@return [String, X] foobar\n@param name<Array> the name\nBYE!")
-      doc.to_raw.should == "Hello world\nBYE!\n@param [Array] name\n  the name\n@return [String, X] foobar"
+      expect(doc.to_raw).to eq "Hello world\nBYE!\n@param [Array] name\n  the name\n@return [String, X] foobar"
     end
 
     it "should handle tags with newlines and indentation" do
       doc = Docstring.new("@example TITLE\n  the \n  example\n  @foo\n@param [X] name\n  the name")
-      doc.to_raw.should == "@example TITLE\n  the \n  example\n  @foo\n@param [X] name\n  the name"
+      expect(doc.to_raw).to eq "@example TITLE\n  the \n  example\n  @foo\n@param [X] name\n  the name"
     end
 
     it "should handle deleted tags" do
       doc = Docstring.new("@example TITLE\n  the \n  example\n  @foo\n@param [X] name\n  the name")
       doc.delete_tags(:param)
-      doc.to_raw.should == "@example TITLE\n  the \n  example\n  @foo"
+      expect(doc.to_raw).to eq "@example TITLE\n  the \n  example\n  @foo"
     end
 
     it "should handle added tags" do
       doc = Docstring.new("@example TITLE\n  the \n  example\n  @foo")
       doc.add_tag(Tags::Tag.new('foo', 'foo'))
-      doc.to_raw.should == "@example TITLE\n  the \n  example\n  @foo\n@foo foo"
+      expect(doc.to_raw).to eq "@example TITLE\n  the \n  example\n  @foo\n@foo foo"
     end
 
     it "should be equal to .all if not modified" do
       doc = Docstring.new("123\n@param")
-      doc.to_raw.should == doc.all
+      expect(doc.to_raw).to eq doc.all
     end
 
     # @bug gh-563
     it "should handle full @option tags" do
       doc = Docstring.new("@option foo [String] bar (nil) baz")
-      doc.to_raw.should == "@option foo [String] bar (nil) baz"
+      expect(doc.to_raw).to eq "@option foo [String] bar (nil) baz"
     end
 
     # @bug gh-563
     it "should handle simple @option tags" do
       doc = Docstring.new("@option foo :key bar")
-      doc.to_raw.should == "@option foo :key bar"
+      expect(doc.to_raw).to eq "@option foo :key bar"
     end
   end
 
   describe '#dup' do
     it "should duplicate docstring text" do
       doc = Docstring.new("foo")
-      doc.dup.should == doc
-      doc.dup.all.should == doc
+      expect(doc.dup).to eq doc
+      expect(doc.dup.all).to eq doc
     end
 
     it "should duplicate tags to new list" do
       doc = Docstring.new("@param x\n@return y")
       doc2 = doc.dup
       doc2.delete_tags(:param)
-      doc.tags.size.should == 2
-      doc2.tags.size.should == 1
+      expect(doc.tags.size).to eq 2
+      expect(doc2.tags.size).to eq 1
     end
 
     it "should preserve summary" do
       doc = Docstring.new("foo. bar")
-      doc.dup.summary.should == doc.summary
+      expect(doc.dup.summary).to eq doc.summary
     end
 
     it "should preserve hash_flag" do
       doc = Docstring.new
       doc.hash_flag = 'foo'
-      doc.dup.hash_flag.should == doc.hash_flag
+      expect(doc.dup.hash_flag).to eq doc.hash_flag
     end
 
     it "should preserve line_range" do
       doc = Docstring.new
       doc.line_range = (1..2)
-      doc.dup.line_range.should == doc.line_range
+      expect(doc.dup.line_range).to eq doc.line_range
     end
   end
 
@@ -326,8 +326,8 @@ describe YARD::Docstring do
       eof
 
       object = YARD::Registry.at('A#b')
-      object.docstring.should == 'Docstring'
-      object.tags.map {|x| x.tag_name }.should == ['return']
+      expect(object.docstring).to eq 'Docstring'
+      expect(object.tags.map {|x| x.tag_name }).to eq ['return']
 
       YARD::Registry.clear
     end

--- a/spec/handlers/alias_handler_spec.rb
+++ b/spec/handlers/alias_handler_spec.rb
@@ -4,69 +4,69 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}AliasHandler" 
   before(:all) { parse_file :alias_handler_001, __FILE__ }
 
   it "should throw alias into namespace object list" do
-    P(:A).aliases[P("A#b")].should == :a
+    expect(P(:A).aliases[P("A#b")]).to eq :a
   end
 
   ['c', 'd?', '[]', '[]=', '-@', '%', '*', 'cstrkey', 'cstrmeth'].each do |a|
     it "should handle the Ruby 'alias' keyword syntax for method ##{a}" do
-      P('A#' + a).should be_instance_of(CodeObjects::MethodObject)
-      P('A#' + a).is_alias?.should be_true
+      expect(P('A#' + a)).to be_instance_of(CodeObjects::MethodObject)
+      expect(P('A#' + a).is_alias?).to be_true
     end
   end
 
   it "should handle keywords as the alias name" do
-    P('A#for').should be_instance_of(CodeObjects::MethodObject)
+    expect(P('A#for')).to be_instance_of(CodeObjects::MethodObject)
   end
 
   it "should allow ConstantNames to be specified as aliases" do
-    P('A#ConstantName').should be_instance_of(CodeObjects::MethodObject)
+    expect(P('A#ConstantName')).to be_instance_of(CodeObjects::MethodObject)
   end
 
   it "should create a new method object for the alias" do
-    P("A#b").should be_instance_of(CodeObjects::MethodObject)
+    expect(P("A#b")).to be_instance_of(CodeObjects::MethodObject)
   end
 
   it "should pull the method into the current class if it's from another one" do
-    P(:B).aliases[P("B#q")].should == :x
-    P(:B).aliases[P("B#r?")].should == :x
+    expect(P(:B).aliases[P("B#q")]).to eq :x
+    expect(P(:B).aliases[P("B#r?")]).to eq :x
   end
 
   it "should gracefully fail to pull a method in if the original method cannot be found" do
-    P(:B).aliases[P("B#s")].should == :to_s
+    expect(P(:B).aliases[P("B#s")]).to eq :to_s
   end
 
   it "should allow complex Ruby expressions after the alias parameters" do
-    P(:B).aliases[P("B#t")].should == :inspect
+    expect(P(:B).aliases[P("B#t")]).to eq :inspect
   end
 
   it "should show up in #is_alias? for method" do
-    P("B#t").is_alias?.should == true
-    P('B#r?').is_alias?.should == true
+    expect(P("B#t").is_alias?).to eq true
+    expect(P('B#r?').is_alias?).to eq true
   end
 
   it "should allow operators and keywords to be specified as symbols" do
-    P('B#<<').should be_instance_of(CodeObjects::MethodObject)
-    P('B#for').should be_instance_of(CodeObjects::MethodObject)
+    expect(P('B#<<')).to be_instance_of(CodeObjects::MethodObject)
+    expect(P('B#for')).to be_instance_of(CodeObjects::MethodObject)
   end
 
   it "should handle keywords in alias names" do
-    P('B#do').is_alias?.should == true
-    P('B#x2').is_alias?.should == true
-    P(:B).aliases[P('B#do')].should == :x
-    P(:B).aliases[P('B#x2')].should == :do
+    expect(P('B#do').is_alias?).to eq true
+    expect(P('B#x2').is_alias?).to eq true
+    expect(P(:B).aliases[P('B#do')]).to eq :x
+    expect(P(:B).aliases[P('B#x2')]).to eq :do
   end
 
   it "should handle quoted symbols" do
     foo = Registry.at('A#foo')
-    foo.should_not be_nil
-    foo.should be_is_alias
-    Registry.at('A').aliases[foo].should == :a
+    expect(foo).to_not be_nil
+    expect(foo).to be_is_alias
+    expect(Registry.at('A').aliases[foo]).to eq :a
   end
 
   it "should prepend aliases object's docstring to comments" do
-    Registry.at('D#a').tag(:return).types.should == ['Numeric']
-    Registry.at('D#b').tag(:return).types.should == ['String']
-    Registry.at('D#b').docstring.should == "Foo bar"
+    expect(Registry.at('D#a').tag(:return).types).to eq ['Numeric']
+    expect(Registry.at('D#b').tag(:return).types).to eq ['String']
+    expect(Registry.at('D#b').docstring).to eq "Foo bar"
   end
 
   it "should raise an UndocumentableError if only one parameter is passed" do

--- a/spec/handlers/attribute_handler_spec.rb
+++ b/spec/handlers/attribute_handler_spec.rb
@@ -6,24 +6,24 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}AttributeHandl
   def read_write(namespace, name, read, write, scope = :instance)
     rname, wname = namespace.to_s+"#"+name.to_s, namespace.to_s+"#"+name.to_s+"="
     if read
-      Registry.at(rname).should be_instance_of(CodeObjects::MethodObject)
+      expect(Registry.at(rname)).to be_instance_of(CodeObjects::MethodObject)
     else
-      Registry.at(rname).should == nil
+      expect(Registry.at(rname)).to eq nil
     end
 
     if write
-      Registry.at(wname).should be_kind_of(CodeObjects::MethodObject)
+      expect(Registry.at(wname)).to be_kind_of(CodeObjects::MethodObject)
     else
-      Registry.at(wname).should == nil
+      expect(Registry.at(wname)).to eq nil
     end
 
     attrs = Registry.at(namespace).attributes[scope][name]
-    attrs[:read].should == (read ? Registry.at(rname) : nil)
-    attrs[:write].should == (write ? Registry.at(wname) : nil)
+    expect(attrs[:read]).to eq (read ? Registry.at(rname) : nil)
+    expect(attrs[:write]).to eq (write ? Registry.at(wname) : nil)
   end
 
   it "should parse attributes inside modules too" do
-    Registry.at("A#x=").should_not == nil
+    expect(Registry.at("A#x=")).to_not eq nil
   end
 
   it "should parse 'attr'" do
@@ -51,44 +51,44 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}AttributeHandl
   end
 
   it "should have a default docstring if one is not supplied" do
-    Registry.at("B#f=").docstring.should_not be_empty
+    expect(Registry.at("B#f=").docstring).to_not be_empty
   end
 
   it "should set the correct docstring if one is supplied" do
-    Registry.at("B#b").docstring.should == "Docstring"
-    Registry.at("B#c").docstring.should == "Docstring"
-    Registry.at("B#d").docstring.should == "Docstring"
+    expect(Registry.at("B#b").docstring).to eq "Docstring"
+    expect(Registry.at("B#c").docstring).to eq "Docstring"
+    expect(Registry.at("B#d").docstring).to eq "Docstring"
   end
 
   it "should be able to differentiate between class and instance attributes" do
-    P('B').class_attributes[:z][:read].scope.should == :class
-    P('B').instance_attributes[:z][:read].scope.should == :instance
+    expect(P('B').class_attributes[:z][:read].scope).to eq :class
+    expect(P('B').instance_attributes[:z][:read].scope).to eq :instance
   end
 
   it "should respond true in method's #is_attribute?" do
-    P('B#a').is_attribute?.should == true
-    P('B#a=').is_attribute?.should == true
+    expect(P('B#a').is_attribute?).to eq true
+    expect(P('B#a=').is_attribute?).to eq true
   end
 
   it "should not return true for #is_explicit? in created methods" do
     Registry.at(:B).meths.each do |meth|
-      meth.is_explicit?.should == false
+      expect(meth.is_explicit?).to eq false
     end
   end
 
   it "should handle attr call with no arguments" do
-    lambda { StubbedSourceParser.parse_string "attr" }.should_not raise_error
+    expect{ StubbedSourceParser.parse_string "attr" }.to_not raise_error
   end
 
   it "should add existing reader method as part of attr_writer combo" do
-    Registry.at('C#foo=').attr_info[:read].should == Registry.at('C#foo')
+    expect(Registry.at('C#foo=').attr_info[:read]).to eq Registry.at('C#foo')
   end
 
   it "should add existing writer method as part of attr_reader combo" do
-    Registry.at('C#foo').attr_info[:write].should == Registry.at('C#foo=')
+    expect(Registry.at('C#foo').attr_info[:write]).to eq Registry.at('C#foo=')
   end
 
   it "should maintain visibility for attr_reader" do
-    Registry.at('D#parser').visibility.should == :protected
+    expect(Registry.at('D#parser').visibility).to eq :protected
   end
 end

--- a/spec/handlers/base_spec.rb
+++ b/spec/handlers/base_spec.rb
@@ -10,7 +10,7 @@ describe YARD::Handlers::Base do
     end
 
     it "should keep track of subclasses" do
-      Handlers::Base.should_receive(:inherited).once
+      expect(Handlers::Base).to receive(:inherited).once
       class TestHandler < Handlers::Base; end
     end
 
@@ -18,25 +18,25 @@ describe YARD::Handlers::Base do
       class TestNotImplementedHandler < Handlers::Base
       end
 
-      lambda { TestNotImplementedHandler.new(0, 0).process }.should raise_error(NotImplementedError)
+      expect{ TestNotImplementedHandler.new(0, 0).process }.to raise_error(NotImplementedError)
     end
 
     it "should allow multiple handles arguments" do
-      Handlers::Base.should_receive(:inherited).once
+      expect(Handlers::Base).to receive(:inherited).once
       class TestHandler1 < Handlers::Base
         handles :a, :b, :c
       end
-      TestHandler1.handlers.should == [:a, :b, :c]
+      expect(TestHandler1.handlers).to eq [:a, :b, :c]
     end
 
     it "should allow multiple handles calls" do
-      Handlers::Base.should_receive(:inherited).once
+      expect(Handlers::Base).to receive(:inherited).once
       class TestHandler2 < Handlers::Base
         handles :a
         handles :b
         handles :c
       end
-      TestHandler2.handlers.should == [:a, :b, :c]
+      expect(TestHandler2.handlers).to eq [:a, :b, :c]
     end
   end
 
@@ -45,7 +45,7 @@ describe YARD::Handlers::Base do
       class AbortHandler1 < Handlers::Ruby::Base
         process { abort! }
       end
-      lambda { AbortHandler1.new(nil, nil).process }.should raise_error(HandlerAborted)
+      expect{ AbortHandler1.new(nil, nil).process }.to raise_error(HandlerAborted)
     end
   end
 
@@ -61,10 +61,10 @@ describe YARD::Handlers::Base do
           def bar; end
         end
       eof
-      Registry.at('A').tag(:since).text.should == "1.0"
-      Registry.at('A#foo').tag(:since).text.should == "1.0"
-      Registry.at('A#bar').tag(:since).text.should == "1.1"
-      Registry.at('A#bar').tag(:author).should be_nil
+      expect(Registry.at('A').tag(:since).text).to eq "1.0"
+      expect(Registry.at('A#foo').tag(:since).text).to eq "1.0"
+      expect(Registry.at('A#bar').tag(:since).text).to eq "1.1"
+      expect(Registry.at('A#bar').tag(:author)).to be_nil
     end
   end
 
@@ -84,8 +84,8 @@ describe YARD::Handlers::Base do
 
       2.times do
         YARD.parse_string 'class Foo; end; def foo; end'
-        GlobalStateHandler1.state.should == nil
-        GlobalStateHandler2.state.should == :bar
+        expect(GlobalStateHandler1.state).to eq nil
+        expect(GlobalStateHandler2.state).to eq :bar
       end
     end
   end if HAVE_RIPPER
@@ -162,11 +162,11 @@ describe YARD::Handlers::Base do
 
     def test_handler(file, stmts, creates = true, parser_type = :ruby)
       Registry.clear
-      Registry.at('#FOO').should be_nil
+      expect(Registry.at('#FOO')).to be_nil
       create_handler(stmts, parser_type)
       parse(file, parser_type)
       Registry.at('#FOO').send(creates ? :should_not : :should, be_nil)
-      Handlers::Base.subclasses.delete_if {|k,v| k.to_s =~ /^InFileHandler/ }
+      Handlers::Base.subclasses.delete_if {|k,v| k.to_s.match( /^InFileHandler/ ) }
     end
 
     [:ruby, :ruby18].each do |parser_type|

--- a/spec/handlers/c/alias_handler_spec.rb
+++ b/spec/handlers/c/alias_handler_spec.rb
@@ -12,8 +12,8 @@ describe YARD::Handlers::C::AliasHandler do
       }
     eof
 
-    Registry.at('Foo#bar').should be_is_alias
-    Registry.at('Foo#bar').docstring.should == 'FOO'
+    expect(Registry.at('Foo#bar')).to be_is_alias
+    expect(Registry.at('Foo#bar').docstring).to eq 'FOO'
   end
 
   it "should allow defining of aliases (rb_define_alias) of attributes" do
@@ -27,7 +27,7 @@ describe YARD::Handlers::C::AliasHandler do
       }
     eof
 
-    Registry.at('Foo#foo').should be_reader
-    Registry.at('Foo#foo?').should be_is_alias
+    expect(Registry.at('Foo#foo')).to be_reader
+    expect(Registry.at('Foo#foo?')).to be_is_alias
   end
 end

--- a/spec/handlers/c/attribute_handler_spec.rb
+++ b/spec/handlers/c/attribute_handler_spec.rb
@@ -16,25 +16,25 @@ describe YARD::Handlers::C::AttributeHandler do
 
   it "should handle readonly attribute (rb_define_attr)" do
     run(1, 0)
-    Registry.at('Foo#foo').should be_reader
-    Registry.at('Foo#foo=').should be_nil
+    expect(Registry.at('Foo#foo')).to be_reader
+    expect(Registry.at('Foo#foo=')).to be_nil
   end
 
   it "should handle writeonly attribute (rb_define_attr)" do
     run(0, 1)
-    Registry.at('Foo#foo').should be_nil
-    Registry.at('Foo#foo=').should be_writer
+    expect(Registry.at('Foo#foo')).to be_nil
+    expect(Registry.at('Foo#foo=')).to be_writer
   end
 
   it "should handle readwrite attribute (rb_define_attr)" do
     run(1, 1)
-    Registry.at('Foo#foo').should be_reader
-    Registry.at('Foo#foo=').should be_writer
+    expect(Registry.at('Foo#foo')).to be_reader
+    expect(Registry.at('Foo#foo=')).to be_writer
   end
 
   it "should handle commented writeonly attribute (/* rb_define_attr */)" do
     run(1, 1, true)
-    Registry.at('Foo#foo').should be_reader
-    Registry.at('Foo#foo=').should be_writer
+    expect(Registry.at('Foo#foo')).to be_reader
+    expect(Registry.at('Foo#foo=')).to be_writer
   end
 end

--- a/spec/handlers/c/class_handler_spec.rb
+++ b/spec/handlers/c/class_handler_spec.rb
@@ -3,12 +3,12 @@ require File.dirname(__FILE__) + "/spec_helper"
 describe YARD::Handlers::C::ClassHandler do
   it "should register classes" do
     parse_init 'cFoo = rb_define_class("Foo", rb_cObject);'
-    Registry.at('Foo').type.should == :class
+    expect(Registry.at('Foo').type).to eq :class
   end
 
   it "should register classes under namespaces" do
     parse_init 'cFoo = rb_define_class_under(cBar, "Foo", rb_cObject);'
-    Registry.at('Bar::Foo').type.should == :class
+    expect(Registry.at('Bar::Foo').type).to eq :class
   end
 
   it "should remember symbol defined with class" do
@@ -16,8 +16,8 @@ describe YARD::Handlers::C::ClassHandler do
       cXYZ = rb_define_class("Foo", rb_cObject);
       rb_define_method(cXYZ, "bar", bar, 0);
     eof
-    Registry.at('Foo').type.should == :class
-    Registry.at('Foo#bar').should_not be_nil
+    expect(Registry.at('Foo').type).to eq :class
+    expect(Registry.at('Foo#bar')).to_not be_nil
   end
 
   it "should lookup superclass symbol name" do
@@ -25,7 +25,7 @@ describe YARD::Handlers::C::ClassHandler do
       cXYZ = rb_define_class("Foo", rb_cObject);
       cBar = rb_define_class("Bar", cXYZ);
     eof
-    Registry.at('Bar').superclass.should == Registry.at('Foo')
+    expect(Registry.at('Bar').superclass).to eq Registry.at('Foo')
   end
 
   it "should user superclass symbol name as proxy if not found" do
@@ -33,7 +33,7 @@ describe YARD::Handlers::C::ClassHandler do
       // cXYZ = rb_define_class("Foo", rb_cObject);
       cBar = rb_define_class("Bar", cXYZ);
     eof
-    Registry.at('Bar').superclass.should == P('XYZ')
+    expect(Registry.at('Bar').superclass).to eq P('XYZ')
   end
 
   it "should not associate declaration comments as class docstring" do
@@ -41,23 +41,23 @@ describe YARD::Handlers::C::ClassHandler do
       /* Docstring! */
       cFoo = rb_define_class("Foo", cObject);
     eof
-    Registry.at('Foo').docstring.should be_blank
+    expect(Registry.at('Foo').docstring).to be_blank
   end
 
   it "should associate a file with the declaration" do
     parse_init(<<-eof)
       cFoo = rb_define_class("Foo", cObject);
     eof
-    Registry.at('Foo').file.should == '(stdin)'
-    Registry.at('Foo').line.should == 2
+    expect(Registry.at('Foo').file).to eq '(stdin)'
+    expect(Registry.at('Foo').line).to eq 2
   end
 
   it "should properly handle Proxy superclasses" do
     parse_init <<-eof
       cFoo = rb_define_class_under(mFoo, "Bar", rb_cBar);
     eof
-    Registry.at('Foo::Bar').type.should == :class
-    Registry.at('Foo::Bar').superclass.should == P('Bar')
-    Registry.at('Foo::Bar').superclass.type.should == :class
+    expect(Registry.at('Foo::Bar').type).to eq :class
+    expect(Registry.at('Foo::Bar').superclass).to eq P('Bar')
+    expect(Registry.at('Foo::Bar').superclass.type).to eq :class
   end
 end

--- a/spec/handlers/c/constant_handler_spec.rb
+++ b/spec/handlers/c/constant_handler_spec.rb
@@ -6,7 +6,7 @@ describe YARD::Handlers::C::ConstantHandler do
       mFoo = rb_define_module("Foo");
       rb_define_const(mFoo, "FOO", ID2SYM(100));
     eof
-    Registry.at('Foo::FOO').type.should == :constant
+    expect(Registry.at('Foo::FOO').type).to eq :constant
   end
 
   it "should look for override comments" do
@@ -23,17 +23,17 @@ describe YARD::Handlers::C::ConstantHandler do
       }
     eof
     foo = Registry.at('Foo::FOO')
-    foo.type.should == :constant
-    foo.docstring.should == 'Foo bar!'
-    foo.value.should == 'ID2SYM(100)'
-    foo.file.should == '(stdin)'
-    foo.line.should == 8
+    expect(foo.type).to eq :constant
+    expect(foo.docstring).to eq 'Foo bar!'
+    expect(foo.value).to eq 'ID2SYM(100)'
+    expect(foo.file).to eq '(stdin)'
+    expect(foo.line).to eq 8
     bar = Registry.at('Foo::BAR')
-    bar.type.should == :constant
-    bar.docstring.should == 'Foo bar!'
-    bar.file.should == '(stdin)'
-    bar.line.should == 9
-    bar.value.should == 'ID2SYM(101)'
+    expect(bar.type).to eq :constant
+    expect(bar.docstring).to eq 'Foo bar!'
+    expect(bar.file).to eq '(stdin)'
+    expect(bar.line).to eq 9
+    expect(bar.value).to eq 'ID2SYM(101)'
   end
 
   it "should use comment attached to declaration as fallback" do
@@ -42,8 +42,8 @@ describe YARD::Handlers::C::ConstantHandler do
       rb_define_const(mFoo, "FOO", ID2SYM(100)); // foobar!
     eof
     foo = Registry.at('Foo::FOO')
-    foo.value.should == 'ID2SYM(100)'
-    foo.docstring.should == 'foobar!'
+    expect(foo.value).to eq 'ID2SYM(100)'
+    expect(foo.docstring).to eq 'foobar!'
   end
 
   it "should allow the form VALUE: DOCSTRING to document value" do
@@ -52,8 +52,8 @@ describe YARD::Handlers::C::ConstantHandler do
       rb_define_const(mFoo, "FOO", ID2SYM(100)); // 100: foobar!
     eof
     foo = Registry.at('Foo::FOO')
-    foo.value.should == '100'
-    foo.docstring.should == 'foobar!'
+    expect(foo.value).to eq '100'
+    expect(foo.docstring).to eq 'foobar!'
   end
 
   it "should allow escaping of backslashes in VALUE: DOCSTRING syntax" do
@@ -62,7 +62,7 @@ describe YARD::Handlers::C::ConstantHandler do
       rb_define_const(mFoo, "FOO", ID2SYM(100)); // 100\\:x\\:y: foobar:x!
     eof
     foo = Registry.at('Foo::FOO')
-    foo.value.should == '100:x:y'
-    foo.docstring.should == 'foobar:x!'
+    expect(foo.value).to eq '100:x:y'
+    expect(foo.docstring).to eq 'foobar:x!'
   end
 end

--- a/spec/handlers/c/init_handler_spec.rb
+++ b/spec/handlers/c/init_handler_spec.rb
@@ -8,7 +8,7 @@ describe YARD::Handlers::C::InitHandler do
         rb_cA = rb_define_class("A", rb_cObject);
       }
     eof
-    Registry.at('A').docstring.should == 'Bar!'
+    expect(Registry.at('A').docstring).to eq 'Bar!'
   end
 
   it "should not add documentation if ClassName is not created in Init" do
@@ -17,7 +17,7 @@ describe YARD::Handlers::C::InitHandler do
       void Init_A() {
       }
     eof
-    Registry.at('A').should be_nil
+    expect(Registry.at('A')).to be_nil
   end
 
   it "should not overwrite override comment" do
@@ -31,7 +31,7 @@ describe YARD::Handlers::C::InitHandler do
         rb_cA = rb_define_class("A", rb_cObject);
       }
     eof
-    Registry.at('A').docstring.should == 'Foo!'
+    expect(Registry.at('A').docstring).to eq 'Foo!'
   end
 
   it "should check non-Init methods for declarations too" do
@@ -41,7 +41,7 @@ describe YARD::Handlers::C::InitHandler do
         rb_define_method(rb_cB, "foo", foo_impl, 0);
       }
     eof
-    Registry.at('B').should be_a(CodeObjects::ClassObject)
-    Registry.at('B#foo').should be_a(CodeObjects::MethodObject)
+    expect(Registry.at('B')).to be_a(CodeObjects::ClassObject)
+    expect(Registry.at('B#foo')).to be_a(CodeObjects::MethodObject)
   end
 end

--- a/spec/handlers/c/method_handler_spec.rb
+++ b/spec/handlers/c/method_handler_spec.rb
@@ -6,8 +6,8 @@ describe YARD::Handlers::C::MethodHandler do
       mFoo = rb_define_module("Foo");
       rb_define_method(mFoo, "bar", bar, 0);
     eof
-    Registry.at('Foo#bar').should_not be_nil
-    Registry.at('Foo#bar').visibility.should == :public
+    expect(Registry.at('Foo#bar')).to_not be_nil
+    expect(Registry.at('Foo#bar').visibility).to eq :public
   end
 
   it "should register private methods" do
@@ -15,8 +15,8 @@ describe YARD::Handlers::C::MethodHandler do
       mFoo = rb_define_module("Foo");
       rb_define_private_method(mFoo, "bar", bar, 0);
     eof
-    Registry.at('Foo#bar').should_not be_nil
-    Registry.at('Foo#bar').visibility.should == :private
+    expect(Registry.at('Foo#bar')).to_not be_nil
+    expect(Registry.at('Foo#bar').visibility).to eq :private
   end
 
   it "should register singleton methods" do
@@ -24,8 +24,8 @@ describe YARD::Handlers::C::MethodHandler do
       mFoo = rb_define_module("Foo");
       rb_define_singleton_method(mFoo, "bar", bar, 0);
     eof
-    Registry.at('Foo.bar').should_not be_nil
-    Registry.at('Foo.bar').visibility.should == :public
+    expect(Registry.at('Foo.bar')).to_not be_nil
+    expect(Registry.at('Foo.bar').visibility).to eq :public
   end
 
   it "should register module functions" do
@@ -42,21 +42,21 @@ describe YARD::Handlers::C::MethodHandler do
     eof
     bar_c = Registry.at('Foo.bar')
     bar_i = Registry.at('Foo#bar')
-    bar_c.should be_module_function
-    bar_c.visibility.should == :public
-    bar_c.docstring.should == "DOCSTRING"
-    bar_c.tag(:return).object.should == bar_c
-    bar_c.source.should == "static VALUE bar(VALUE self) { x(); y(); z(); }"
-    bar_i.should_not be_module_function
-    bar_i.visibility.should == :private
-    bar_i.docstring.should == "DOCSTRING"
-    bar_i.tag(:return).object.should == bar_i
-    bar_i.source.should == bar_c.source
+    expect(bar_c).to be_module_function
+    expect(bar_c.visibility).to eq :public
+    expect(bar_c.docstring).to eq "DOCSTRING"
+    expect(bar_c.tag(:return).object).to eq bar_c
+    expect(bar_c.source).to eq "static VALUE bar(VALUE self) { x(); y(); z(); }"
+    expect(bar_i).to_not be_module_function
+    expect(bar_i.visibility).to eq :private
+    expect(bar_i.docstring).to eq "DOCSTRING"
+    expect(bar_i.tag(:return).object).to eq bar_i
+    expect(bar_i.source).to eq bar_c.source
   end
 
   it "should register global functions into Kernel" do
     parse_init 'rb_define_global_function("bar", bar, 0);'
-    Registry.at('Kernel#bar').should_not be_nil
+    expect(Registry.at('Kernel#bar')).to_not be_nil
   end
 
   it "should look for symbol containing method source" do
@@ -71,12 +71,12 @@ describe YARD::Handlers::C::MethodHandler do
     eof
     foo = Registry.at('Foo#foo')
     bar = Registry.at('Foo#bar')
-    foo.source.should == "static VALUE foo(VALUE self) { x(); y(); z(); }"
-    foo.file.should == '(stdin)'
-    foo.line.should == 1
-    bar.source.should == "VALUE bar() { a(); b(); c(); }"
-    bar.file.should == '(stdin)'
-    bar.line.should == 2
+    expect(foo.source).to eq "static VALUE foo(VALUE self) { x(); y(); z(); }"
+    expect(foo.file).to eq '(stdin)'
+    expect(foo.line).to eq 1
+    expect(bar.source).to eq "VALUE bar() { a(); b(); c(); }"
+    expect(bar.file).to eq '(stdin)'
+    expect(bar.line).to eq 2
   end
 
   it "should find docstrings attached to method symbols" do
@@ -89,7 +89,7 @@ describe YARD::Handlers::C::MethodHandler do
       }
     eof
     foo = Registry.at('Foo#foo')
-    foo.docstring.should == 'DOCSTRING'
+    expect(foo.docstring).to eq 'DOCSTRING'
   end
 
   it "should use declaration comments as docstring if there are no others" do
@@ -104,9 +104,9 @@ describe YARD::Handlers::C::MethodHandler do
       }
     eof
     foo = Registry.at('Foo#foo')
-    foo.docstring.should == 'DOCSTRING'
+    expect(foo.docstring).to eq 'DOCSTRING'
     bar = Registry.at('Foo#bar')
-    bar.docstring.should == 'DOCSTRING!'
+    expect(bar.docstring).to eq 'DOCSTRING!'
   end
 
   it "should look for symbols in other file" do
@@ -114,7 +114,7 @@ describe YARD::Handlers::C::MethodHandler do
       /* DOCSTRING! */
       static VALUE foo() { x(); }
     eof
-    File.should_receive(:read).with('other.c').and_return(other)
+    expect(File).to receive(:read).with('other.c').and_return(other)
     parse <<-eof
       void Init_Foo() {
         mFoo = rb_define_module("Foo");
@@ -122,14 +122,14 @@ describe YARD::Handlers::C::MethodHandler do
       }
     eof
     foo = Registry.at('Foo#foo')
-    foo.docstring.should == 'DOCSTRING!'
-    foo.file.should == 'other.c'
-    foo.line.should == 2
-    foo.source.should == 'static VALUE foo() { x(); }'
+    expect(foo.docstring).to eq 'DOCSTRING!'
+    expect(foo.file).to eq 'other.c'
+    expect(foo.line).to eq 2
+    expect(foo.source).to eq 'static VALUE foo() { x(); }'
   end
 
   it "should allow extra file to include /'s and other filename characters" do
-    File.should_receive(:read).at_least(1).times.with('ext/a-file.c').and_return(<<-eof)
+    expect(File).to receive(:read).at_least(1).times.with('ext/a-file.c').and_return(<<-eof)
       /* FOO */
       VALUE foo(VALUE x) { int value = x; }
 
@@ -140,12 +140,12 @@ describe YARD::Handlers::C::MethodHandler do
       rb_define_method(rb_cFoo, "foo", foo, 1); /* in ext/a-file.c */
       rb_define_global_function("bar", bar, 1); /* in ext/a-file.c */
     eof
-    Registry.at('Foo#foo').docstring.should == 'FOO'
-    Registry.at('Kernel#bar').docstring.should == 'BAR'
+    expect(Registry.at('Foo#foo').docstring).to eq 'FOO'
+    expect(Registry.at('Kernel#bar').docstring).to eq 'BAR'
   end
 
   it "should warn if other file can't be found" do
-    log.should_receive(:warn).with(/Missing source file `other.c' when parsing Foo#foo/)
+    expect(log).to receive(:warn).with(/Missing source file `other.c' when parsing Foo#foo/)
     parse <<-eof
       void Init_Foo() {
         mFoo = rb_define_module("Foo");
@@ -171,9 +171,9 @@ describe YARD::Handlers::C::MethodHandler do
         rb_define_method(mBar, "baz", foo, 0);
       }
     eof
-    Registry.at('Foo#foo').docstring.should == 'Foo bar!'
-    Registry.at('Foo#initialize').docstring.should == 'Foo bar!'
-    Registry.at('Foo::Bar#baz').docstring.should == 'Foo bar!'
+    expect(Registry.at('Foo#foo').docstring).to eq 'Foo bar!'
+    expect(Registry.at('Foo#initialize').docstring).to eq 'Foo bar!'
+    expect(Registry.at('Foo::Bar#baz').docstring).to eq 'Foo bar!'
   end
 
   it "should look at overrides in other files" do
@@ -184,7 +184,7 @@ describe YARD::Handlers::C::MethodHandler do
        * Foo bar!
        */
     eof
-    File.should_receive(:read).with('foo/bar/other.c').and_return(other)
+    expect(File).to receive(:read).with('foo/bar/other.c').and_return(other)
     src = <<-eof
       void Init_Foo() {
         mFoo = rb_define_module("Foo");
@@ -195,9 +195,9 @@ describe YARD::Handlers::C::MethodHandler do
       }
     eof
     parse(src, 'foo/bar/baz/init.c')
-    Registry.at('Foo#foo').docstring.should == 'Foo bar!'
-    Registry.at('Foo#initialize').docstring.should == 'Foo bar!'
-    Registry.at('Foo::Bar#baz').docstring.should == 'Foo bar!'
+    expect(Registry.at('Foo#foo').docstring).to eq 'Foo bar!'
+    expect(Registry.at('Foo#initialize').docstring).to eq 'Foo bar!'
+    expect(Registry.at('Foo::Bar#baz').docstring).to eq 'Foo bar!'
   end
 
   it "should add return tag on methods ending in '?'" do
@@ -210,8 +210,8 @@ describe YARD::Handlers::C::MethodHandler do
       }
     eof
     foo = Registry.at('Foo#foo?')
-    foo.docstring.should == 'DOCSTRING'
-    foo.tag(:return).types.should == ['Boolean']
+    expect(foo.docstring).to eq 'DOCSTRING'
+    expect(foo.tag(:return).types).to eq ['Boolean']
   end
 
   it "should not add return tag if return tags exist" do
@@ -224,7 +224,7 @@ describe YARD::Handlers::C::MethodHandler do
       }
     eof
     foo = Registry.at('Foo#foo?')
-    foo.tag(:return).types.should == ['String']
+    expect(foo.tag(:return).types).to eq ['String']
   end
 
   it "should handle casted method names" do
@@ -233,7 +233,7 @@ describe YARD::Handlers::C::MethodHandler do
       rb_define_method(mFoo, "bar", (METHOD)bar, 0);
       rb_define_global_function("baz", (METHOD)baz, 0);
     eof
-    Registry.at('Foo#bar').should_not be_nil
-    Registry.at('Kernel#baz').should_not be_nil
+    expect(Registry.at('Foo#bar')).to_not be_nil
+    expect(Registry.at('Kernel#baz')).to_not be_nil
   end
 end

--- a/spec/handlers/c/mixin_handler_spec.rb
+++ b/spec/handlers/c/mixin_handler_spec.rb
@@ -12,8 +12,8 @@ describe YARD::Handlers::C::MixinHandler do
     foo = Registry.at('Foo')
     bar = Registry.at('Bar')
     baz = Registry.at('Baz')
-    bar.mixins(:instance).should == [foo]
-    baz.mixins(:instance).should == [foo]
+    expect(bar.mixins(:instance)).to eq [foo]
+    expect(baz.mixins(:instance)).to eq [foo]
   end
 
   it "should add include as proxy if symbol lookup fails" do
@@ -22,6 +22,6 @@ describe YARD::Handlers::C::MixinHandler do
       rb_include_module(mFoo, mXYZ);
     eof
     foo = Registry.at('Foo')
-    foo.mixins(:instance).should == [P('XYZ')]
+    expect(foo.mixins(:instance)).to eq [P('XYZ')]
   end
 end

--- a/spec/handlers/c/module_handler_spec.rb
+++ b/spec/handlers/c/module_handler_spec.rb
@@ -3,12 +3,12 @@ require File.dirname(__FILE__) + "/spec_helper"
 describe YARD::Handlers::C::ClassHandler do
   it "should register modules" do
     parse_init 'mFoo = rb_define_module("Foo");'
-    Registry.at('Foo').type.should == :module
+    expect(Registry.at('Foo').type).to eq :module
   end
 
   it "should register classes under namespaces" do
     parse_init 'mFoo = rb_define_module_under(mBar, "Foo");'
-    Registry.at('Bar::Foo').type.should == :module
+    expect(Registry.at('Bar::Foo').type).to eq :module
   end
 
   it "should remember symbol defined with class" do
@@ -16,8 +16,8 @@ describe YARD::Handlers::C::ClassHandler do
       cXYZ = rb_define_module("Foo");
       rb_define_method(cXYZ, "bar", bar, 0);
     eof
-    Registry.at('Foo').type.should == :module
-    Registry.at('Foo#bar').should_not be_nil
+    expect(Registry.at('Foo').type).to eq :module
+    expect(Registry.at('Foo#bar')).to_not be_nil
   end
 
   it "should not associate declaration comments as module docstring" do
@@ -25,14 +25,14 @@ describe YARD::Handlers::C::ClassHandler do
       /* Docstring! */
       mFoo = rb_define_module("Foo");
     eof
-    Registry.at('Foo').docstring.should be_blank
+    expect(Registry.at('Foo').docstring).to be_blank
   end
 
   it "should associate a file with the declaration" do
     parse_init(<<-eof)
       mFoo = rb_define_module("Foo");
     eof
-    Registry.at('Foo').file.should == '(stdin)'
-    Registry.at('Foo').line.should == 2
+    expect(Registry.at('Foo').file).to eq '(stdin)'
+    expect(Registry.at('Foo').line).to eq 2
   end
 end

--- a/spec/handlers/c/override_comment_handler_spec.rb
+++ b/spec/handlers/c/override_comment_handler_spec.rb
@@ -10,10 +10,10 @@ describe YARD::Handlers::C::OverrideCommentHandler do
          */
         void
       eof
-      Registry.at('A').type.should == type
-      Registry.at('A').docstring.should == 'Foo bar baz'
-      Registry.at('A').file.should == '(stdin)'
-      Registry.at('A').line.should == 2
+      expect(Registry.at('A').type).to eq type
+      expect(Registry.at('A').docstring).to eq 'Foo bar baz'
+      expect(Registry.at('A').file).to eq '(stdin)'
+      expect(Registry.at('A').line).to eq 2
     end
   end
 
@@ -25,9 +25,9 @@ describe YARD::Handlers::C::OverrideCommentHandler do
        * Foo bar baz
        */
     eof
-    Registry.at('A').docstring.should == 'Foo bar baz'
-    Registry.at('B').docstring.should == 'Foo bar baz'
-    Registry.at('C').docstring.should == 'Foo bar baz'
+    expect(Registry.at('A').docstring).to eq 'Foo bar baz'
+    expect(Registry.at('B').docstring).to eq 'Foo bar baz'
+    expect(Registry.at('C').docstring).to eq 'Foo bar baz'
     Registry.at('C').type == :module
   end
 
@@ -39,8 +39,8 @@ describe YARD::Handlers::C::OverrideCommentHandler do
       void
     eof
     obj = Registry.at('A')
-    obj.type.should == :class
-    obj.docstring.should == 'Foo bar baz'
-    obj.superclass.should == P('B')
+    expect(obj.type).to eq :class
+    expect(obj.docstring).to eq 'Foo bar baz'
+    expect(obj.superclass).to eq P('B')
   end
 end

--- a/spec/handlers/c/path_handler_spec.rb
+++ b/spec/handlers/c/path_handler_spec.rb
@@ -7,8 +7,8 @@ describe YARD::Handlers::C::PathHandler do
       cBar = rb_define_class_under(mFoo, "Bar", rb_cObject);
       rb_define_method(cBar, "foo", foo, 1);
     eof
-    Registry.at('Foo::Bar').should_not be_nil
-    Registry.at('Foo::Bar#foo').should_not be_nil
+    expect(Registry.at('Foo::Bar')).to_not be_nil
+    expect(Registry.at('Foo::Bar#foo')).to_not be_nil
   end
 
   it 'should track variable names defined under namespaces' do
@@ -18,8 +18,8 @@ describe YARD::Handlers::C::PathHandler do
       mBaz = rb_define_module_under(cBar, "Baz");
       rb_define_method(mBaz, "foo", foo, 1);
     eof
-    Registry.at('Foo::Bar::Baz').should_not be_nil
-    Registry.at('Foo::Bar::Baz#foo').should_not be_nil
+    expect(Registry.at('Foo::Bar::Baz')).to_not be_nil
+    expect(Registry.at('Foo::Bar::Baz#foo')).to_not be_nil
   end
 
   it "should handle rb_path2class() calls" do
@@ -30,6 +30,6 @@ describe YARD::Handlers::C::PathHandler do
       mBaz = rb_define_module_under(cBar, "Baz");
       rb_define_method(somePath, "foo", foo, 1);
     eof
-    Registry.at('Foo::Bar::Baz#foo').should_not be_nil
+    expect(Registry.at('Foo::Bar::Baz#foo')).to_not be_nil
   end
 end

--- a/spec/handlers/c/struct_handler_spec.rb
+++ b/spec/handlers/c/struct_handler_spec.rb
@@ -9,7 +9,7 @@ describe YARD::Handlers::C::StructHandler do
           "Range", rb_cFoo, range_alloc,
           "begin", "end", "excl", NULL);
     eof
-    Registry.at('Range').type.should == :class
-    Registry.at('Range').superclass.should == P(:Foo)
+    expect(Registry.at('Range').type).to eq :class
+    expect(Registry.at('Range').superclass).to eq P(:Foo)
   end
 end

--- a/spec/handlers/class_condition_handler_spec.rb
+++ b/spec/handlers/class_condition_handler_spec.rb
@@ -4,12 +4,12 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassCondition
   before(:all) { parse_file :class_condition_handler_001, __FILE__ }
 
   def verify_method(*names)
-    names.each {|name| Registry.at("A##{name}").should_not be_nil }
-    names.each {|name| Registry.at("A##{name}not").should be_nil }
+    names.each {|name| expect(Registry.at("A##{name}")).to_not be_nil }
+    names.each {|name| expect(Registry.at("A##{name}not")).to be_nil }
   end
 
   def no_undoc_error(code)
-    lambda { StubbedSourceParser.parse_string(code) }.should_not raise_error
+    expect{ StubbedSourceParser.parse_string(code) }.to_not raise_error
   end
 
   it "should parse all unless blocks for complex conditions" do
@@ -49,19 +49,19 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassCondition
   end
 
   it "should maintain visibility and scope state inside condition" do
-    Registry.at('A#m').visibility.should == :private
-    Registry.at('A#mnot').visibility.should == :private
+    expect(Registry.at('A#m').visibility).to eq :private
+    expect(Registry.at('A#mnot').visibility).to eq :private
   end
 
   it "should not fail on complex conditions" do
-    log.should_not_receive(:warn)
-    log.should_not_receive(:error)
+    expect(log).to_not receive(:warn)
+    expect(log).to_not receive(:error)
     no_undoc_error "if defined?(A) && defined?(B); puts 'hi' end"
     no_undoc_error(<<-eof)
       (<<-TEST) unless defined?(ABCD_MODEL_TEST)
         'String'
       TEST
     eof
-    no_undoc_error "if caller.none? { |l| l =~ %r{lib/rails/generators\\.rb:(\\d+):in `lookup!'$} }; end"
+    no_undoc_error "if caller.none? { |l| l.match( %r{lib/rails/generators\\.rb:(\\d+):in `lookup!'$} ) }; end"
   end
 end

--- a/spec/handlers/class_variable_handler_spec.rb
+++ b/spec/handlers/class_variable_handler_spec.rb
@@ -5,7 +5,7 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassVariableH
 
   it "should not parse class variables inside methods" do
     obj = Registry.at("A::B::@@somevar")
-    obj.source.should == "@@somevar = \"hello\""
-    obj.value.should == '"hello"'
+    expect(obj.source).to eq "@@somevar = \"hello\""
+    expect(obj.value).to eq '"hello"'
   end
 end

--- a/spec/handlers/constant_handler_spec.rb
+++ b/spec/handlers/constant_handler_spec.rb
@@ -4,58 +4,58 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ConstantHandle
   before(:all) { parse_file :constant_handler_001, __FILE__ }
 
   it "should not parse constants inside methods" do
-    Registry.at("A::B::SOMECONSTANT").source.should == "SOMECONSTANT= \"hello\""
+    expect(Registry.at("A::B::SOMECONSTANT").source).to eq "SOMECONSTANT= \"hello\""
   end
 
   it "should only parse valid constants" do
-    Registry.at("A::B::notaconstant").should be_nil
+    expect(Registry.at("A::B::notaconstant")).to be_nil
   end
 
   it "should maintain newlines" do
-    Registry.at("A::B::MYCONSTANT").value.gsub("\r", "").should == "A +\nB +\nC +\nD"
+    expect(Registry.at("A::B::MYCONSTANT").value.gsub("\r", "")).to eq "A +\nB +\nC +\nD"
   end
 
   it "should turn Const = Struct.new(:sym) into class Const with attr :sym" do
     obj = Registry.at("MyClass")
-    obj.should be_kind_of(CodeObjects::ClassObject)
+    expect(obj).to be_kind_of(CodeObjects::ClassObject)
     attrs = obj.attributes[:instance]
     [:a, :b, :c].each do |key|
-      attrs.should have_key(key)
-      attrs[key][:read].should_not be_nil
-      attrs[key][:write].should_not be_nil
+      expect(attrs).to have_key(key)
+      expect(attrs[key][:read]).to_not be_nil
+      expect(attrs[key][:write]).to_not be_nil
     end
   end
 
   it "should turn Const = Struct.new('Name', :sym) into class Const with attr :sym" do
     obj = Registry.at("NotMyClass")
-    obj.should be_kind_of(CodeObjects::ClassObject)
+    expect(obj).to be_kind_of(CodeObjects::ClassObject)
     attrs = obj.attributes[:instance]
     [:b, :c].each do |key|
-      attrs.should have_key(key)
-      attrs[key][:read].should_not be_nil
-      attrs[key][:write].should_not be_nil
+      expect(attrs).to have_key(key)
+      expect(attrs[key][:read]).to_not be_nil
+      expect(attrs[key][:write]).to_not be_nil
     end
 
-    Registry.at("NotMyClass2").should be_nil
+    expect(Registry.at("NotMyClass2")).to be_nil
   end
 
   it "should turn Const = Struct.new into empty struct" do
     obj = Registry.at("MyEmptyStruct")
-    obj.should_not be_nil
-    obj.attributes[:instance].should be_empty
+    expect(obj).to_not be_nil
+    expect(obj.attributes[:instance]).to be_empty
   end
 
   it "should maintain docstrings on structs defined via constants" do
     obj = Registry.at("DocstringStruct")
-    obj.should_not be_nil
-    obj.docstring.should == "A crazy struct."
-    obj.attributes[:instance].should_not be_empty
+    expect(obj).to_not be_nil
+    expect(obj.docstring).to eq "A crazy struct."
+    expect(obj.attributes[:instance]).to_not be_empty
     a1 = Registry.at("DocstringStruct#bar")
     a2 = Registry.at("DocstringStruct#baz")
-    a1.docstring.should == "An attr"
-    a1.tag(:return).types.should == ["String"]
-    a2.docstring.should == "Another attr"
-    a2.tag(:return).types.should == ["Number"]
+    expect(a1.docstring).to eq "An attr"
+    expect(a1.tag(:return).types).to eq ["String"]
+    expect(a2.docstring).to eq "Another attr"
+    expect(a2.tag(:return).types).to eq ["Number"]
   end
 
   it "should raise undocumentable error in 1.9 parser for Struct.new assignment to non-const" do

--- a/spec/handlers/dsl_handler_spec.rb
+++ b/spec/handlers/dsl_handler_spec.rb
@@ -6,184 +6,184 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}DSLHandler" do
 
   it "should create a readable attribute when @!attribute r is found" do
     obj = Registry.at('Foo#attr1')
-    obj.should_not be_nil
-    obj.should be_reader
-    obj.tag(:return).types.should == ['Numeric']
-    Registry.at('Foo#attr1=').should be_nil
+    expect(obj).to_not be_nil
+    expect(obj).to be_reader
+    expect(obj.tag(:return).types).to eq ['Numeric']
+    expect(Registry.at('Foo#attr1=')).to be_nil
   end
 
   it "should create a writable attribute when @!attribute w is found" do
     obj = Registry.at('Foo#attr2=')
-    obj.should_not be_nil
-    obj.should be_writer
-    Registry.at('Foo#attr2').should be_nil
+    expect(obj).to_not be_nil
+    expect(obj).to be_writer
+    expect(Registry.at('Foo#attr2')).to be_nil
   end
 
   it "should default to readwrite @!attribute" do
     obj = Registry.at('Foo#attr3')
-    obj.should_not be_nil
-    obj.should be_reader
+    expect(obj).to_not be_nil
+    expect(obj).to be_reader
     obj = Registry.at('Foo#attr3=')
-    obj.should_not be_nil
-    obj.should be_writer
+    expect(obj).to_not be_nil
+    expect(obj).to be_writer
   end
 
   it "should allow @!attribute to define alternate method name" do
-    Registry.at('Foo#attr4').should be_nil
-    Registry.at('Foo#custom').should_not be_nil
+    expect(Registry.at('Foo#attr4')).to be_nil
+    expect(Registry.at('Foo#custom')).to_not be_nil
   end
 
   it "should default to creating an instance method for any DSL method with special tags" do
     obj = Registry.at('Foo#implicit0')
-    obj.should_not be_nil
-    obj.docstring.should == "IMPLICIT METHOD!"
-    obj.tag(:return).types.should == ['String']
+    expect(obj).to_not be_nil
+    expect(obj.docstring).to eq "IMPLICIT METHOD!"
+    expect(obj.tag(:return).types).to eq ['String']
   end
 
   it "should recognize implicit docstring when it has scope tag" do
     obj = Registry.at("Foo.implicit1")
-    obj.should_not be_nil
-    obj.scope.should == :class
+    expect(obj).to_not be_nil
+    expect(obj.scope).to eq :class
   end
 
   it "should recognize implicit docstring when it has visibility tag" do
     obj = Registry.at("Foo#implicit2")
-    obj.should_not be_nil
-    obj.visibility.should == :protected
+    expect(obj).to_not be_nil
+    expect(obj.visibility).to eq :protected
   end
 
   it "should not recognize implicit docstring with any other normal tag" do
     obj = Registry.at('Foo#implicit_invalid3')
-    obj.should be_nil
+    expect(obj).to be_nil
   end
 
   it "should set the method name when using @!method" do
     obj = Registry.at('Foo.xyz')
-    obj.should_not be_nil
-    obj.signature.should == 'def xyz(a, b, c)'
-    obj.parameters.should == [['a', nil], ['b', nil], ['c', nil]]
-    obj.source.should == 'foo_bar'
-    obj.docstring.should == 'The foo method'
+    expect(obj).to_not be_nil
+    expect(obj.signature).to eq 'def xyz(a, b, c)'
+    expect(obj.parameters).to eq [['a', nil], ['b', nil], ['c', nil]]
+    expect(obj.source).to eq 'foo_bar'
+    expect(obj.docstring).to eq 'The foo method'
   end
 
   it "should allow setting of @!scope" do
-    Registry.at('Foo.xyz').scope.should == :class
+    expect(Registry.at('Foo.xyz').scope).to eq :class
   end
 
   it "should create module function if @!scope is module" do
     mod_c = Registry.at('Foo.modfunc1')
     mod_i = Registry.at('Foo#modfunc1')
-    mod_c.scope.should == :class
-    mod_i.visibility.should == :private
+    expect(mod_c.scope).to eq :class
+    expect(mod_i.visibility).to eq :private
   end
 
   it "should allow setting of @!visibility" do
-    Registry.at('Foo.xyz').visibility.should == :protected
+    expect(Registry.at('Foo.xyz').visibility).to eq :protected
   end
 
   it "should ignore DSL methods without tags" do
-    Registry.at('Foo#implicit_invalid').should be_nil
+    expect(Registry.at('Foo#implicit_invalid')).to be_nil
   end
 
   it "should accept a DSL method without tags if it has hash_flag (##)" do
-    Registry.at('Foo#implicit_valid').should_not be_nil
-    Registry.at('Foo#implicit_invalid2').should be_nil
+    expect(Registry.at('Foo#implicit_valid')).to_not be_nil
+    expect(Registry.at('Foo#implicit_invalid2')).to be_nil
   end
 
   it "should allow creation of macros" do
     macro = CodeObjects::MacroObject.find('property')
-    macro.should_not be_nil
-    macro.should_not be_attached
-    macro.method_object.should be_nil
+    expect(macro).to_not be_nil
+    expect(macro).to_not be_attached
+    expect(macro.method_object).to be_nil
   end
 
   it "should handle macros with no parameters to expand" do
-    Registry.at('Foo#none').should_not be_nil
-    Registry.at('Baz#none').signature.should == 'def none(foo, bar)'
+    expect(Registry.at('Foo#none')).to_not be_nil
+    expect(Registry.at('Baz#none').signature).to eq 'def none(foo, bar)'
   end
 
   it "should expand $N on method definitions" do
-    Registry.at('Foo#regular_meth').docstring.should == 'a b c'
+    expect(Registry.at('Foo#regular_meth').docstring).to eq 'a b c'
   end
 
   it "should apply new macro docstrings on new objects" do
     obj = Registry.at('Foo#name')
-    obj.should_not be_nil
-    obj.source.should == 'property :name, String, :a, :b, :c'
-    obj.signature.should == 'def name(a, b, c)'
-    obj.docstring.should == 'A property that is awesome.'
-    obj.tag(:param).name.should == 'a'
-    obj.tag(:param).text.should == 'first parameter'
-    obj.tag(:return).types.should == ['String']
-    obj.tag(:return).text.should == 'the property name'
+    expect(obj).to_not be_nil
+    expect(obj.source).to eq 'property :name, String, :a, :b, :c'
+    expect(obj.signature).to eq 'def name(a, b, c)'
+    expect(obj.docstring).to eq 'A property that is awesome.'
+    expect(obj.tag(:param).name).to eq 'a'
+    expect(obj.tag(:param).text).to eq 'first parameter'
+    expect(obj.tag(:return).types).to eq ['String']
+    expect(obj.tag(:return).text).to eq 'the property name'
   end
 
   it "should allow reuse of named macros" do
     obj = Registry.at('Foo#age')
-    obj.should_not be_nil
-    obj.source.should == 'property :age, Fixnum, :value'
-    obj.signature.should == 'def age(value)'
-    obj.docstring.should == 'A property that is awesome.'
-    obj.tag(:param).name.should == 'value'
-    obj.tag(:param).text.should == 'first parameter'
-    obj.tag(:return).types.should == ['Fixnum']
-    obj.tag(:return).text.should == 'the property age'
+    expect(obj).to_not be_nil
+    expect(obj.source).to eq 'property :age, Fixnum, :value'
+    expect(obj.signature).to eq 'def age(value)'
+    expect(obj.docstring).to eq 'A property that is awesome.'
+    expect(obj.tag(:param).name).to eq 'value'
+    expect(obj.tag(:param).text).to eq 'first parameter'
+    expect(obj.tag(:return).types).to eq ['Fixnum']
+    expect(obj.tag(:return).text).to eq 'the property age'
   end
 
   it "should know about method information on DSL with macro expansion" do
-    Registry.at('Foo#right_name').should_not be_nil
-    Registry.at('Foo#right_name').source.should ==
-      'implicit_with_different_method_name :wrong, :right'
-    Registry.at('Foo#wrong_name').should be_nil
+    expect(Registry.at('Foo#right_name')).to_not be_nil
+    expect(Registry.at('Foo#right_name').source)
+      .to eq 'implicit_with_different_method_name :wrong, :right'
+    expect(Registry.at('Foo#wrong_name')).to be_nil
   end
 
   it "should use attached macros" do
     macro = CodeObjects::MacroObject.find('parser')
-    macro.macro_data.should == "@!method $1(opts = {})\n@return NOTHING!"
-    macro.should_not be_nil
-    macro.should be_attached
-    macro.method_object.should == P('Foo.parser')
+    expect(macro.macro_data).to eq "@!method $1(opts = {})\n@return NOTHING!"
+    expect(macro).to_not be_nil
+    expect(macro).to be_attached
+    expect(macro.method_object).to eq P('Foo.parser')
     obj = Registry.at('Foo#c_parser')
-    obj.should_not be_nil
-    obj.docstring.should == ""
-    obj.signature.should == "def c_parser(opts = {})"
-    obj.docstring.tag(:return).text.should == "NOTHING!"
+    expect(obj).to_not be_nil
+    expect(obj.docstring).to eq ""
+    expect(obj.signature).to eq "def c_parser(opts = {})"
+    expect(obj.docstring.tag(:return).text).to eq "NOTHING!"
   end
 
   it "should append docstring on DSL method to attached macro" do
     obj = Registry.at('Foo#d_parser')
-    obj.should_not be_nil
-    obj.docstring.should == "Another docstring"
-    obj.signature.should == "def d_parser(opts = {})"
-    obj.docstring.tag(:return).text.should == "NOTHING!"
+    expect(obj).to_not be_nil
+    expect(obj.docstring).to eq "Another docstring"
+    expect(obj.signature).to eq "def d_parser(opts = {})"
+    expect(obj.docstring.tag(:return).text).to eq "NOTHING!"
   end
 
   it "should only use attached macros on methods defined in inherited hierarchy" do
-    Registry.at('Bar#x_parser').should be_nil
-    Registry.at('Baz#y_parser').should_not be_nil
+    expect(Registry.at('Bar#x_parser')).to be_nil
+    expect(Registry.at('Baz#y_parser')).to_not be_nil
   end
 
   it "should look through mixins for attached macros" do
     meth = Registry.at('Baz#mixin_method')
-    meth.should_not be_nil
-    meth.docstring.should == 'DSL method mixin_method'
+    expect(meth).to_not be_nil
+    expect(meth.docstring).to eq 'DSL method mixin_method'
   end
 
   it "should handle top-level DSL methods" do
     obj = Registry.at('#my_other_method')
-    obj.should_not be_nil
-    obj.docstring.should == "Docstring for method"
+    expect(obj).to_not be_nil
+    expect(obj.docstring).to eq "Docstring for method"
   end
 
   it "should handle Constant.foo syntax" do
     obj = Registry.at('#beep')
-    obj.should_not be_nil
-    obj.signature.should == 'def beep(a, b, c)'
+    expect(obj).to_not be_nil
+    expect(obj.signature).to eq 'def beep(a, b, c)'
   end
 
   it "should expand attached macros in first DSL method" do
-    Registry.at('DSLMethods#foo').docstring.should == "Returns String for foo"
-    Registry.at('DSLMethods#bar').docstring.should == "Returns Integer for bar"
+    expect(Registry.at('DSLMethods#foo').docstring).to eq "Returns String for foo"
+    expect(Registry.at('DSLMethods#bar').docstring).to eq "Returns Integer for bar"
   end
 
   it "should not detect implicit macros with invalid method names" do

--- a/spec/handlers/exception_handler_spec.rb
+++ b/spec/handlers/exception_handler_spec.rb
@@ -4,45 +4,45 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ExceptionHandl
   before(:all) { parse_file :exception_handler_001, __FILE__ }
 
   it "should not document an exception outside of a method" do
-    P('Testing').has_tag?(:raise).should == false
+    expect(P('Testing').has_tag?(:raise)).to eq false
   end
 
   it "should document a valid raise" do
-    P('Testing#mymethod').tag(:raise).types.should == ['ArgumentError']
+    expect(P('Testing#mymethod').tag(:raise).types).to eq ['ArgumentError']
   end
 
   it "should only document non-dynamic raises" do
-    P('Testing#mymethod2').tag(:raise).should be_nil
-    P('Testing#mymethod6').tag(:raise).should be_nil
-    P('Testing#mymethod7').tag(:raise).should be_nil
+    expect(P('Testing#mymethod2').tag(:raise)).to be_nil
+    expect(P('Testing#mymethod6').tag(:raise)).to be_nil
+    expect(P('Testing#mymethod7').tag(:raise)).to be_nil
   end
 
   it "should treat ConstantName.new as a valid exception class" do
-    P('Testing#mymethod8').tag(:raise).types.should == ['ExceptionClass']
+    expect(P('Testing#mymethod8').tag(:raise).types).to eq ['ExceptionClass']
   end
 
   it "should not document a method with an existing @raise tag" do
-    P('Testing#mymethod3').tag(:raise).types.should == ['A']
+    expect(P('Testing#mymethod3').tag(:raise).types).to eq ['A']
   end
 
   it "should only document the first raise message of a method (limitation of exception handler)" do
-    P('Testing#mymethod4').tag(:raise).types.should == ['A']
+    expect(P('Testing#mymethod4').tag(:raise).types).to eq ['A']
   end
 
   it "should handle complex class names" do
-    P('Testing#mymethod5').tag(:raise).types.should == ['YARD::Parser::UndocumentableError']
+    expect(P('Testing#mymethod5').tag(:raise).types).to eq ['YARD::Parser::UndocumentableError']
   end
 
   it "should ignore any raise calls on a receiver" do
-    P('Testing#mymethod9').tag(:raise).should be_nil
+    expect(P('Testing#mymethod9').tag(:raise)).to be_nil
   end
 
   it "should handle raise expressions that are method calls" do
-    P('Testing#mymethod10').tag(:raise).should be_nil
-    P('Testing#mymethod11').tag(:raise).should be_nil
+    expect(P('Testing#mymethod10').tag(:raise)).to be_nil
+    expect(P('Testing#mymethod11').tag(:raise)).to be_nil
   end
 
   it "should ignore empty raise call" do
-    P('Testing#mymethod12').tag(:raise).should be_nil
+    expect(P('Testing#mymethod12').tag(:raise)).to be_nil
   end
 end

--- a/spec/handlers/extend_handler_spec.rb
+++ b/spec/handlers/extend_handler_spec.rb
@@ -4,17 +4,17 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ExtendHandler"
   before(:all) { parse_file :extend_handler_001, __FILE__ }
 
   it "should include modules at class scope" do
-    Registry.at(:B).class_mixins.should == [P(:A)]
-    Registry.at(:B).instance_mixins.should be_empty
+    expect(Registry.at(:B).class_mixins).to eq [P(:A)]
+    expect(Registry.at(:B).instance_mixins).to be_empty
   end
 
   it "should handle a module extending itself" do
-    Registry.at(:C).class_mixins.should == [P(:C)]
-    Registry.at(:C).instance_mixins.should be_empty
+    expect(Registry.at(:C).class_mixins).to eq [P(:C)]
+    expect(Registry.at(:C).instance_mixins).to be_empty
   end
 
   it "should extend module with correct namespace" do
-    Registry.at('Q::R::S').class_mixins.first.path.should == 'A'
+    expect(Registry.at('Q::R::S').class_mixins.first.path).to eq 'A'
   end
 
   it "should not allow extending self if object is a class" do

--- a/spec/handlers/legacy_base_spec.rb
+++ b/spec/handlers/legacy_base_spec.rb
@@ -11,54 +11,54 @@ describe YARD::Handlers::Ruby::Legacy::Base, "#tokval" do
   end
 
   it "should return the String's value without quotes" do
-    tokval('"hello"').should == "hello"
+    expect(tokval('"hello"')).to eq "hello"
   end
 
   it "should not allow interpolated strings with TkSTRING" do
-    tokval('"#{c}"', RubyToken::TkSTRING).should be_nil
+    expect(tokval('"#{c}"', RubyToken::TkSTRING)).to be_nil
   end
 
   it "should return a Symbol's value as a String (as if it was done via :name.to_sym)" do
-    tokval(':sym').should == :sym
+    expect(tokval(':sym')).to eq :sym
   end
 
   it "should return nil for any non accepted type" do
-    tokval('identifier').should be_nil
-    tokval(':sym', RubyToken::TkId).should be_nil
+    expect(tokval('identifier')).to be_nil
+    expect(tokval(':sym', RubyToken::TkId)).to be_nil
   end
 
   it "should accept TkVal tokens by default" do
-    tokval('2.5').should == 2.5
-    tokval(':sym').should == :sym
+    expect(tokval('2.5')).to eq 2.5
+    expect(tokval(':sym')).to eq :sym
   end
 
   it "should accept any ID type if TkId is set" do
-    tokval('variable', RubyToken::TkId).should == "variable"
-    tokval('CONSTANT', RubyToken::TkId).should == "CONSTANT"
+    expect(tokval('variable', RubyToken::TkId)).to eq "variable"
+    expect(tokval('CONSTANT', RubyToken::TkId)).to eq "CONSTANT"
   end
 
   it "should allow extra token types to be accepted" do
-    tokval('2.5', RubyToken::TkFLOAT).should == 2.5
-    tokval('2', RubyToken::TkFLOAT).should be_nil
-    tokval(':symbol', RubyToken::TkFLOAT).should be_nil
+    expect(tokval('2.5', RubyToken::TkFLOAT)).to eq 2.5
+    expect(tokval('2', RubyToken::TkFLOAT)).to be_nil
+    expect(tokval(':symbol', RubyToken::TkFLOAT)).to be_nil
   end
 
   it "should allow :string for any string type" do
-    tokval('"hello"', :string).should == "hello"
-    tokval('"#{c}"', :string).should == '#{c}'
+    expect(tokval('"hello"', :string)).to eq "hello"
+    expect(tokval('"#{c}"', :string)).to eq '#{c}'
   end
 
   it "should not include interpolated strings when using :attr" do
-    tokval('"#{c}"', :attr).should be_nil
+    expect(tokval('"#{c}"', :attr)).to be_nil
   end
 
   it "should allow any number type with :number" do
-    tokval('2.5', :number).should == 2.5
-    tokval('2', :number).should == 2
+    expect(tokval('2.5', :number)).to eq 2.5
+    expect(tokval('2', :number)).to eq 2
   end
 
   it "should should allow method names with :identifier" do
-    tokval('methodname?', :identifier).should == "methodname?"
+    expect(tokval('methodname?', :identifier)).to eq "methodname?"
   end
 
   #it "should obey documentation expectations" do docspec end
@@ -72,57 +72,57 @@ describe YARD::Handlers::Base, "#tokval_list" do
   end
 
   it "should return the list of tokvalues" do
-    tokval_list(":a, :b, \"\#{c}\", 'd'", :attr).should == [:a, :b, 'd']
-    tokval_list(":a, :b, File.read(\"\#{c}\", ['w']), :d",
-      RubyToken::Token).should  == [:a, :b, 'File.read("#{c}", [\'w\'])', :d]
+    expect(tokval_list(":a, :b, \"\#{c}\", 'd'", :attr)).to match_array( [:a, :b, 'd'] )
+    expect(tokval_list(":a, :b, File.read(\"\#{c}\", ['w']), :d",
+      RubyToken::Token)).to eq [:a, :b, 'File.read("#{c}", [\'w\'])', :d]
   end
 
   it "should try to skip any invalid tokens" do
-    tokval_list(":a, :b, \"\#{c}\", :d", :attr).should  == [:a, :b, :d]
-    tokval_list(":a, :b, File.read(\"\#{c}\", 'w', File.open { }), :d", :attr).should  == [:a, :b, :d]
-    tokval_list("CONST1, identifier, File.read(\"\#{c}\", 'w', File.open { }), CONST2",
-      RubyToken::TkId).should  == ['CONST1', 'identifier', 'CONST2']
+    expect(tokval_list(":a, :b, \"\#{c}\", :d", :attr)).to match_array( [:a, :b, :d] )
+    expect(tokval_list(":a, :b, File.read(\"\#{c}\", 'w', File.open { }), :d", :attr)).to match_array( [:a, :b, :d] )
+    expect(tokval_list("CONST1, identifier, File.read(\"\#{c}\", 'w', File.open { }), CONST2",
+      RubyToken::TkId)).to eq ['CONST1', 'identifier', 'CONST2']
   end
 
   it "should ignore a token if another invalid token is read before a comma" do
-    tokval_list(":a, :b XYZ, :c", RubyToken::TkSYMBOL).should == [:a, :c]
+    expect(tokval_list(":a, :b XYZ, :c", RubyToken::TkSYMBOL)).to eq [:a, :c]
   end
 
   it "should stop on most keywords" do
-    tokval_list(':a rescue :x == 5', RubyToken::Token).should == [:a]
+    expect(tokval_list(':a rescue :x eq 5', RubyToken::Token)).to match_array( [:a] )
   end
 
   it "should handle ignore parentheses that begin the token list" do
-    tokval_list('(:a, :b, :c)', :attr).should == [:a, :b, :c]
+    expect(tokval_list('(:a, :b, :c)', :attr)).to eq [:a, :b, :c]
   end
 
   it "should end when a closing parenthesis was found" do
-    tokval_list(':a, :b, :c), :d', :attr).should == [:a, :b, :c]
+    expect(tokval_list(':a, :b, :c), :d', :attr)).to eq [:a, :b, :c]
   end
 
   it "should ignore parentheses around items in a list" do
-    tokval_list(':a, (:b), :c, (:d TEST), :e, [:f], :g', :attr).should == [:a, :b, :c, :e, :g]
-    tokval_list(':a, (((:f)))', :attr).should == [:a, :f]
-    tokval_list(':a, ([:f]), :c)', RubyToken::Token).should == [:a, '[:f]', :c]
+    expect(tokval_list(':a, (:b), :c, (:d TEST), :e, [:f], :g', :attr)).to eq [:a, :b, :c, :e, :g]
+    expect(tokval_list(':a, (((:f)))', :attr)).to eq [:a, :f]
+    expect(tokval_list(':a, ([:f]), :c)', RubyToken::Token)).to eq [:a, '[:f]', :c]
   end
 
   it "should not stop on a true/false/self keyword (cannot handle nil)" do
-    tokval_list(':a, true, :b, self, false, :c, nil, File, super, if, XYZ',
-      RubyToken::Token).should == [:a, true, :b, 'self', false, :c, 'File', 'super']
+    expect(tokval_list(':a, true, :b, self, false, :c, nil, File, super, if, XYZ',
+      RubyToken::Token)).to eq [:a, true, :b, 'self', false, :c, 'File', 'super']
   end
 
   it "should ignore invalid commas" do
-    tokval_list(":a, :b, , :d").should == [:a, :b, :d]
+    expect(tokval_list(":a, :b, , :d")).to eq [:a, :b, :d]
   end
 
   it "should return an empty list if no matches were found" do
-    tokval_list('attr_accessor :x').should == []
+    expect(tokval_list('attr_accessor :x')).to eq []
   end
 
   it "should treat {} as a valid value" do
     # FIXME: tokval_list destroys extra spaces surrounding the '=' in
     #        this situation. This is technically a design flaw of the
     #        tokval parser, but this is now the expected behaviour.
-    tokval_list("opts = {}", :all).should == ["opts={}"]
+    expect(tokval_list("opts = {}", :all)).to eq ["opts={}"]
   end
 end

--- a/spec/handlers/method_condition_handler_spec.rb
+++ b/spec/handlers/method_condition_handler_spec.rb
@@ -4,11 +4,11 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodConditio
   before(:all) { parse_file :method_condition_handler_001, __FILE__ }
 
   it "should not parse regular if blocks in methods" do
-    Registry.at('#b').should be_nil
+    expect(Registry.at('#b')).to be_nil
   end
 
   it "should parse if/unless blocks in the form X if COND" do
-    Registry.at('#c').should_not be_nil
-    Registry.at('#d').should_not be_nil
+    expect(Registry.at('#c')).to_not be_nil
+    expect(Registry.at('#d')).to_not be_nil
   end
 end

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -8,177 +8,177 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHandler"
   end
 
   it "should add methods to parent's #meths list" do
-    P(:Foo).meths.should include(P("Foo#method1"))
+    expect(P(:Foo).meths).to include(P("Foo#method1"))
   end
 
   it "should parse/add class methods (self.method2)" do
-    P(:Foo).meths.should include(P("Foo.method2"))
+    expect(P(:Foo).meths).to include(P("Foo.method2"))
   end
 
   it "should parse/add class methods from other namespaces (String.hello)" do
-    P("String.hello").should be_instance_of(CodeObjects::MethodObject)
+    expect(P("String.hello")).to be_instance_of(CodeObjects::MethodObject)
   end
 
   [:[], :[]=, :allowed?, :/, :=~, :==, :`, :|, :*, :&, :%, :'^', :-@, :+@, :'~@'].each do |name|
     it "should allow valid method #{name}" do
-      Registry.at("Foo##{name}").should_not be_nil
+      expect(Registry.at("Foo##{name}")).to_not be_nil
     end
   end
 
   it "should allow self.methname" do
-    Registry.at("Foo.new").should_not be_nil
+    expect(Registry.at("Foo.new")).to_not be_nil
   end
 
   it "should mark dynamic methods as such" do
-    P('Foo#dynamic').dynamic?.should == true
+    expect(P('Foo#dynamic').dynamic?).to eq true
   end
 
   it "should show that a method is explicitly defined (if it was originally defined implicitly by attribute)" do
-    P('Foo#method1').is_explicit?.should == true
+    expect(P('Foo#method1').is_explicit?).to eq true
   end
 
   it "should handle parameters" do
-    P('Foo#[]').parameters.should == [['key', "'default'"]]
-    P('Foo#/').parameters.should == [['x', "File.new('x', 'w')"], ['y', '2']]
+    expect(P('Foo#[]').parameters).to eq [['key', "'default'"]]
+    expect(P('Foo#/').parameters).to eq [['x', "File.new('x', 'w')"], ['y', '2']]
   end
 
   it "should handle opts = {} as parameter" do
-    P('Foo#optsmeth').parameters.should == [['x', nil], ['opts', '{}']]
+    expect(P('Foo#optsmeth').parameters).to eq [['x', nil], ['opts', '{}']]
   end
 
   it "should handle &block as parameter" do
-    P('Foo#blockmeth').parameters.should == [['x', nil], ['&block', nil]]
+    expect(P('Foo#blockmeth').parameters).to eq [['x', nil], ['&block', nil]]
   end
 
   it "should handle overloads" do
     meth = P('Foo#foo')
 
     o1 = meth.tags(:overload).first
-    o1.name.should == :bar
-    o1.parameters.should == [['a', nil], ['b', "1"]]
-    o1.tag(:return).type.should == "String"
+    expect(o1.name).to eq :bar
+    expect(o1.parameters).to eq [['a', nil], ['b', "1"]]
+    expect(o1.tag(:return).type).to eq "String"
 
     o2 = meth.tags(:overload)[1]
-    o2.name.should == :baz
-    o2.parameters.should == [['b', nil], ['c', nil]]
-    o2.tag(:return).type.should == "Fixnum"
+    expect(o2.name).to eq :baz
+    expect(o2.parameters).to eq [['b', nil], ['c', nil]]
+    expect(o2.tag(:return).type).to eq "Fixnum"
 
     o3 = meth.tags(:overload)[2]
-    o3.name.should == :bang
-    o3.parameters.should == [['d', nil], ['e', nil]]
-    o3.docstring.should be_empty
-    o3.docstring.should be_blank
+    expect(o3.name).to eq :bang
+    expect(o3.parameters).to eq [['d', nil], ['e', nil]]
+    expect(o3.docstring).to be_empty
+    expect(o3.docstring).to be_blank
   end
 
   it "should set a return tag if not set on #initialize" do
     meth = P('Foo#initialize')
 
-    meth.should have_tag(:return)
-    meth.tag(:return).types.should == ["Foo"]
-    meth.tag(:return).text.should == "a new instance of Foo"
+    expect(meth).to have_tag(:return)
+    expect(meth.tag(:return).types).to eq ["Foo"]
+    expect(meth.tag(:return).text).to eq "a new instance of Foo"
   end
 
   %w(inherited included method_added method_removed method_undefined).each do |meth|
     it "should set @private tag on #{meth} callback method if no docstring is set" do
-      P('Foo.' + meth).should have_tag(:private)
+      expect(P('Foo.' + meth)).to have_tag(:private)
     end
   end
 
   it "should not set @private tag on extended callback method since docstring is set" do
-    P('Foo.extended').should_not have_tag(:private)
+    expect(P('Foo.extended')).to_not have_tag(:private)
   end
 
   it "should add @return [Boolean] tag to methods ending in ? without return types" do
     meth = P('Foo#boolean?')
-    meth.should have_tag(:return)
-    meth.tag(:return).types.should == ['Boolean']
+    expect(meth).to have_tag(:return)
+    expect(meth.tag(:return).types).to eq ['Boolean']
   end
 
   it "should add Boolean type to return tag without types" do
     meth = P('Foo#boolean2?')
-    meth.should have_tag(:return)
-    meth.tag(:return).types.should == ['Boolean']
+    expect(meth).to have_tag(:return)
+    expect(meth.tag(:return).types).to eq ['Boolean']
   end
 
   it "should not change return type for method ending in ? with return types set" do
     meth = P('Foo#boolean3?')
-    meth.should have_tag(:return)
-    meth.tag(:return).types.should == ['NotBoolean', 'nil']
+    expect(meth).to have_tag(:return)
+    expect(meth.tag(:return).types).to eq ['NotBoolean', 'nil']
   end
 
   it "should not change return type for method ending in ? with return types set by @overload" do
     meth = P('Foo#rainy?')
-    meth.should have_tag(:overload)
-    meth.tag(:overload).should have_tag(:return)
-    meth.should_not have_tag(:return)
+    expect(meth).to have_tag(:overload)
+    expect(meth.tag(:overload)).to have_tag(:return)
+    expect(meth).to_not have_tag(:return)
   end
 
   it "should add method writer to existing attribute" do
-    Registry.at('Foo#attr_name').should be_reader
-    Registry.at('Foo#attr_name=').should be_writer
+    expect(Registry.at('Foo#attr_name')).to be_reader
+    expect(Registry.at('Foo#attr_name=')).to be_writer
   end
 
   it "should add method reader to existing attribute" do
-    Registry.at('Foo#attr_name2').should be_reader
-    Registry.at('Foo#attr_name2=').should be_writer
+    expect(Registry.at('Foo#attr_name2')).to be_reader
+    expect(Registry.at('Foo#attr_name2=')).to be_writer
   end
 
   it "should generate an options parameter if @option refers to an undocumented parameter" do
     meth = P('Foo#auto_opts')
-    meth.should have_tag(:param)
-    meth.tag(:param).name.should == "opts"
-    meth.tag(:param).types.should == ["Hash"]
+    expect(meth).to have_tag(:param)
+    expect(meth.tag(:param).name).to eq "opts"
+    expect(meth.tag(:param).types).to eq ["Hash"]
   end
 
   it "should raise an undocumentable error when a method is defined on an object instance" do
     undoc_error "error = Foo; def error.at(foo) end"
-    Registry.at('error').should be_nil
+    expect(Registry.at('error')).to be_nil
   end
 
   it "should allow class method to be defined on constant reference object" do
-    Registry.at('Foo.meth_on_const').should_not be_nil
-    Registry.at('Foo.meth2_on_const').should_not be_nil
+    expect(Registry.at('Foo.meth_on_const')).to_not be_nil
+    expect(Registry.at('Foo.meth2_on_const')).to_not be_nil
   end
 
   it "should copy alias information on method (re-)definition to new method" do
-    Registry.at('D').aliases.should be_empty
-    Registry.at('D#b').is_alias?.should == false
-    Registry.at('D#a').is_alias?.should == false
+    expect(Registry.at('D').aliases).to be_empty
+    expect(Registry.at('D#b').is_alias?).to eq false
+    expect(Registry.at('D#a').is_alias?).to eq false
   end
 
   it "should add macros for class methods" do
     macro = CodeObjects::MacroObject.find('prop')
-    macro.should_not be_nil
-    macro.macro_data.should == "@!method $1(value)\n$3\n@return [$2]"
-    macro.method_object.should == Registry.at('E.property')
-    macro.should be_attached
+    expect(macro).to_not be_nil
+    expect(macro.macro_data).to eq "@!method $1(value)\n$3\n@return [$2]"
+    expect(macro.method_object).to eq Registry.at('E.property')
+    expect(macro).to be_attached
     obj = Registry.at('E#foo')
-    obj.should_not be_nil
-    obj.docstring.should == 'create a foo'
-    obj.signature.should == 'def foo(value)'
-    obj.tag(:return).types.should == ['String']
+    expect(obj).to_not be_nil
+    expect(obj.docstring).to eq 'create a foo'
+    expect(obj.signature).to eq 'def foo(value)'
+    expect(obj.tag(:return).types).to eq ['String']
   end
 
   it "should handle macros on any object" do
     macro = CodeObjects::MacroObject.find('xyz')
-    macro.should_not be_nil
-    macro.macro_data.should == '@!method $1'
+    expect(macro).to_not be_nil
+    expect(macro.macro_data).to eq '@!method $1'
   end
 
   it "should skip macros on instance methods" do
-    Registry.at('E#a').should be_nil
+    expect(Registry.at('E#a')).to be_nil
   end
 
   it "should warn if the macro name is invalid" do
-    log.should_receive(:warn).with(/Invalid directive.*@!macro/)
+    expect(log).to receive(:warn).with(/Invalid directive.*@!macro/)
     YARD.parse_string "class Foo\n# @!macro\ndef self.foo; end\nend"
   end
 
   it "should handle 'def end' methods" do
     obj = Registry.at('F::A#foo')
-    obj.should_not be_nil
+    expect(obj).to_not be_nil
     obj = Registry.at('F::A#bar')
-    obj.should_not be_nil
-    obj.docstring.should == 'PASS'
+    expect(obj).to_not be_nil
+    expect(obj.docstring).to eq 'PASS'
   end
 end

--- a/spec/handlers/mixin_handler_spec.rb
+++ b/spec/handlers/mixin_handler_spec.rb
@@ -4,52 +4,52 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MixinHandler" 
   before(:all) { parse_file :mixin_handler_001, __FILE__ }
 
   it "should handle includes from classes or modules" do
-    Registry.at(:X).instance_mixins.should include(P(:A))
-    Registry.at(:Y).instance_mixins.should include(P(:A))
+    expect(Registry.at(:X).instance_mixins).to include(P(:A))
+    expect(Registry.at(:Y).instance_mixins).to include(P(:A))
   end
 
   it "should handle includes in class << self" do
-    Registry.at(:Y).class_mixins.should include(P(:A))
+    expect(Registry.at(:Y).class_mixins).to include(P(:A))
   end
 
   it "should handle includes for modules that don't yet exist" do
-    Registry.at(:X).instance_mixins.should include(P(nil, :NOTEXIST))
+    expect(Registry.at(:X).instance_mixins).to include(P(nil, :NOTEXIST))
   end
 
   it "should set the type of non-existing modules to :module" do
     o = Registry.at(:X).instance_mixins.find {|o| o.name == :NOTEXIST }
-    o.type.should == :module
+    expect(o.type).to eq :module
   end
 
   it "should handle includes with multiple parameters" do
-    Registry.at(:X).should_not be_nil
+    expect(Registry.at(:X)).to_not be_nil
   end
 
   it "should handle complex include statements" do
-    P(:Y).instance_mixins.should include(P('B::C'))
-    P(:Y).instance_mixins.should include(P(:B))
+    expect(P(:Y).instance_mixins).to include(P('B::C'))
+    expect(P(:Y).instance_mixins).to include(P(:B))
   end
 
   it "should treat a mixed in Constant by taking its value as the real object name" do
-    P(:Y).instance_mixins.should include(Registry.at('B::D'))
+    expect(P(:Y).instance_mixins).to include(Registry.at('B::D'))
   end
 
   it "should add includes in the correct order when include is given multiple arguments" do
-    P(:Z).instance_mixins.should == [P(:A), P(:B)]
+    expect(P(:Z).instance_mixins).to eq [P(:A), P(:B)]
   end
 
   it "should avoid including self for unresolved mixins of the same name" do
-    P("ABC::DEF::FOO").mixins.should == [P("ABC::FOO")]
-    P("ABC::DEF::BAR").mixins.should == [P("ABC::BAR")]
+    expect(P("ABC::DEF::FOO").mixins).to eq [P("ABC::FOO")]
+    expect(P("ABC::DEF::BAR").mixins).to eq [P("ABC::BAR")]
   end
 
   it "should raise undocumentable error if argument is variable" do
     undoc_error "module X; include invalid; end"
-    Registry.at('X').mixins.should == []
+    expect(Registry.at('X').mixins).to eq []
   end
 
   it "should parse all other arguments before erroring out on undocumentable error" do
     undoc_error "module X; include invalid, Y; end"
-    Registry.at('X').mixins.should == [P('Y')]
+    expect(Registry.at('X').mixins).to eq [P('Y')]
   end
 end

--- a/spec/handlers/module_function_handler_spec.rb
+++ b/spec/handlers/module_function_handler_spec.rb
@@ -6,12 +6,12 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}VisibilityHand
   def assert_module_function(namespace, name)
     klass = Registry.at("#{namespace}.#{name}")
     instance = Registry.at("#{namespace}##{name}")
-    klass.should_not be_nil
-    instance.should_not be_nil
-    klass.should be_module_function
-    instance.should_not be_module_function
-    klass.visibility.should == :public
-    instance.visibility.should == :private
+    expect(klass).to_not be_nil
+    expect(instance).to_not be_nil
+    expect(klass).to be_module_function
+    expect(instance).to_not be_module_function
+    expect(klass.visibility).to eq :public
+    expect(instance.visibility).to eq :private
   end
 
   it "should be able to create a module function with parameters" do
@@ -38,7 +38,7 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}VisibilityHand
         def baz; end
       end
     eof
-    Registry.at('Foo.qux').should be_nil
+    expect(Registry.at('Foo.qux')).to be_nil
     assert_module_function('Foo', 'bar')
     assert_module_function('Foo', 'baz')
   end
@@ -56,14 +56,14 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}VisibilityHand
     eof
     assert_module_function('Foo', 'bar')
     o = Registry.at('Foo.bar')
-    o.tag(:param).types.should == ['String']
-    o.tag(:param).name.should == 'foo'
-    o.tag(:param).text.should == 'bar'
-    o.tag(:option).name.should == 'foo'
-    o.tag(:option).pair.types.should == ['String']
-    o.tag(:option).pair.defaults.should == ['nil']
-    o.tag(:option).pair.text.should == 'baz'
-    o.tag(:return).types.should == ['void']
+    expect(o.tag(:param).types).to eq ['String']
+    expect(o.tag(:param).name).to eq 'foo'
+    expect(o.tag(:param).text).to eq 'bar'
+    expect(o.tag(:option).name).to eq 'foo'
+    expect(o.tag(:option).pair.types).to eq ['String']
+    expect(o.tag(:option).pair.defaults).to eq ['nil']
+    expect(o.tag(:option).pair.text).to eq 'baz'
+    expect(o.tag(:return).types).to eq ['void']
   end
 
   it "should handle all method names in parameters" do
@@ -88,9 +88,9 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}VisibilityHand
         module_function *(method_call)
       end
     eof
-    Registry.at('Foo#name').should be_nil
-    Registry.at('Foo#argument').should be_nil
-    Registry.at('Foo#method_call').should be_nil
+    expect(Registry.at('Foo#name')).to be_nil
+    expect(Registry.at('Foo#argument')).to be_nil
+    expect(Registry.at('Foo#method_call')).to be_nil
   end
 
   it "should handle constants passed in as symbols" do

--- a/spec/handlers/module_handler_spec.rb
+++ b/spec/handlers/module_handler_spec.rb
@@ -4,31 +4,31 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ModuleHandler"
   before(:all) { parse_file :module_handler_001, __FILE__ }
 
   it "should parse a module block" do
-    Registry.at(:ModName).should_not == nil
-    Registry.at("ModName::OtherModName").should_not == nil
+    expect(Registry.at(:ModName)).to_not eq nil
+    expect(Registry.at("ModName::OtherModName")).to_not eq nil
   end
 
   it "should attach docstring" do
-    Registry.at("ModName::OtherModName").docstring.should == "Docstring"
+    expect(Registry.at("ModName::OtherModName").docstring).to eq "Docstring"
   end
 
   it "should handle any formatting" do
-    Registry.at(:StressTest).should_not == nil
+    expect(Registry.at(:StressTest)).to_not eq nil
   end
 
   it "should handle complex module names" do
-    Registry.at("A::B").should_not == nil
+    expect(Registry.at("A::B")).to_not eq nil
   end
 
   it "should handle modules in the form ::ModName" do
-    Registry.at("Kernel").should_not be_nil
+    expect(Registry.at("Kernel")).to_not be_nil
   end
 
   it "should list mixins in proper order" do
-    Registry.at('D').mixins.should == [P(:C), P(:B), P(:A)]
+    expect(Registry.at('D').mixins).to eq [P(:C), P(:B), P(:A)]
   end
 
   it "should create proper module when constant is in namespace" do
-    Registry.at('Q::FOO::A').should_not be_nil
+    expect(Registry.at('Q::FOO::A')).to_not be_nil
   end
 end

--- a/spec/handlers/private_constant_handler_spec.rb
+++ b/spec/handlers/private_constant_handler_spec.rb
@@ -4,13 +4,13 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}PrivateConstan
   before(:all) { parse_file :private_constant_handler_001, __FILE__ }
 
   it "should handle private_constant statement" do
-    Registry.at('A::Foo').visibility.should == :private
-    Registry.at('A::B').visibility.should == :private
-    Registry.at('A::C').visibility.should == :private
+    expect(Registry.at('A::Foo').visibility).to eq :private
+    expect(Registry.at('A::B').visibility).to eq :private
+    expect(Registry.at('A::C').visibility).to eq :private
   end
 
   it "should make all other constants public" do
-    Registry.at('A::D').visibility.should == :public
+    expect(Registry.at('A::D').visibility).to eq :public
   end
 
   it "should fail if parameter is not String, Symbol or Constant" do

--- a/spec/handlers/processor_spec.rb
+++ b/spec/handlers/processor_spec.rb
@@ -6,19 +6,19 @@ describe YARD::Handlers::Processor do
   end
 
   it "should start with public visibility" do
-    @proc.visibility.should == :public
+    expect(@proc.visibility).to eq :public
   end
 
   it "should start in instance scope" do
-    @proc.scope.should == :instance
+    expect(@proc.scope).to eq :instance
   end
 
   it "should start in root namespace" do
-    @proc.namespace.should == Registry.root
+    expect(@proc.namespace).to eq Registry.root
   end
 
   it "should have a globals structure" do
-    @proc.globals.should be_a(OpenStruct)
+    expect(@proc.globals).to be_a(OpenStruct)
   end
 
   it 'should ignore HandlerAborted exceptions (but print debug info)' do
@@ -27,8 +27,8 @@ describe YARD::Handlers::Processor do
     end
     stmt = OpenStruct.new(:line => 1, :show => 'SOURCE')
     @proc.stub!(:find_handlers).and_return([AbortHandlerProcessor])
-    log.should_receive(:debug).with(/AbortHandlerProcessor cancelled from/)
-    log.should_receive(:debug).with("\tin file '(stdin)':1:\n\nSOURCE\n")
+    expect(log).to receive(:debug).with(/AbortHandlerProcessor cancelled from/)
+    expect(log).to receive(:debug).with("\tin file '(stdin)':1:\n\nSOURCE\n")
     @proc.process([stmt])
   end
 end

--- a/spec/handlers/ruby/base_spec.rb
+++ b/spec/handlers/ruby/base_spec.rb
@@ -13,11 +13,11 @@ describe YARD::Handlers::Ruby::Base, '#valid_handler?' do
   end
 
   def valid(handler, stmt)
-    @processor.find_handlers(stmt).should include(handler)
+    expect(@processor.find_handlers(stmt)).to include(handler)
   end
 
   def invalid(handler, stmt)
-    @processor.find_handlers(stmt).should_not include(handler)
+    expect(@processor.find_handlers(stmt)).to_not include(handler)
   end
 
   it "should only handle Handlers inherited from Ruby::Base class" do
@@ -28,7 +28,7 @@ describe YARD::Handlers::Ruby::Base, '#valid_handler?' do
       handles :list
     end
     Handlers::Base.stub!(:subclasses).and_return [IgnoredHandler, NotIgnoredHandler]
-    @processor.find_handlers(s()).should == [NotIgnoredHandler]
+    expect(@processor.find_handlers(s())).to eq( [NotIgnoredHandler] )
   end
 
   it "should handle string input (matches AstNode#source)" do

--- a/spec/handlers/ruby/legacy/base_spec.rb
+++ b/spec/handlers/ruby/legacy/base_spec.rb
@@ -25,7 +25,7 @@ describe YARD::Handlers::Ruby::Legacy::Base, "#handles and inheritance" do
       handles "hello"
     end
     Handlers::Base.stub!(:subclasses).and_return [IgnoredHandler, NotIgnoredHandlerLegacy]
-    @processor.find_handlers(stmt("hello world")).should == [NotIgnoredHandlerLegacy]
+    expect(@processor.find_handlers(stmt("hello world"))).to eq [NotIgnoredHandlerLegacy]
   end
 
   it "should handle a string input" do
@@ -33,8 +33,8 @@ describe YARD::Handlers::Ruby::Legacy::Base, "#handles and inheritance" do
       handles "hello"
     end
 
-    TestStringHandler.handles?(stmt("hello world")).should be_true
-    TestStringHandler.handles?(stmt("nothello world")).should be_false
+    expect(TestStringHandler.handles?(stmt("hello world"))).to be_true
+    expect(TestStringHandler.handles?(stmt("nothello world"))).to be_false
   end
 
   it "should handle regex input" do
@@ -42,8 +42,8 @@ describe YARD::Handlers::Ruby::Legacy::Base, "#handles and inheritance" do
       handles /^nothello$/
     end
 
-    TestRegexHandler.handles?(stmt("nothello")).should be_true
-    TestRegexHandler.handles?(stmt("not hello hello")).should be_false
+    expect(TestRegexHandler.handles?(stmt("nothello"))).to be_true
+    expect(TestRegexHandler.handles?(stmt("not hello hello"))).to be_false
   end
 
   it "should handle token input" do
@@ -51,8 +51,8 @@ describe YARD::Handlers::Ruby::Legacy::Base, "#handles and inheritance" do
       handles TkMODULE
     end
 
-    TestTokenHandler.handles?(stmt("module")).should be_true
-    TestTokenHandler.handles?(stmt("if")).should be_false
+    expect(TestTokenHandler.handles?(stmt("module"))).to be_true
+    expect(TestTokenHandler.handles?(stmt("if"))).to be_false
   end
 
   it "should parse a do/end or { } block with #parse_block" do
@@ -73,10 +73,10 @@ describe YARD::Handlers::Ruby::Legacy::Base, "#handles and inheritance" do
     Handlers::Base.stub!(:subclasses).and_return [MyBlockHandler, MyBlockInnerHandler]
     Parser::SourceParser.parser_type = :ruby18
     Parser::SourceParser.parse_string "myMethod do inner end"
-    MyBlockInnerHandler.should be_reached
+    expect(MyBlockInnerHandler).to be_reached
     MyBlockInnerHandler.reset
     Parser::SourceParser.parse_string "myMethod { inner }"
-    MyBlockInnerHandler.should be_reached
+    expect(MyBlockInnerHandler).to be_reached
     Parser::SourceParser.parser_type = :ruby
   end
 end

--- a/spec/handlers/spec_helper.rb
+++ b/spec/handlers/spec_helper.rb
@@ -4,7 +4,7 @@ require 'stringio'
 include Handlers
 
 def undoc_error(code)
-  lambda { StubbedSourceParser.parse_string(code) }.should raise_error(Parser::UndocumentableError)
+  expect { StubbedSourceParser.parse_string(code) }.to raise_error(Parser::UndocumentableError)
 end
 
 def with_parser(parser_type, &block)

--- a/spec/handlers/visibility_handler_spec.rb
+++ b/spec/handlers/visibility_handler_spec.rb
@@ -4,36 +4,36 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}VisibilityHand
   before(:all) { parse_file :visibility_handler_001, __FILE__ }
 
   it "should be able to set visibility to public" do
-    Registry.at("Testing#pub").visibility.should == :public
-    Registry.at("Testing#pub2").visibility.should == :public
+    expect(Registry.at("Testing#pub").visibility).to eq :public
+    expect(Registry.at("Testing#pub2").visibility).to eq :public
   end
 
   it "should be able to set visibility to private" do
-    Registry.at("Testing#priv").visibility.should == :private
+    expect(Registry.at("Testing#priv").visibility).to eq :private
   end
 
   it "should be able to set visibility to protected" do
-    Registry.at("Testing#prot").visibility.should == :protected
+    expect(Registry.at("Testing#prot").visibility).to eq :protected
   end
 
   it "should support parameters and only set visibility on those methods" do
-    Registry['Testing#notpriv'].visibility.should == :protected
-    Registry['Testing#notpriv2'].visibility.should == :protected
-    Registry['Testing#notpriv?'].visibility.should == :protected
+    expect(Registry['Testing#notpriv'].visibility).to eq :protected
+    expect(Registry['Testing#notpriv2'].visibility).to eq :protected
+    expect(Registry['Testing#notpriv?'].visibility).to eq :protected
   end
 
   it "should only accept strings and symbols" do
-    Registry.at('Testing#name').should be_nil
-    Registry.at('Testing#argument').should be_nil
-    Registry.at('Testing#method_call').should be_nil
+    expect(Registry.at('Testing#name')).to be_nil
+    expect(Registry.at('Testing#argument')).to be_nil
+    expect(Registry.at('Testing#method_call')).to be_nil
   end
 
   it "should handle constants passed in as symbols" do
-    Registry.at('Testing#Foo').visibility.should == :private
+    expect(Registry.at('Testing#Foo').visibility).to eq :private
   end
 
   it 'should not register classes with visibility' do
-    Registry.at('Testing::Bar').visibility.should == :public
-    Registry.at('Testing::Baz').visibility.should == :public
+    expect(Registry.at('Testing::Bar').visibility).to eq :public
+    expect(Registry.at('Testing::Baz').visibility).to eq :public
   end
 end

--- a/spec/handlers/yield_handler_spec.rb
+++ b/spec/handlers/yield_handler_spec.rb
@@ -4,48 +4,48 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}YieldHandler" 
   before(:all) { parse_file :yield_handler_001, __FILE__ }
 
   it "should only parse yield blocks in methods" do
-    P(:Testing).tag(:yield).should be_nil
-    P(:Testing).tag(:yieldparam).should be_nil
+    expect(P(:Testing).tag(:yield)).to be_nil
+    expect(P(:Testing).tag(:yieldparam)).to be_nil
   end
 
   it "should handle an empty yield statement" do
-    P('Testing#mymethod').tag(:yield).should be_nil
-    P('Testing#mymethod').tag(:yieldparam).should be_nil
+    expect(P('Testing#mymethod').tag(:yield)).to be_nil
+    expect(P('Testing#mymethod').tag(:yieldparam)).to be_nil
   end
 
   it "should not document a yield statement in a method with either @yield or @yieldparam" do
-    P('Testing#mymethod2').tag(:yield).types.should == ['a', 'b']
-    P('Testing#mymethod2').tag(:yield).text.should == "Blah"
-    P('Testing#mymethod2').tags(:yieldparam).size.should == 2
+    expect(P('Testing#mymethod2').tag(:yield).types).to eq ['a', 'b']
+    expect(P('Testing#mymethod2').tag(:yield).text).to eq "Blah"
+    expect(P('Testing#mymethod2').tags(:yieldparam).size).to eq 2
 
-    P('Testing#mymethod3').tag(:yield).types.should == ['a', 'b']
-    P('Testing#mymethod3').tags(:yieldparam).size.should == 0
+    expect(P('Testing#mymethod3').tag(:yield).types).to eq ['a', 'b']
+    expect(P('Testing#mymethod3').tags(:yieldparam).size).to eq 0
 
-    P('Testing#mymethod4').tag(:yieldparam).name.should == '_self'
-    P('Testing#mymethod4').tag(:yieldparam).text.should == 'BLAH'
+    expect(P('Testing#mymethod4').tag(:yieldparam).name).to eq '_self'
+    expect(P('Testing#mymethod4').tag(:yieldparam).text).to eq 'BLAH'
   end
 
   it "should handle any arbitrary yield statement" do
-    P('Testing#mymethod5').tag(:yield).types.should == [':a', 'b', '_self', 'File.read(\'file\', \'w\')', 'CONSTANT']
+    expect(P('Testing#mymethod5').tag(:yield).types).to eq [':a', 'b', '_self', 'File.read(\'file\', \'w\')', 'CONSTANT']
   end
 
   it "should handle parentheses" do
-    P('Testing#mymethod6').tag(:yield).types.should == ['b', 'a']
+    expect(P('Testing#mymethod6').tag(:yield).types).to eq ['b', 'a']
   end
 
   it "should only document the first yield statement in a method (limitation of yield handler)" do
-    P('Testing#mymethod7').tag(:yield).types.should == ['a']
+    expect(P('Testing#mymethod7').tag(:yield).types).to eq ['a']
   end
 
   it "should handle `self` keyword and list object type as yieldparam for _self" do
-    P('Testing#mymethod8').tag(:yield).types.should == ['_self']
-    P('Testing#mymethod8').tag(:yieldparam).types.should == ['Testing']
-    P('Testing#mymethod8').tag(:yieldparam).text.should == "the object that the method was called on"
+    expect(P('Testing#mymethod8').tag(:yield).types).to eq ['_self']
+    expect(P('Testing#mymethod8').tag(:yieldparam).types).to eq ['Testing']
+    expect(P('Testing#mymethod8').tag(:yieldparam).text).to eq "the object that the method was called on"
   end
 
   it "should handle `super` keyword and document it under _super" do
-    P('Testing#mymethod9').tag(:yield).types.should == ['_super']
-    P('Testing#mymethod9').tag(:yieldparam).types.should be_nil
-    P('Testing#mymethod9').tag(:yieldparam).text.should == "the result of the method from the superclass"
+    expect(P('Testing#mymethod9').tag(:yield).types).to eq ['_super']
+    expect(P('Testing#mymethod9').tag(:yieldparam).types).to be_nil
+    expect(P('Testing#mymethod9').tag(:yieldparam).text).to eq "the result of the method from the superclass"
   end
 end

--- a/spec/i18n/locale_spec.rb
+++ b/spec/i18n/locale_spec.rb
@@ -11,14 +11,14 @@ describe YARD::I18n::Locale do
 
   describe "#name" do
     it "should return name" do
-      locale("fr").name.should == "fr"
+      expect(locale("fr").name).to eq "fr"
     end
   end
 
   describe "#load" do
     it "should return false for nonexistent PO" do
-      File.should_receive(:exist?).with('foo/fr.po').and_return(false)
-      @locale.load('foo').should == false
+      expect(File).to receive(:exist?).with('foo/fr.po').and_return(false)
+      expect(@locale.load('foo')).to eq false
     end
 
     have_gettext_gem = true
@@ -53,14 +53,14 @@ msgid "Hello"
 msgstr "Bonjour"
 eop
       parser = GetText::POParser.new
-      File.should_receive(:exist?).with('foo/fr.po').and_return(true)
-      GetText::POParser.should_receive(:new).and_return(parser)
-      parser.should_receive(:parse_file) do |file, hash|
-        file.should == 'foo/fr.po'
+      expect(File).to receive(:exist?).with('foo/fr.po').and_return(true)
+      expect(GetText::POParser).to receive(:new).and_return(parser)
+      expect(parser).to receive(:parse_file) do |file, hash|
+        expect(file).to eq 'foo/fr.po'
         parser.parse(data, hash)
       end
-      @locale.load('foo').should == true
-      @locale.translate('Hello').should == "Bonjour"
+      expect(@locale.load('foo')).to eq true
+      expect(@locale.translate('Hello')).to eq "Bonjour"
     end
   end
 

--- a/spec/i18n/message_spec.rb
+++ b/spec/i18n/message_spec.rb
@@ -11,7 +11,7 @@ describe YARD::I18n::Message do
 
   describe "#id" do
     it "should return ID" do
-      message("Hello World!").id.should == "Hello World!"
+      expect(message("Hello World!").id).to eq "Hello World!"
     end
   end
 
@@ -19,7 +19,7 @@ describe YARD::I18n::Message do
     it "should add some locations" do
       @message.add_location("hello.rb", 10)
       @message.add_location("message.rb", 5)
-      @message.locations.should == Set.new([["hello.rb", 10], ["message.rb", 5]])
+      expect(@message.locations).to eq Set.new([["hello.rb", 10], ["message.rb", 5]])
     end
   end
 
@@ -27,7 +27,7 @@ describe YARD::I18n::Message do
     it "should add some comments" do
       @message.add_comment("YARD.title")
       @message.add_comment("Hello#message")
-      @message.comments.should == Set.new(["YARD.title", "Hello#message"])
+      expect(@message.comments).to eq Set.new(["YARD.title", "Hello#message"])
     end
   end
 
@@ -46,7 +46,7 @@ describe YARD::I18n::Message do
         other_message.add_comment(comment)
       end
 
-      @message.should == other_message
+      expect(@message).to eq other_message
     end
   end
 end

--- a/spec/i18n/messages_spec.rb
+++ b/spec/i18n/messages_spec.rb
@@ -22,7 +22,7 @@ describe YARD::I18n::Messages do
         enumerated_messages << message
       end
       enumerated_messages = enumerated_messages.sort_by {|m| m.id }
-      enumerated_messages.should == [message("Hello World!"), message("Title")]
+      expect(enumerated_messages).to eq [message("Hello World!"), message("Title")]
     end
 
     it "should not any Message for empty messages" do
@@ -30,29 +30,29 @@ describe YARD::I18n::Messages do
       @messages.each do |message|
         enumerated_messages << message
       end
-      enumerated_messages.should == []
+      expect(enumerated_messages).to eq []
     end
   end
 
   describe "#[]" do
     it "should return registered message" do
       @messages.register("Hello World!")
-      @messages["Hello World!"].should == message("Hello World!")
+      expect(@messages["Hello World!"]).to eq message("Hello World!")
     end
 
     it "should return for nonexistent message ID" do
-      @messages["Hello World!"].should == nil
+      expect(@messages["Hello World!"]).to eq nil
     end
   end
 
   describe "#register" do
     it "should return registered message" do
-      @messages.register("Hello World!").should == message("Hello World!")
+      expect(@messages.register("Hello World!")).to eq message("Hello World!")
     end
 
     it "should return existent message" do
       message = @messages.register("Hello World!")
-      @messages.register("Hello World!").object_id.should == message.object_id
+      expect(@messages.register("Hello World!").object_id).to eq message.object_id
     end
   end
 
@@ -61,7 +61,7 @@ describe YARD::I18n::Messages do
       @messages.register("Hello World!")
       other_messages = messages
       other_messages.register("Hello World!")
-      @messages.should == other_messages
+      expect(@messages).to eq other_messages
     end
   end
 end

--- a/spec/i18n/pot_generator_spec.rb
+++ b/spec/i18n/pot_generator_spec.rb
@@ -25,7 +25,7 @@ describe YARD::I18n::PotGenerator do
 
   describe "Generate" do
     it "should generate the default header" do
-      @generator.generate.should == <<-'eoh'
+      expect(@generator.generate).to eq <<-'eoh'
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
@@ -61,7 +61,7 @@ eoh
         }
       }
       add_messages(@generator.messages, messages)
-      @generator.generate.should == <<-'eoh'
+      expect(@generator.generate).to eq <<-'eoh'
 HEADER
 
 # YARD.parse
@@ -89,7 +89,7 @@ eoh
     end
 
     it "should escape <\\>" do
-      generate_message_pot("hello \\ world").should == <<-'eop'
+      expect(generate_message_pot("hello \\ world")).to eq <<-'eop'
 msgid "hello \\ world"
 msgstr ""
 
@@ -97,7 +97,7 @@ eop
     end
 
     it "should escape <\">" do
-      generate_message_pot("hello \" world").should == <<-'eop'
+      expect(generate_message_pot("hello \" world")).to eq <<-'eop'
 msgid "hello \" world"
 msgstr ""
 
@@ -105,7 +105,7 @@ eop
     end
 
     it "should escape <\\n>" do
-      generate_message_pot("hello \n world").should == <<-'eop'
+      expect(generate_message_pot("hello \n world")).to eq <<-'eop'
 msgid "hello \n"
 " world"
 msgstr ""
@@ -125,7 +125,7 @@ eop
         o.docstring = "An alias to {Parser::SourceParser}'s parsing method"
       end
       @generator.parse_objects([object])
-      @generator.messages.should == create_messages({
+      expect(@generator.messages).to eq create_messages({
         "An alias to {Parser::SourceParser}'s parsing method" => {
           :locations => [],
           :comments => ["YARD.parse"],
@@ -139,7 +139,7 @@ eop
         o.files = [["yard.rb", 12]]
       end
       @generator.parse_objects([object])
-      @generator.messages.should == create_messages({
+      expect(@generator.messages).to eq create_messages({
         "An alias to {Parser::SourceParser}'s parsing method" => {
           :locations => [["yard.rb", 13]],
           :comments => ["YARD.parse"],
@@ -153,7 +153,7 @@ eop
         o.files = [["yard.rb", 12]]
       end
       @generator.parse_objects([object])
-      @generator.messages.should == create_messages({
+      expect(@generator.messages).to eq create_messages({
         "tag|see|Parser::SourceParser.parse" => {
           :locations => [["yard.rb", 12]],
           :comments => ["@see"],
@@ -170,7 +170,7 @@ eod
         o.files = [["yard.rb", 12]]
       end
       @generator.parse_objects([object])
-      @generator.messages.should == create_messages({
+      expect(@generator.messages).to eq create_messages({
         "tag|example|Parse a glob of files" => {
           :locations => [["yard.rb", 12]],
           :comments => ["@example"],
@@ -191,7 +191,7 @@ eod
         o.files = [["yard.rb", 12]]
       end
       @generator.parse_objects([object])
-      @generator.messages.should == create_messages({
+      expect(@generator.messages).to eq create_messages({
         "tag|param|paths" => {
           :locations => [["yard.rb", 12]],
           :comments => ["@param [String, Array<String>]"],
@@ -216,7 +216,7 @@ eor
       File.stub!(:read).with(path).and_return(text)
       file = YARD::CodeObjects::ExtraFileObject.new(path)
       @generator.parse_files([file])
-      @generator.messages.should == create_messages({
+      expect(@generator.messages).to eq create_messages({
         "Getting Started Guide" => {
           :locations => [[path, 1]],
           :comments => ["title"],
@@ -247,7 +247,7 @@ eot
       File.stub!(:read).with(path).and_return(text)
       file = YARD::CodeObjects::ExtraFileObject.new(path)
       @generator.parse_files([file])
-      @generator.messages.should == create_messages({
+      expect(@generator.messages).to eq create_messages({
         paragraph1 => {
           :locations => [[path, 1]],
           :comments => [],

--- a/spec/i18n/text_spec.rb
+++ b/spec/i18n/text_spec.rb
@@ -18,9 +18,9 @@ describe YARD::I18n::Text do
 
 # Getting Started with YARD
 eot
-        extract_messages(text, :have_header => true).should ==
+        expect(extract_messages(text, :have_header => true)).to match_array(
           [[:attribute, "title", "Getting Started Guide", 1],
-           [:paragraph, "# Getting Started with YARD", 3]]
+           [:paragraph, "# Getting Started with YARD", 3]] )
       end
 
       it "should ignore markup line" do
@@ -30,9 +30,9 @@ eot
 
 # Getting Started with YARD
 eot
-        extract_messages(text, :have_header => true).should ==
+        expect(extract_messages(text, :have_header => true)).to match_array(
           [[:attribute, "title", "Getting Started Guide", 2],
-           [:paragraph, "# Getting Started with YARD", 4]]
+           [:paragraph, "# Getting Started with YARD", 4]] )
       end
 
       it "should terminate header block by markup line not at the first line" do
@@ -42,10 +42,10 @@ eot
 
 # Getting Started with YARD
 eot
-        extract_messages(text, :have_header => true).should ==
+        expect(extract_messages(text, :have_header => true)).to match_array(
           [[:attribute, "title", "Getting Started Guide", 1],
            [:paragraph, "#!markdown", 2],
-           [:paragraph, "# Getting Started with YARD", 4]]
+           [:paragraph, "# Getting Started with YARD", 4]] )
       end
     end
 
@@ -64,9 +64,9 @@ eop
 
 #{paragraph2}
 eot
-        extract_messages(text).should ==
+        expect(extract_messages(text)).to match_array(
           [[:paragraph, paragraph1, 1],
-           [:paragraph, paragraph2, 4]]
+           [:paragraph, paragraph2, 4]] )
       end
     end
   end
@@ -96,7 +96,7 @@ eot
 
 Paragraph.
 eot
-        translate(text, :have_header => true).should == <<-eot
+        expect(translate(text, :have_header => true)).to eq <<-eot
 # @title Bonjour (Hello in fr)
 
 # Getting Started with YARD
@@ -114,7 +114,7 @@ eot
 
 Paragraph.
 eot
-        translate(text, :have_header => true).should == <<-eot
+        expect(translate(text, :have_header => true)).to eq <<-eot
 #!markdown
 # @title Bonjour (Hello in fr)
 
@@ -138,7 +138,7 @@ eop
 
 #{paragraph2}
 eot
-        translate(text).should == <<-eot
+        expect(translate(text)).to eq <<-eot
 Paragraphe 1.
 
 Paragraphe 2.
@@ -152,7 +152,7 @@ eop
         text = <<-eot
 #{nonexistent_paragraph}
 eot
-        translate(text).should == <<-eot
+        expect(translate(text)).to eq <<-eot
 #{nonexistent_paragraph}
 eot
       end
@@ -161,16 +161,16 @@ eot
         text = <<-eot
 Paragraph 1.
 
-  
-	
+
+
 
 Paragraph 2.
 eot
-        translate(text).should == <<-eot
+        expect(translate(text)).to eq <<-eot
 Paragraphe 1.
 
-  
-	
+
+
 
 Paragraphe 2.
 eot

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -6,9 +6,9 @@ describe YARD::Logger do
       log.show_backtraces = true
       log.enter_level(Logger::DEBUG) do
         log.show_backtraces = false
-        log.show_backtraces.should == true
+        expect(log.show_backtraces).to eq true
       end
-      log.show_backtraces.should == false
+      expect(log.show_backtraces).to eq false
     end
   end
 
@@ -17,16 +17,16 @@ describe YARD::Logger do
     after { log.show_backtraces = false }
 
     it "should log backtrace in error by default" do
-      log.should_receive(:error).with("RuntimeError: foo")
-      log.should_receive(:error).with("Stack trace:\n\tline1\n\tline2\n")
+      expect(log).to receive(:error).with("RuntimeError: foo")
+      expect(log).to receive(:error).with("Stack trace:\n\tline1\n\tline2\n")
       exc = RuntimeError.new("foo")
       exc.set_backtrace(['line1', 'line2'])
       log.enter_level(Logger::INFO) { log.backtrace(exc) }
     end
 
     it "should allow backtrace to be entered in other modes" do
-      log.should_receive(:warn).with("RuntimeError: foo")
-      log.should_receive(:warn).with("Stack trace:\n\tline1\n\tline2\n")
+      expect(log).to receive(:warn).with("RuntimeError: foo")
+      expect(log).to receive(:warn).with("Stack trace:\n\tline1\n\tline2\n")
       exc = RuntimeError.new("foo")
       exc.set_backtrace(['line1', 'line2'])
       log.enter_level(Logger::INFO) { log.backtrace(exc, :warn) }

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -13,7 +13,7 @@ describe YARD::Options do
       end
       o = DefaultOptions1.new
       o.reset_defaults
-      o.foo.should == 'HELLO'
+      expect(o.foo).to eq 'HELLO'
     end
 
     it "should call lambda if value is a Proc" do
@@ -22,7 +22,7 @@ describe YARD::Options do
       end
       o = DefaultOptions2.new
       o.reset_defaults
-      o.foo.should == 100
+      expect(o.foo).to eq 100
     end
   end
 
@@ -31,10 +31,10 @@ describe YARD::Options do
       class ResetDefaultOptions1 < YARD::Options
         default_attr :foo, 'FOO'
       end
-      ResetDefaultOptions1.new.foo.should be_nil
+      expect(ResetDefaultOptions1.new.foo).to be_nil
       o = ResetDefaultOptions1.new
       o.reset_defaults
-      o.foo.should == 'FOO'
+      expect(o.foo).to eq 'FOO'
     end
 
     it "should use defaults from superclass as well" do
@@ -45,7 +45,7 @@ describe YARD::Options do
       end
       o = ResetDefaultOptions3.new
       o.reset_defaults
-      o.foo.should == 'FOO'
+      expect(o.foo).to eq 'FOO'
     end
   end
 
@@ -53,20 +53,20 @@ describe YARD::Options do
     it "should delete an option" do
       o = FooOptions.new
       o.delete(:foo)
-      o.to_hash.should == {}
+      expect(o.to_hash).to eq ({ } )
     end
 
     it "should not error if an option is deleted that does not exist" do
       o = FooOptions.new
       o.delete(:foo)
       o.delete(:foo)
-      o.to_hash.should == {}
+      expect(o.to_hash).to eq ({ } )
     end
   end
 
   describe '#[]' do
     it "should handle getting option values using hash syntax" do
-      FooOptions.new[:foo].should == "abc"
+      expect(FooOptions.new[:foo]).to eq "abc"
     end
   end
 
@@ -74,13 +74,13 @@ describe YARD::Options do
     it "should handle setting options using hash syntax" do
       o = FooOptions.new
       o[:foo] = "xyz"
-      o[:foo].should == "xyz"
+      expect(o[:foo]).to eq "xyz"
     end
 
     it "should allow setting of unregistered keys" do
       o = FooOptions.new
       o[:bar] = "foo"
-      o[:bar].should == "foo"
+      expect(o[:bar]).to eq "foo"
     end
   end
 
@@ -88,44 +88,44 @@ describe YARD::Options do
     it "should allow setting of unregistered keys" do
       o = FooOptions.new
       o.bar = 'foo'
-      o.bar.should == 'foo'
+      expect(o.bar).to eq 'foo'
     end
 
     it "should allow getting values of unregistered keys (return nil)" do
-      FooOptions.new.bar.should be_nil
+      expect(FooOptions.new.bar).to be_nil
     end
 
     it "should print debugging messages about unregistered keys" do
-      log.should_receive(:debug).with("Attempting to access unregistered key bar on FooOptions")
+      expect(log).to receive(:debug).with("Attempting to access unregistered key bar on FooOptions")
       FooOptions.new.bar
-      log.should_receive(:debug).with("Attempting to set unregistered key bar on FooOptions")
+      expect(log).to receive(:debug).with("Attempting to set unregistered key bar on FooOptions")
       FooOptions.new.bar = 1
     end
   end
 
   describe '#update' do
     it "should allow updating of options" do
-      FooOptions.new.update(:foo => "xyz").foo.should == "xyz"
+      expect(FooOptions.new.update(:foo => "xyz").foo).to eq "xyz"
     end
 
     it "should not ignore keys with no setter (OpenStruct behaviour)" do
       o = FooOptions.new
       o.update(:bar => "xyz")
-      o.to_hash.should == {:foo => "abc", :bar => "xyz"}
+      expect(o.to_hash).to eq ({ :foo => "abc", :bar => "xyz"} )
     end
   end
 
   describe '#merge' do
     it "should update a new object" do
       o = FooOptions.new
-      o.merge(:foo => "xyz").object_id.should_not == o.object_id
-      o.merge(:foo => "xyz").to_hash.should == {:foo => "xyz"}
+      expect(o.merge(:foo => "xyz").object_id).to_not eq o.object_id
+      expect(o.merge(:foo => "xyz").to_hash).to eq ({ :foo => "xyz"} )
     end
 
     it "should add in values from original object" do
       o = FooOptions.new
       o.update(:bar => "foo")
-      o.merge(:baz => 1).to_hash.should == {:foo => "abc", :bar => "foo", :baz => 1}
+      expect(o.merge(:baz => 1).to_hash).to eq ({ :foo => "abc", :bar => "foo", :baz => 1} )
     end
   end
 
@@ -137,10 +137,10 @@ describe YARD::Options do
       end
       o = ToHashOptions1.new
       hash = o.to_hash
-      hash.keys.should include(:foo, :bar, :baz)
-      hash[:foo].should == 1
-      hash[:bar].should == 2
-      hash[:baz].should == "hello"
+      expect(hash.keys).to include(:foo, :bar, :baz)
+      expect(hash[:foo]).to eq 1
+      expect(hash[:bar]).to eq 2
+      expect(hash[:baz]).to eq "hello"
     end
 
     it "should use accessor when converting values to hash" do
@@ -149,7 +149,7 @@ describe YARD::Options do
         def foo; "HELLO#{@foo}" end
       end
       o = ToHashOptions2.new
-      o.to_hash.should == {:foo => "HELLO1"}
+      expect(o.to_hash).to eq ({ :foo => "HELLO1"} )
     end
 
     it "should ignore ivars with no accessor" do
@@ -158,14 +158,14 @@ describe YARD::Options do
         def initialize; @foo = 1; @bar = "NOIGNORE" end
       end
       o = ToHashOptions3.new
-      o.to_hash.should == {:foo => 1, :bar => "NOIGNORE"}
+      expect(o.to_hash).to eq ({ :foo => 1, :bar => "NOIGNORE"} )
     end
   end
 
   describe '#tap' do
     it "should support #tap(&block) (even in 1.8.6)" do
       o = FooOptions.new.tap {|o| o.foo = :BAR }
-      o.to_hash.should == {:foo => :BAR}
+      expect(o.to_hash).to eq ({ :foo => :BAR} )
     end
   end
 end

--- a/spec/parser/base_spec.rb
+++ b/spec/parser/base_spec.rb
@@ -5,20 +5,20 @@ describe YARD::Parser::Base do
     class MyParser < Parser::Base; def initialize(a, b) end end
 
     it "should take 2 arguments" do
-      lambda { YARD::Parser::Base.new }.should raise_error(ArgumentError,
+      expect{ YARD::Parser::Base.new }.to raise_error(ArgumentError,
         /wrong (number|#) of arguments|given 0, expected 2/)
     end
 
     it "should raise NotImplementedError on #initialize" do
-      lambda { YARD::Parser::Base.new('a', 'b') }.should raise_error(NotImplementedError)
+      expect{ YARD::Parser::Base.new('a', 'b') }.to raise_error(NotImplementedError)
     end
 
     it "should raise NotImplementedError on #parse" do
-      lambda { MyParser.new('a', 'b').parse }.should raise_error(NotImplementedError)
+      expect{ MyParser.new('a', 'b').parse }.to raise_error(NotImplementedError)
     end
 
     it "should raise NotImplementedError on #tokenize" do
-      lambda { MyParser.new('a', 'b').tokenize }.should raise_error(NotImplementedError)
+      expect{ MyParser.new('a', 'b').tokenize }.to raise_error(NotImplementedError)
     end
   end
 end

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -15,14 +15,14 @@ describe YARD::Parser::C::CParser do
 
       it "should parse Array class" do
         obj = YARD::Registry.at('Array')
-        obj.should_not be_nil
-        obj.docstring.should_not be_blank
+        expect(obj).to_not be_nil
+        expect(obj.docstring).to_not be_blank
       end
 
       it "should parse method" do
         obj = YARD::Registry.at('Array#initialize')
-        obj.docstring.should_not be_blank
-        obj.tags(:overload).size.should > 1
+        expect(obj.docstring).to_not be_blank
+        expect(obj.tags(:overload).size).to be > 1
       end
     end
 
@@ -35,21 +35,21 @@ describe YARD::Parser::C::CParser do
 
       it "should look for methods in extra files (if 'in' comment is found)" do
         extra_contents = File.read(@extrafile)
-        File.should_receive(:read).with('extra.c').and_return(extra_contents)
+        expect(File).to receive(:read).with('extra.c').and_return(extra_contents)
         parse(@contents)
-        Registry.at('Multifile#extra').docstring.should == 'foo'
+        expect(Registry.at('Multifile#extra').docstring).to eq 'foo'
       end
 
       it "should stop searching for extra source file gracefully if file is not found" do
-        File.should_receive(:read).with('extra.c').and_raise(Errno::ENOENT)
-        log.should_receive(:warn).with("Missing source file `extra.c' when parsing Multifile#extra")
+        expect(File).to receive(:read).with('extra.c').and_raise(Errno::ENOENT)
+        expect(log).to receive(:warn).with("Missing source file `extra.c' when parsing Multifile#extra")
         parse(@contents)
-        Registry.at('Multifile#extra').docstring.should == ''
+        expect(Registry.at('Multifile#extra').docstring).to eq ''
       end
 
       it "should differentiate between a struct and a pointer to a struct retval" do
         parse(@contents)
-        Registry.at('Multifile#hello_mars').docstring.should == 'Hello Mars'
+        expect(Registry.at('Multifile#hello_mars').docstring).to eq 'Hello Mars'
       end
     end
 
@@ -67,8 +67,8 @@ describe YARD::Parser::C::CParser do
             rb_define_method(rb_cFoo, "foo", foo, 1);
           }
         eof
-        Registry.at('Foo#foo').source.gsub(/\s\s+/, ' ').should ==
-          "VALUE foo(VALUE x) { int value = x;\n}"
+        expect(Registry.at('Foo#foo').source.gsub(/\s\s+/, ' ')).
+          to eq "VALUE foo(VALUE x) { int value = x;\n}"
       end
     end
 
@@ -86,8 +86,8 @@ describe YARD::Parser::C::CParser do
           }
         eof
         constant = Registry.at('Mask::DEADBEEF')
-        constant.value.should == '0xdeadbeef'
-        constant.docstring.should == "This constant is frequently used to indicate a\nsoftware crash or deadlock in embedded systems."
+        expect(constant.value).to eq '0xdeadbeef'
+        expect(constant.docstring).to eq "This constant is frequently used to indicate a\nsoftware crash or deadlock in embedded systems."
       end
     end
 
@@ -137,35 +137,35 @@ describe YARD::Parser::C::CParser do
 
     it "should parse GMP::Z class" do
       z = YARD::Registry.at('GMP::Z')
-      z.should_not be_nil
-      z.docstring.should_not be_blank
+      expect(z).to_not be_nil
+      expect(z.docstring).to_not be_blank
     end
 
     it "should parse GMP::Z methods w/ bodies" do
       add = YARD::Registry.at('GMP::Z#+')
-      add.docstring.should_not be_blank
-      add.source.should_not be_nil
-      add.source.should_not be_empty
+      expect(add.docstring).to_not be_blank
+      expect(add.source).to_not be_nil
+      expect(add.source).to_not be_empty
 
       add_self = YARD::Registry.at('GMP::Z#+')
-      add_self.docstring.should_not be_blank
-      add_self.source.should_not be_nil
-      add_self.source.should_not be_empty
+      expect(add_self.docstring).to_not be_blank
+      expect(add_self.source).to_not be_nil
+      expect(add_self.source).to_not be_empty
 
       sqrtrem = YARD::Registry.at('GMP::Z#+')
-      sqrtrem.docstring.should_not be_blank
-      sqrtrem.source.should_not be_nil
-      sqrtrem.source.should_not be_empty
+      expect(sqrtrem.docstring).to_not be_blank
+      expect(sqrtrem.source).to_not be_nil
+      expect(sqrtrem.source).to_not be_empty
     end
 
     it "should parse GMP::Z methods w/o bodies" do
       neg = YARD::Registry.at('GMP::Z#neg')
-      neg.docstring.should_not be_blank
-      neg.source.should be_nil
+      expect(neg.docstring).to_not be_blank
+      expect(neg.source).to be_nil
 
       neg_self = YARD::Registry.at('GMP::Z#neg')
-      neg_self.docstring.should_not be_blank
-      neg_self.source.should be_nil
+      expect(neg_self.docstring).to_not be_blank
+      expect(neg_self.source).to be_nil
     end
   end
 end

--- a/spec/parser/ruby/ast_node_spec.rb
+++ b/spec/parser/ruby/ast_node_spec.rb
@@ -8,12 +8,12 @@ describe YARD::Parser::Ruby::AstNode do
   describe "#jump" do
     it "should jump to the first specific inner node if found" do
       ast = s(:paren, s(:paren, s(:params, s(s(:ident, "hi"), s(:ident, "bye")))))
-      ast.jump(:params)[0][0].type.should equal(:ident)
+      expect(ast.jump(:params)[0][0].type).to equal(:ident)
     end
 
     it "should return the original ast if no inner node is found" do
       ast = s(:paren, s(:list, s(:list, s(s(:ident, "hi"), s(:ident, "bye")))))
-      ast.jump(:params).object_id.should == ast.object_id
+      expect(ast.jump(:params).object_id).to eq ast.object_id
     end
   end
 
@@ -23,7 +23,7 @@ describe YARD::Parser::Ruby::AstNode do
       out = StringIO.new
       PP.pp(obj, out)
       vcall = RUBY_VERSION >= '1.9.3' ? 'vcall' : 'var_ref'
-      out.string.should == "s(s(:#{vcall},\n" +
+      expect(out.string).to eq "s(s(:#{vcall},\n" +
         "      s(:ident, \"bye\", line: 2..2, source: 4..6),\n" +
         "      docstring: \"x\",\n" +
         "      line: 2..2,\n" +

--- a/spec/parser/ruby/legacy/statement_list_spec.rb
+++ b/spec/parser/ruby/legacy/statement_list_spec.rb
@@ -12,9 +12,9 @@ describe YARD::Parser::Ruby::Legacy::StatementList do
       end
 eof
 
-    s.tokens.to_s(true).should == "if\n          foo\n        ...\n      end"
-    s.tokens.to_s.should == "if\n          foo"
-    s.block.to_s.should == "puts 'hi'"
+    expect(s.tokens.to_s(true)).to eq "if\n          foo\n        ...\n      end"
+    expect(s.tokens.to_s).to eq "if\n          foo"
+    expect(s.block.to_s).to eq "puts 'hi'"
 
     s = stmt <<-eof
       if foo ||
@@ -23,72 +23,72 @@ eof
       end
 eof
 
-    s.tokens.to_s(true).should == "if foo ||\n          bar\n        ...\n      end"
-    s.tokens.to_s.should == "if foo ||\n          bar"
-    s.block.to_s.should == "puts 'hi'"
+    expect(s.tokens.to_s(true)).to eq "if foo ||\n          bar\n        ...\n      end"
+    expect(s.tokens.to_s).to eq "if foo ||\n          bar"
+    expect(s.block.to_s).to eq "puts 'hi'"
   end
 
   it "should allow semicolons within parentheses" do
     s = stmt "(foo; bar)"
 
-    s.tokens.to_s(true).should == "(foo; bar)"
-    s.block.should be_nil
+    expect(s.tokens.to_s(true)).to eq "(foo; bar)"
+    expect(s.block).to be_nil
   end
 
   it "should allow for non-block statements" do
     s = stmt "hello_world(1, 2, 3)"
-    s.tokens.to_s.should == "hello_world(1, 2, 3)"
-    s.block.should be_nil
+    expect(s.tokens.to_s).to eq "hello_world(1, 2, 3)"
+    expect(s.block).to be_nil
   end
 
   it "should allow block statements to be used as part of other block statements" do
     s = stmt "while (foo; bar); foo = 12; end; while"
 
-    s.tokens.to_s(true).should == "while (foo; bar); ... end"
-    s.tokens.to_s.should == "while (foo; bar)"
-    s.block.to_s.should == "foo = 12"
+    expect(s.tokens.to_s(true)).to eq "while (foo; bar); ... end"
+    expect(s.tokens.to_s).to eq "while (foo; bar)"
+    expect(s.block.to_s).to eq "foo = 12"
   end
 
   it "should allow continued processing after a block" do
     s = stmt "if foo; end.stuff"
-    s.tokens.to_s(true).should == "if foo; end.stuff"
-    s.block.to_s.should == ""
+    expect(s.tokens.to_s(true)).to eq "if foo; end.stuff"
+    expect(s.block.to_s).to eq ""
 
     s = stmt "if foo; end[stuff]"
-    s.tokens.to_s(true).should == "if foo; end[stuff]"
-    s.block.to_s.should == ""
+    expect(s.tokens.to_s(true)).to eq "if foo; end[stuff]"
+    expect(s.block.to_s).to eq ""
 
     s = stmt "if foo; hi end.map do; 123; end"
-    s.tokens.to_s(true).should == "if foo; ... end.map do; 123; end"
-    s.block.to_s.should == "hi"
+    expect(s.tokens.to_s(true)).to eq "if foo; ... end.map do; 123; end"
+    expect(s.block.to_s).to eq "hi"
   end
 
   it "should parse default arguments" do
     s = stmt "def foo(bar, baz = 1, bang = 2); bar; end"
-    s.tokens.to_s(true).should == "def foo(bar, baz = 1, bang = 2) ... end"
-    s.block.to_s.should == "bar"
+    expect(s.tokens.to_s(true)).to eq "def foo(bar, baz = 1, bang = 2) ... end"
+    expect(s.block.to_s).to eq "bar"
 
     s = stmt "def foo bar, baz = 1, bang = 2; bar; end"
-    s.tokens.to_s(true).should == "def foo bar, baz = 1, bang = 2; ... end"
-    s.block.to_s.should == "bar"
+    expect(s.tokens.to_s(true)).to eq "def foo bar, baz = 1, bang = 2; ... end"
+    expect(s.block.to_s).to eq "bar"
 
     s = stmt "def foo bar , baz = 1 , bang = 2; bar; end"
-    s.tokens.to_s(true).should == "def foo bar , baz = 1 , bang = 2; ... end"
-    s.block.to_s.should == "bar"
+    expect(s.tokens.to_s(true)).to eq "def foo bar , baz = 1 , bang = 2; ... end"
+    expect(s.block.to_s).to eq "bar"
   end
 
   it "should parse complex default arguments" do
     s = stmt "def foo(bar, baz = File.new(1, 2), bang = 3); bar; end"
-    s.tokens.to_s(true).should == "def foo(bar, baz = File.new(1, 2), bang = 3) ... end"
-    s.block.to_s.should == "bar"
+    expect(s.tokens.to_s(true)).to eq "def foo(bar, baz = File.new(1, 2), bang = 3) ... end"
+    expect(s.block.to_s).to eq "bar"
 
     s = stmt "def foo bar, baz = File.new(1, 2), bang = 3; bar; end"
-    s.tokens.to_s(true).should == "def foo bar, baz = File.new(1, 2), bang = 3; ... end"
-    s.block.to_s.should == "bar"
+    expect(s.tokens.to_s(true)).to eq "def foo bar, baz = File.new(1, 2), bang = 3; ... end"
+    expect(s.block.to_s).to eq "bar"
 
     s = stmt "def foo bar , baz = File.new(1, 2) , bang = 3; bar; end"
-    s.tokens.to_s(true).should == "def foo bar , baz = File.new(1, 2) , bang = 3; ... end"
-    s.block.to_s.should == "bar"
+    expect(s.tokens.to_s(true)).to eq "def foo bar , baz = File.new(1, 2) , bang = 3; ... end"
+    expect(s.block.to_s).to eq "bar"
   end
 
   it "should parse blocks with do/end" do
@@ -98,59 +98,59 @@ eof
       end
     eof
 
-    s.tokens.to_s(true).should == "foo do\n        ...\n      end"
-    s.block.to_s.should == "puts 'hi'"
+    expect(s.tokens.to_s(true)).to eq "foo do\n        ...\n      end"
+    expect(s.block.to_s).to eq "puts 'hi'"
   end
 
   it "should parse blocks with {}" do
     s = stmt "x { y }"
-    s.tokens.to_s(true).should == "x { ... }"
-    s.block.to_s.should == "y"
+    expect(s.tokens.to_s(true)).to eq "x { ... }"
+    expect(s.block.to_s).to eq "y"
 
     s = stmt "x() { y }"
-    s.tokens.to_s(true).should == "x() { ... }"
-    s.block.to_s.should == "y"
+    expect(s.tokens.to_s(true)).to eq "x() { ... }"
+    expect(s.block.to_s).to eq "y"
   end
 
   it "should parse blocks with begin/end" do
     s = stmt "begin xyz end"
-    s.tokens.to_s(true).should == "begin ... end"
-    s.block.to_s.should == "xyz"
+    expect(s.tokens.to_s(true)).to eq "begin ... end"
+    expect(s.block.to_s).to eq "xyz"
   end
 
   it "should parse nested blocks" do
     s = stmt "foo(:x) { baz(:y) { skippy } }"
 
-    s.tokens.to_s(true).should == "foo(:x) { ... }"
-    s.block.to_s.should == "baz(:y) { skippy }"
+    expect(s.tokens.to_s(true)).to eq "foo(:x) { ... }"
+    expect(s.block.to_s).to eq "baz(:y) { skippy }"
   end
 
   it "should not parse hashes as blocks" do
     s = stmt "x({})"
-    s.tokens.to_s(true).should == "x({})"
-    s.block.to_s.should == ""
+    expect(s.tokens.to_s(true)).to eq "x({})"
+    expect(s.block.to_s).to eq ""
 
     s = stmt "x = {}"
-    s.tokens.to_s(true).should == "x = {}"
-    s.block.to_s.should == ""
+    expect(s.tokens.to_s(true)).to eq "x = {}"
+    expect(s.block.to_s).to eq ""
 
     s = stmt "x(y, {})"
-    s.tokens.to_s(true).should == "x(y, {})"
-    s.block.to_s.should == ""
+    expect(s.tokens.to_s(true)).to eq "x(y, {})"
+    expect(s.block.to_s).to eq ""
   end
 
   it "should parse hashes in blocks with {}" do
     s = stmt "x {x = {}}"
 
-    s.tokens.to_s(true).should == "x {...}"
-    s.block.to_s.should == "x = {}"
+    expect(s.tokens.to_s(true)).to eq "x {...}"
+    expect(s.block.to_s).to eq "x = {}"
   end
 
   it "should parse blocks with {} in hashes" do
     s = stmt "[:foo, x {}]"
 
-    s.tokens.to_s(true).should == "[:foo, x {}]"
-    s.block.to_s.should == ""
+    expect(s.tokens.to_s(true)).to eq "[:foo, x {}]"
+    expect(s.block.to_s).to eq ""
   end
 
   it "should handle multiple methods" do
@@ -158,7 +158,7 @@ eof
       def %; end
       def b; end
     eof
-    s.to_s.should == "def %; end"
+    expect(s.to_s).to eq "def %; end"
   end
 
   it "should handle nested methods" do
@@ -167,8 +167,8 @@ eof
         def ~@
         end end
     eof
-    s.tokens.to_s(true).should == "def *(o) ... end"
-    s.block.to_s.should == "def +@; end\n        def ~@\n        end"
+    expect(s.tokens.to_s(true)).to eq "def *(o) ... end"
+    expect(s.block.to_s).to eq "def +@; end\n        def ~@\n        end"
 
     s = stmts(<<-eof)
       def /(other) 'hi' end
@@ -176,7 +176,7 @@ eof
         def dynamic; end
       end
     eof
-    s[1].to_s.should == "def method1\n        def dynamic; end\n      end"
+    expect(s[1].to_s).to eq "def method1\n        def dynamic; end\n      end"
   end
 
   it "should get comment line numbers" do
@@ -186,8 +186,8 @@ eof
       # comment
       def method; end
     eof
-    s.comments.should == ["comment", "comment", "comment"]
-    s.comments_range.should == (1..3)
+    expect(s.comments).to eq ["comment", "comment", "comment"]
+    expect(s.comments_range).to eq (1..3)
 
     s = stmt <<-eof
 
@@ -195,8 +195,8 @@ eof
       # comment
       def method; end
     eof
-    s.comments.should == ["comment", "comment"]
-    s.comments_range.should == (2..3)
+    expect(s.comments).to eq ["comment", "comment"]
+    expect(s.comments_range).to eq (2..3)
 
     s = stmt <<-eof
       # comment
@@ -204,21 +204,21 @@ eof
 
       def method; end
     eof
-    s.comments.should == ["comment", "comment"]
-    s.comments_range.should == (1..2)
+    expect(s.comments).to eq ["comment", "comment"]
+    expect(s.comments_range).to eq (1..2)
 
     s = stmt <<-eof
       # comment
       def method; end
     eof
-    s.comments.should == ["comment"]
-    s.comments_range.should == (1..1)
+    expect(s.comments).to eq ["comment"]
+    expect(s.comments_range).to eq (1..1)
 
     s = stmt <<-eof
       def method; end # comment
     eof
-    s.comments.should == ["comment"]
-    s.comments_range.should == (1..1)
+    expect(s.comments).to eq ["comment"]
+    expect(s.comments_range).to eq (1..1)
   end
 
   it "should only look up to two lines back for comments" do
@@ -229,7 +229,7 @@ eof
 
       def method; end
     eof
-    s.comments.should == ["comments"]
+    expect(s.comments).to eq ["comments"]
 
     s = stmt <<-eof
       # comments
@@ -237,7 +237,7 @@ eof
 
       def method; end
     eof
-    s.comments.should == nil
+    expect(s.comments).to eq nil
 
     ss = stmts <<-eof
       # comments
@@ -248,38 +248,38 @@ eof
       # hello
       def method2; end
     eof
-    ss[0].comments.should == nil
-    ss[1].comments.should == ['hello']
+    expect(ss[0].comments).to eq nil
+    expect(ss[1].comments).to eq ['hello']
   end
 
   it "should handle CRLF (Windows) newlines" do
     s = stmts("require 'foo'\r\n\r\n# Test Test\r\n# \r\n# Example:\r\n#   example code\r\ndef test\r\nend\r\n")
-    s[1].comments.should == ['Test Test', '', 'Example:', '  example code']
+    expect(s[1].comments).to eq ['Test Test', '', 'Example:', '  example code']
   end
 
   it "should handle elsif blocks" do
     s = stmts(stmt("if 0\n  foo\nelsif 2\n  bar\nend\nbaz").block)
-    s.size.should == 2
-    s[1].tokens.to_s.should == "elsif 2"
-    s[1].block.to_s.should == "bar"
+    expect(s.size).to eq 2
+    expect(s[1].tokens.to_s).to eq "elsif 2"
+    expect(s[1].block.to_s).to eq "bar"
   end
 
   it "should handle else blocks" do
     s = stmts(stmt("if 0\n  foo\nelse\n  bar\nend\nbaz").block)
-    s.size.should == 2
-    s[1].tokens.to_s.should == "else"
-    s[1].block.to_s.should == "bar"
+    expect(s.size).to eq 2
+    expect(s[1].tokens.to_s).to eq "else"
+    expect(s[1].block.to_s).to eq "bar"
   end
 
   it "should allow aliasing keywords" do
     ['do x', 'x do', 'end begin', 'begin end'].each do |a|
       s = stmt("alias #{a}\ndef foo; end")
-      s.tokens.to_s.should == "alias #{a}"
-      s.block.should be_nil
+      expect(s.tokens.to_s).to eq "alias #{a}"
+      expect(s.block).to be_nil
     end
 
     s = stmt("alias do x if 2 ==\n 2")
-    s.tokens.to_s.should == "alias do x if 2 ==\n 2"
+    expect(s.tokens.to_s).to eq "alias do x if 2 ==\n 2"
   end
 
   it "should not open a block on an aliased keyword block opener" do
@@ -287,13 +287,13 @@ eof
       class A; alias x do end
       class B; end
     eof
-    s[0].block.to_s.should == 'alias x do'
-    s.size.should > 1
+    expect(s[0].block.to_s).to eq 'alias x do'
+    expect(s.size).to be > 1
   end
 
   it "should convert heredoc to string" do
     src = "<<-XML\n  foo\n\nXML"
     s = stmt(src)
-    s.source.should == '"foo\n\n"'
+    expect(s.source).to eq '"foo\n\n"'
   end
 end

--- a/spec/parser/ruby/legacy/token_list_spec.rb
+++ b/spec/parser/ruby/legacy/token_list_spec.rb
@@ -6,40 +6,40 @@ include YARD::Parser::Ruby::Legacy::RubyToken
 describe YARD::Parser::Ruby::Legacy::TokenList do
   describe  "#initialize / #push" do
     it "should accept a tokenlist (via constructor or push)" do
-      lambda { TokenList.new(TokenList.new) }.should_not raise_error(ArgumentError)
-      TokenList.new.push(TokenList.new("x = 2")).size.should == 6
+      expect{TokenList.new(TokenList.new) }.to_not raise_error(ArgumentError)
+      expect(TokenList.new.push(TokenList.new("x = 2")).size).to eq 6
     end
 
     it "accept a token (via constructor or push)" do
-      lambda { TokenList.new(Token.new(0, 0)) }.should_not raise_error(ArgumentError)
-      TokenList.new.push(Token.new(0, 0), Token.new(1, 1)).size.should == 2
+      expect{TokenList.new(Token.new(0, 0)) }.to_not raise_error(ArgumentError)
+      expect(TokenList.new.push(Token.new(0, 0), Token.new(1, 1)).size).to eq 2
     end
 
     it "should accept a string and parse it as code (via constructor or push)" do
-      lambda { TokenList.new("x = 2") }.should_not raise_error(ArgumentError)
+      expect{TokenList.new("x = 2") }.to_not raise_error(ArgumentError)
       x = TokenList.new
       x.push("x", "=", "2")
-      x.size.should == 6
-      x.to_s.should == "x\n=\n2\n"
+      expect(x.size).to eq 6
+      expect(x.to_s).to eq "x\n=\n2\n"
     end
 
     it "should not accept any other input" do
-      lambda { TokenList.new(:notcode) }.should raise_error(ArgumentError)
+      expect{TokenList.new(:notcode) }.to raise_error(ArgumentError)
     end
 
     it "should not interpolate string data" do
       x = TokenList.new('x = "hello #{world}"')
-      x.size.should == 6
-      x[4].class.should == TkDSTRING
-      x.to_s.should == 'x = "hello #{world}"' + "\n"
+      expect(x.size).to eq 6
+      expect(x[4].class).to eq TkDSTRING
+      expect(x.to_s).to eq 'x = "hello #{world}"' + "\n"
     end
 
     it 'handles label syntax' do
       x = TokenList.new('a:1,b:2')
-      x[0].class.should == TkLABEL
-      x[0].text.should == 'a:'
-      x[3].class.should == TkLABEL
-      x[3].text.should == 'b:'
+      expect(x[0].class).to eq TkLABEL
+      expect(x[0].text).to eq 'a:'
+      expect(x[3].class).to eq TkLABEL
+      expect(x[3].text).to eq 'b:'
     end
   end
 
@@ -63,15 +63,15 @@ describe YARD::Parser::Ruby::Legacy::TokenList do
     end
 
     it "should only show the statement portion of the tokens by default" do
-      @t.to_s.should == "def x"
+      expect(@t.to_s).to eq "def x"
     end
 
     it "should show ... for the block token if all of the tokens are shown" do
-      @t.to_s(true).should == "def x; ... end"
+      expect(@t.to_s(true)).to eq "def x; ... end"
     end
 
     it "should ignore ... if show_block = false" do
-      @t.to_s(true, false).should == "def x;  end"
+      expect(@t.to_s(true, false)).to eq "def x;  end"
     end
   end
 end

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -21,8 +21,8 @@ describe YARD::Parser::Ruby::RubyParser do
         # comment
         def method; end
       eof
-      s.comments.should == "comment\ncomment\ncomment"
-      s.comments_range.should == (1..3)
+      expect(s.comments).to eq "comment\ncomment\ncomment"
+      expect(s.comments_range).to eq (1..3)
 
       s = stmt <<-eof
 
@@ -30,8 +30,8 @@ describe YARD::Parser::Ruby::RubyParser do
         # comment
         def method; end
       eof
-      s.comments.should == "comment\ncomment"
-      s.comments_range.should == (2..3)
+      expect(s.comments).to eq "comment\ncomment"
+      expect(s.comments_range).to eq (2..3)
 
       s = stmt <<-eof
         # comment
@@ -39,21 +39,21 @@ describe YARD::Parser::Ruby::RubyParser do
 
         def method; end
       eof
-      s.comments.should == "comment\ncomment"
-      s.comments_range.should == (1..2)
+      expect(s.comments).to eq "comment\ncomment"
+      expect(s.comments_range).to eq (1..2)
 
       s = stmt <<-eof
         # comment
         def method; end
       eof
-      s.comments.should == "comment"
-      s.comments_range.should == (1..1)
+      expect(s.comments).to eq "comment"
+      expect(s.comments_range).to eq (1..1)
 
       s = stmt <<-eof
         def method; end # comment
       eof
-      s.comments.should == "comment"
-      s.comments_range.should == (1..1)
+      expect(s.comments).to eq "comment"
+      expect(s.comments_range).to eq (1..1)
     end
 
     it "should only look up to two lines back for comments" do
@@ -64,7 +64,7 @@ describe YARD::Parser::Ruby::RubyParser do
 
         def method; end
       eof
-      s[1].comments.should == "comments"
+      expect(s[1].comments).to eq "comments"
 
       s = stmts <<-eof
         # comments
@@ -72,7 +72,7 @@ describe YARD::Parser::Ruby::RubyParser do
 
         def method; end
       eof
-      s[1].comments.should == nil
+      expect(s[1].comments).to eq nil
 
       ss = stmts <<-eof
         # comments
@@ -83,8 +83,8 @@ describe YARD::Parser::Ruby::RubyParser do
         # hello
         def method2; end
       eof
-      ss[1].comments.should == nil
-      ss[2].comments.should == 'hello'
+      expect(ss[1].comments).to eq nil
+      expect(ss[2].comments).to eq 'hello'
     end
 
     it "should handle block comment followed by line comment" do
@@ -97,7 +97,7 @@ comments2
 # comments3
 def hello; end
 eof
-      ss.last.comments.should == "comments3"
+      expect(ss.last.comments).to eq "comments3"
     end
 
     it "should handle block comment followed by block comment" do
@@ -110,145 +110,145 @@ comments2
 =end
 def hello; end
 eof
-      ss.last.comments.strip.should == "comments2"
+      expect(ss.last.comments.strip).to eq "comments2"
     end
 
     it "should handle 1.9 lambda syntax with args" do
       src = "->(a,b,c=1,*args,&block) { hello_world }"
-      stmt(src).source.should == src
+      expect(stmt(src).source).to eq src
     end
 
     it "should handle 1.9 lambda syntax" do
       src = "-> { hello_world }"
-      stmt(src).source.should == src
+      expect(stmt(src).source).to eq src
     end
 
     it "should handle standard lambda syntax" do
       src = "lambda { hello_world }"
-      stmt(src).source.should == src
+      expect(stmt(src).source).to eq src
     end
 
     it "should throw a ParserSyntaxError on invalid code" do
-      lambda { stmt("Foo, bar.") }.should raise_error(YARD::Parser::ParserSyntaxError)
+      expect{ stmt("Foo, bar.") }.to raise_error(YARD::Parser::ParserSyntaxError)
     end
 
     it "should handle bare hashes as method parameters" do
       src = "command :a => 1, :b => 2, :c => 3"
-      stmt(src).jump(:command)[1].source.should == ":a => 1, :b => 2, :c => 3"
+      expect(stmt(src).jump(:command)[1].source).to eq ":a => 1, :b => 2, :c => 3"
 
       src = "command a: 1, b: 2, c: 3"
-      stmt(src).jump(:command)[1].source.should == "a: 1, b: 2, c: 3"
+      expect(stmt(src).jump(:command)[1].source).to eq "a: 1, b: 2, c: 3"
     end
 
     it "should handle source for hash syntax" do
       src = "{ :a => 1, :b => 2, :c => 3 }"
-      stmt(src).jump(:hash).source.should == "{ :a => 1, :b => 2, :c => 3 }"
+      expect(stmt(src).jump(:hash).source).to eq "{ :a => 1, :b => 2, :c => 3 }"
     end
 
     it "should handle an empty hash" do
-      stmt("{}").jump(:hash).source.should == "{}"
+      expect(stmt("{}").jump(:hash).source).to eq "{}"
     end
 
     it "new hash label syntax should show label without colon" do
       ast = stmt("{ a: 1 }").jump(:label)
-      ast[0].should == "a"
-      ast.source.should == "a:"
+      expect(ast[0]).to eq "a"
+      expect(ast.source).to eq "a:"
     end
 
     it "should handle begin/rescue blocks" do
       ast = stmt("begin; X; rescue => e; Y end").jump(:rescue)
-      ast.source.should == "rescue => e; Y end"
+      expect(ast.source).to eq "rescue => e; Y end"
 
       ast = stmt("begin; X; rescue A => e; Y end").jump(:rescue)
-      ast.source.should == "rescue A => e; Y end"
+      expect(ast.source).to eq "rescue A => e; Y end"
 
       ast = stmt("begin; X; rescue A, B => e; Y end").jump(:rescue)
-      ast.source.should == "rescue A, B => e; Y end"
+      expect(ast.source).to eq "rescue A, B => e; Y end"
     end
 
     it "should handle method rescue blocks" do
       ast = stmt("def x; A; rescue Y; B end")
-      ast.source.should == "def x; A; rescue Y; B end"
-      ast.jump(:rescue).source.should == "rescue Y; B end"
+      expect(ast.source).to eq "def x; A; rescue Y; B end"
+      expect(ast.jump(:rescue).source).to eq "rescue Y; B end"
     end
 
     it "should handle defs with keywords as method name" do
       ast = stmt("# docstring\nclass A;\ndef class; end\nend")
-      ast.jump(:class).docstring.should == "docstring"
-      ast.jump(:class).line_range.should == (2..4)
+      expect(ast.jump(:class).docstring).to eq "docstring"
+      expect(ast.jump(:class).line_range).to eq (2..4)
     end
 
     it "should end source properly on array reference" do
       ast = stmt("AS[0, 1 ]   ")
-      ast.source.should == 'AS[0, 1 ]'
+      expect(ast.source).to eq 'AS[0, 1 ]'
 
       ast = stmt("def x(a = S[1]) end").jump(:default_arg)
-      ast.source.should == 'a = S[1]'
+      expect(ast.source).to eq 'a = S[1]'
     end
 
     it "should end source properly on if/unless mod" do
       %w(if unless while).each do |mod|
-        stmt("A=1 #{mod} true").source.should == "A=1 #{mod} true"
+        expect(stmt("A=1 #{mod} true").source).to eq "A=1 #{mod} true"
       end
     end
 
     it "should show proper source for assignment" do
-      stmt("A=1").jump(:assign).source.should == "A=1"
+      expect(stmt("A=1").jump(:assign).source).to eq "A=1"
     end
 
     it "should show proper source for a top_const_ref" do
       s = stmt("::\nFoo::Bar")
-      s.jump(:top_const_ref).source.should == "::\nFoo"
-      s.should be_ref
-      s.jump(:top_const_ref).should be_ref
-      s.source.should == "::\nFoo::Bar"
-      s.line_range.to_a.should == [1, 2]
+      expect(s.jump(:top_const_ref).source).to eq "::\nFoo"
+      expect(s).to be_ref
+      expect(s.jump(:top_const_ref)).to be_ref
+      expect(s.source).to eq "::\nFoo::Bar"
+      expect(s.line_range.to_a).to eq [1, 2]
     end
 
     it "should show proper source for inline heredoc" do
       src = "def foo\n  foo(<<-XML, 1, 2)\n    bar\n\n  XML\nend"
       s = stmt(src)
       t = tokenize(src)
-      s.source.should == src
-      t.map {|x| x[1] }.join.should == src
+      expect(s.source).to eq src
+      expect(t.map {|x| x[1] }.join).to eq src
     end
 
     it "should show proper source for regular heredoc" do
       src = "def foo\n  x = <<-XML\n  Hello \#{name}!\n  Bye!\n  XML\nend"
       s = stmt(src)
       t = tokenize(src)
-      s.source.should == src
-      t.map {|x| x[1] }.join.should == src
+      expect(s.source).to eq src
+      expect(t.map {|x| x[1] }.join).to eq src
     end
 
     it "should show proper source for heredoc with comment" do
       src = "def foo\n  x = <<-XML # HI!\n  Hello \#{name}!\n  Bye!\n  XML\nend"
       s = stmt(src)
       t = tokenize(src)
-      s.source.should == src
-      t.map {|x| x[1] }.join.should == src
+      expect(s.source).to eq src
+      expect(t.map {|x| x[1] }.join).to eq src
     end
 
     it "should show proper source for string" do
       ["'", '"'].each do |q|
         src = "#{q}hello\n\nworld#{q}"
         s = stmt(src)
-        s.jump(:string_content).source.should == "hello\n\nworld"
-        s.source.should == src
+        expect(s.jump(:string_content).source).to eq "hello\n\nworld"
+        expect(s.source).to eq src
       end
 
       src = '("this is a string")'
-      stmt(src).jump(:string_literal).source.should == '"this is a string"'
+      expect(stmt(src).jump(:string_literal).source).to eq '"this is a string"'
     end
 
     it "should show proper source for %w() array" do
       src = "%w(\na b c\n d e f\n)"
-      stmt(src).jump(:qwords_literal).source.should == src
+      expect(stmt(src).jump(:qwords_literal).source).to eq src
     end
 
     it "should show proper source for %w{} array" do
       src = "%w{\na b c\n d e f\n}"
-      stmt(src).jump(:array).source.should == src
+      expect(stmt(src).jump(:array).source).to eq src
     end
 
     it "should parse %w() array in constant declaration" do
@@ -257,9 +257,9 @@ eof
           FOO = %w( foo bar )
         end
       eof
-      s.jump(:qwords_literal).source.should == '%w( foo bar )'
+      expect(s.jump(:qwords_literal).source).to eq '%w( foo bar )'
       if RUBY_VERSION >= '1.9.3' # ripper fix: array node encapsulates qwords
-        s.jump(:array).source.should == '%w( foo bar )'
+        expect(s.jump(:array).source).to eq '%w( foo bar )'
       end
     end
 
@@ -268,7 +268,7 @@ eof
         {}[:key]
         FOO = %w( foo bar )
       eof
-      s[1].jump(:array).source.should == '%w( foo bar )'
+      expect(s[1].jump(:array).source).to eq '%w( foo bar )'
     end
 
     it "should parse %w() array source in object[]= parsed context" do
@@ -276,7 +276,7 @@ eof
         {}[:key] = :value
         FOO = %w( foo bar )
       eof
-      s[1].jump(:array).source.should == '%w( foo bar )'
+      expect(s[1].jump(:array).source).to eq '%w( foo bar )'
     end
 
     it "should parse [] as array" do
@@ -285,15 +285,15 @@ eof
           FOO = ['foo', 'bar']
         end
       eof
-      s.jump(:array).source.should == "['foo', 'bar']"
+      expect(s.jump(:array).source).to eq "['foo', 'bar']"
     end
 
     it "should show source for unary minus" do
-      stmt("X = - 1").jump(:unary).source.should == '- 1'
+      expect(stmt("X = - 1").jump(:unary).source).to eq '- 1'
     end
 
     it "should show source for unary exclamation" do
-      stmt("X = !1").jump(:unary).source.should == '!1'
+      expect(stmt("X = !1").jump(:unary).source).to eq '!1'
     end
 
     it "should have the correct line range for class/modules" do
@@ -306,7 +306,7 @@ eof
           # Ending comment
         end
       eof
-      s.jump(:class).line_range.should == (1..7)
+      expect(s.jump(:class).line_range).to eq (1..7)
     end
 
     it "should find lone comments" do
@@ -323,12 +323,12 @@ eof
         end
       eof
       comment = ast.first.last.first
-      comment.type.should == :comment
-      comment.docstring_hash_flag.should be_true
-      comment.docstring.strip.should == "comment here"
+      expect(comment.type).to eq :comment
+      expect(comment.docstring_hash_flag).to be_true
+      expect(comment.docstring.strip).to eq "comment here"
 
-      ast.first.last.last.type.should == :comment
-      ast.first.last.last.docstring.should == "end comment"
+      expect(ast.first.last.last.type).to eq :comment
+      expect(ast.first.last.last.docstring).to eq "end comment"
     end
   end
 end if HAVE_RIPPER

--- a/spec/parser/source_parser_spec.rb
+++ b/spec/parser/source_parser_spec.rb
@@ -47,11 +47,11 @@ describe YARD::Parser::SourceParser do
 
     it "should handle basic callback support" do
       before_list do |files, globals|
-        files.should == ['foo.rb', 'bar.rb']
-        globals.should == OpenStruct.new
+        expect(files).to eq ['foo.rb', 'bar.rb']
+        expect(globals).to eq OpenStruct.new
       end
       parse_list ['foo.rb', 'foo!'], ['bar.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
+      expect(Registry.at('Foo')).to_not be_nil
     end
 
     it "should support multiple callbacks" do
@@ -59,8 +59,8 @@ describe YARD::Parser::SourceParser do
       before_list { checks << :one }
       before_list { checks << :two }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
-      checks.should == [:one, :two]
+      expect(Registry.at('Foo')).to_not be_nil
+      expect(checks).to eq [:one, :two]
     end
 
     it "should cancel parsing if it returns false" do
@@ -69,8 +69,8 @@ describe YARD::Parser::SourceParser do
       before_list { false }
       before_list { checks << :three }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should be_nil
-      checks.should == [:one]
+      expect(Registry.at('Foo')).to be_nil
+      expect(checks).to eq [:one]
     end
 
     it "should not cancel on nil" do
@@ -79,17 +79,17 @@ describe YARD::Parser::SourceParser do
       before_list { nil }
       before_list { checks << :two }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
-      checks.should == [:one, :two]
+      expect(Registry.at('Foo')).to_not be_nil
+      expect(checks).to eq [:one, :two]
     end
 
     it "should pass in globals" do
       before_list {|f,g| g.x = 1 }
       before_list {|f,g| g.x += 1 }
       before_list {|f,g| g.x += 1 }
-      after_list {|f,g| g.x.should == 3 }
+      after_list {|f,g| expect(g.x).to eq 3 }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
+      expect(Registry.at('Foo')).to_not be_nil
     end
   end
 
@@ -102,11 +102,11 @@ describe YARD::Parser::SourceParser do
     it "should handle basic callback support and maintain files/globals" do
       before_list do |f,g| g.foo = :bar end
       after_list do |files, globals|
-        files.should == ['foo.rb', 'bar.rb']
-        globals.foo.should == :bar
+        expect(files).to eq ['foo.rb', 'bar.rb']
+        expect(globals.foo).to eq :bar
       end
       parse_list ['foo.rb', 'foo!'], ['bar.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
+      expect(Registry.at('Foo')).to_not be_nil
     end
 
     it "should support multiple callbacks" do
@@ -114,8 +114,8 @@ describe YARD::Parser::SourceParser do
       after_list { checks << :one }
       after_list { checks << :two }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
-      checks.should == [:one, :two]
+      expect(Registry.at('Foo')).to_not be_nil
+      expect(checks).to eq [:one, :two]
     end
 
     it "should not cancel parsing if it returns false" do
@@ -124,8 +124,8 @@ describe YARD::Parser::SourceParser do
       after_list { false }
       after_list { checks << :three }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
-      checks.should == [:one, :three]
+      expect(Registry.at('Foo')).to_not be_nil
+      expect(checks).to eq [:one, :three]
     end
   end
 
@@ -137,11 +137,11 @@ describe YARD::Parser::SourceParser do
 
     it "should handle basic callback support" do
       before_file do |parser|
-        parser.contents.should == 'class Foo; end'
-        parser.file.should =~ /(foo|bar)\.rb/
+        expect(parser.contents).to eq 'class Foo; end'
+        expect(parser.file).to match( /(foo|bar)\.rb/ )
       end
       parse_list ['foo.rb', 'class Foo; end'], ['bar.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
+      expect(Registry.at('Foo')).to_not be_nil
     end
 
     it "should support multiple callbacks" do
@@ -149,8 +149,8 @@ describe YARD::Parser::SourceParser do
       before_file { checks << :one }
       before_file { checks << :two }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
-      checks.should == [:one, :two, :one, :two, :one, :two]
+      expect(Registry.at('Foo')).to_not be_nil
+      expect(checks).to eq [:one, :two, :one, :two, :one, :two]
     end
 
     it "should cancel parsing if it returns false" do
@@ -159,8 +159,8 @@ describe YARD::Parser::SourceParser do
       before_file { false }
       before_file { checks << :three }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should be_nil
-      checks.should == [:one, :one, :one]
+      expect(Registry.at('Foo')).to be_nil
+      expect(checks).to eq [:one, :one, :one]
     end
 
     it "should not cancel on nil" do
@@ -169,8 +169,8 @@ describe YARD::Parser::SourceParser do
       before_file { nil }
       before_file { checks << :two }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
-      checks.should == [:one, :two, :one, :two, :one, :two]
+      expect(Registry.at('Foo')).to_not be_nil
+      expect(checks).to eq [:one, :two, :one, :two, :one, :two]
     end
   end
 
@@ -182,11 +182,11 @@ describe YARD::Parser::SourceParser do
 
     it "should handle basic callback support" do
       after_file do |parser|
-        parser.contents.should == 'class Foo; end'
-        parser.file.should =~ /(foo|bar)\.rb/
+        expect(parser.contents).to eq 'class Foo; end'
+        expect(parser.file).to match( /(foo|bar)\.rb/ )
       end
       parse_list ['foo.rb', 'class Foo; end'], ['bar.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
+      expect(Registry.at('Foo')).to_not be_nil
     end
 
     it "should support multiple callbacks" do
@@ -194,8 +194,8 @@ describe YARD::Parser::SourceParser do
       after_file { checks << :one }
       after_file { checks << :two }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
-      checks.should == [:one, :two, :one, :two, :one, :two]
+      expect(Registry.at('Foo')).to_not be_nil
+      expect(checks).to eq [:one, :two, :one, :two, :one, :two]
     end
 
     it "should not cancel parsing if it returns false" do
@@ -204,8 +204,8 @@ describe YARD::Parser::SourceParser do
       after_file { false }
       after_file { checks << :three }
       parse_list ['file.rb', ''], ['file2.rb', ''], ['file3.rb', 'class Foo; end']
-      Registry.at('Foo').should_not be_nil
-      checks.should == [:one, :three, :one, :three, :one, :three]
+      expect(Registry.at('Foo')).to_not be_nil
+      expect(checks).to eq [:one, :three, :one, :three, :one, :three]
     end
   end
 
@@ -214,15 +214,15 @@ describe YARD::Parser::SourceParser do
 
     it "should register a subclass of Parser::Base" do
       parser = mock(:parser)
-      parser.should_receive(:parse)
-      MyParser.should_receive(:new).with('content', '(stdin)').and_return(parser)
+      expect(parser).to receive(:parse)
+      expect(MyParser).to receive(:new).with('content', '(stdin)').and_return(parser)
       Parser::SourceParser.register_parser_type(:my_parser, MyParser, 'myparser')
       Parser::SourceParser.parse_string('content', :my_parser)
     end
 
     it "should require class to be a subclass of Parser::Base" do
-      lambda { Parser::SourceParser.register_parser_type(:my_parser, String) }.should raise_error(ArgumentError)
-      lambda { Parser::SourceParser.register_parser_type(:my_parser, Parser::Base) }.should raise_error(ArgumentError)
+      expect{ Parser::SourceParser.register_parser_type(:my_parser, String) }.to raise_error(ArgumentError)
+      expect{ Parser::SourceParser.register_parser_type(:my_parser, Parser::Base) }.to raise_error(ArgumentError)
     end
   end
 
@@ -231,28 +231,28 @@ describe YARD::Parser::SourceParser do
 
     it "should find an extension in a registered array of extensions" do
       Parser::SourceParser.register_parser_type(:my_parser, MyParser, ['a', 'b', 'd'])
-      Parser::SourceParser.parser_type_for_extension('a').should == :my_parser
-      Parser::SourceParser.parser_type_for_extension('b').should == :my_parser
-      Parser::SourceParser.parser_type_for_extension('d').should == :my_parser
-      Parser::SourceParser.parser_type_for_extension('c').should_not == :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('a')).to eq :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('b')).to eq :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('d')).to eq :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('c')).to_not eq :my_parser
     end
 
     it "should find an extension in a Regexp" do
       Parser::SourceParser.register_parser_type(:my_parser, MyParser, /abc$/)
-      Parser::SourceParser.parser_type_for_extension('dabc').should == :my_parser
-      Parser::SourceParser.parser_type_for_extension('dabcd').should_not == :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('dabc')).to eq :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('dabcd')).to_not eq :my_parser
     end
 
     it "should find an extension in a list of Regexps" do
       Parser::SourceParser.register_parser_type(:my_parser, MyParser, [/ab$/, /abc$/])
-      Parser::SourceParser.parser_type_for_extension('dabc').should == :my_parser
-      Parser::SourceParser.parser_type_for_extension('dabcd').should_not == :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('dabc')).to eq :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('dabcd')).to_not eq :my_parser
     end
 
     it "should find an extension in a String" do
       Parser::SourceParser.register_parser_type(:my_parser, MyParser, "abc")
-      Parser::SourceParser.parser_type_for_extension('abc').should == :my_parser
-      Parser::SourceParser.parser_type_for_extension('abcd').should_not == :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('abc')).to eq :my_parser
+      expect(Parser::SourceParser.parser_type_for_extension('abcd')).to_not eq :my_parser
     end
   end
 
@@ -267,10 +267,10 @@ describe YARD::Parser::SourceParser do
           end
         end
       eof
-      Registry.at(:Hello).should_not == nil
-      Registry.at("Hello::Hi#me").should_not == nil
-      Registry.at("Hello::Hi#me").docstring.should == "Docstring\nDocstring2"
-      Registry.at("Hello::Hi#me").docstring.line_range.should == (3..4)
+      expect(Registry.at(:Hello)).to_not eq nil
+      expect(Registry.at("Hello::Hi#me")).to_not eq nil
+      expect(Registry.at("Hello::Hi#me").docstring).to eq "Docstring\nDocstring2"
+      expect(Registry.at("Hello::Hi#me").docstring.line_range).to eq (3..4)
     end
 
     it "should parse Ruby code with metaclasses" do
@@ -284,9 +284,9 @@ describe YARD::Parser::SourceParser do
           end
         end
       eof
-      Registry.at(:Hello).should_not == nil
-      Registry.at("Hello::Hi.me").should_not == nil
-      Registry.at("Hello::Hi.me").docstring.should == "Docstring"
+      expect(Registry.at(:Hello)).to_not eq nil
+      expect(Registry.at("Hello::Hi.me")).to_not eq nil
+      expect(Registry.at("Hello::Hi.me").docstring).to eq "Docstring"
     end
 
     it "should only use prepended comments for an object" do
@@ -297,7 +297,7 @@ describe YARD::Parser::SourceParser do
         module Hello
         end # FAIL
       eof
-      Registry.at(:Hello).docstring.should == "PASS"
+      expect(Registry.at(:Hello).docstring).to eq "PASS"
     end
 
     it "should not add comments appended to last line of block" do
@@ -305,7 +305,7 @@ describe YARD::Parser::SourceParser do
         module Hello2
         end # FAIL
       eof
-      Registry.at(:Hello2).docstring.should be_blank
+      expect(Registry.at(:Hello2).docstring).to be_blank
     end
 
     it "should add comments appended to an object's first line" do
@@ -320,9 +320,9 @@ describe YARD::Parser::SourceParser do
         end
       eof
 
-      Registry.at(:Hello).docstring.should == "PASS"
-      Registry.at(:Hello2).docstring.should == "PASS"
-      Registry.at('Hello2#x').docstring.should == "ANOTHER PASS"
+      expect(Registry.at(:Hello).docstring).to eq "PASS"
+      expect(Registry.at(:Hello2).docstring).to eq "PASS"
+      expect(Registry.at('Hello2#x').docstring).to eq "ANOTHER PASS"
     end
 
     it "should take preceeding comments only if they exist" do
@@ -333,7 +333,7 @@ describe YARD::Parser::SourceParser do
         end
       eof
 
-      Registry.at(:Hello).docstring.should == "PASS"
+      expect(Registry.at(:Hello).docstring).to eq "PASS"
     end
 
     it "should strip all hashes prefixed on comment line" do
@@ -344,35 +344,35 @@ describe YARD::Parser::SourceParser do
         module Hello
         end
       eof
-      Registry.at(:Hello).docstring.should == "PASS\nPASS\nPASS"
+      expect(Registry.at(:Hello).docstring).to eq "PASS\nPASS\nPASS"
     end
 
     it "should handle =begin/=end style comments" do
       YARD.parse_string "=begin\nfoo\nbar\n=end\nclass Foo; end\n"
-      Registry.at(:Foo).docstring.should == "foo\nbar"
+      expect(Registry.at(:Foo).docstring).to eq "foo\nbar"
 
       YARD.parse_string "=begin\n\nfoo\nbar\n=end\nclass Foo; end\n"
-      Registry.at(:Foo).docstring.should == "foo\nbar"
+      expect(Registry.at(:Foo).docstring).to eq "foo\nbar"
 
       YARD.parse_string "=begin\nfoo\n\nbar\n=end\nclass Foo; end\n"
-      Registry.at(:Foo).docstring.should == "foo\n\nbar"
+      expect(Registry.at(:Foo).docstring).to eq "foo\n\nbar"
     end
 
     it "should know about docstrings starting with ##" do
       {'#' => false, '##' => true}.each do |hash, expected|
         YARD.parse_string "#{hash}\n# Foo bar\nclass Foo; end"
-        Registry.at(:Foo).docstring.hash_flag.should == expected
+        expect(Registry.at(:Foo).docstring.hash_flag).to eq expected
       end
     end
 
     it "should remove shebang from initial file comments" do
       YARD.parse_string "#!/bin/ruby\n# this is a comment\nclass Foo; end"
-      Registry.at(:Foo).docstring.should == "this is a comment"
+      expect(Registry.at(:Foo).docstring).to eq "this is a comment"
     end
 
     it "should remove encoding line from initial file comments" do
       YARD.parse_string "# encoding: utf-8\n# this is a comment\nclass Foo; end"
-      Registry.at(:Foo).docstring.should == "this is a comment"
+      expect(Registry.at(:Foo).docstring).to eq "this is a comment"
     end
 
     it "should add macros on any object" do
@@ -387,9 +387,9 @@ describe YARD::Parser::SourceParser do
       eof
 
       macro = CodeObjects::MacroObject.find('foo')
-      macro.macro_data.should == "This is a macro\n@return [String] the string"
-      Registry.at('Foo').docstring.to_raw.should ==  macro.macro_data
-      Registry.at('Foo#foo').docstring.to_raw.should == macro.macro_data
+      expect(macro.macro_data).to eq "This is a macro\n@return [String] the string"
+      expect(Registry.at('Foo').docstring.to_raw).to eq  macro.macro_data
+      expect(Registry.at('Foo#foo').docstring.to_raw).to eq macro.macro_data
     end
 
     it "should allow directives parsed on lone comments" do
@@ -406,12 +406,12 @@ describe YARD::Parser::SourceParser do
       eof
       foo = Registry.at('Foo.foo')
       bar = Registry.at('Foo#bar')
-      foo.should_not be_nil
-      foo.visibility.should == :private
-      foo.tag(:param).name.should == 'a'
-      foo.tag(:return).types.should == ['Symbol']
-      bar.should_not be_nil
-      bar.signature.should == 'def bar(value)'
+      expect(foo).to_not be_nil
+      expect(foo.visibility).to eq :private
+      expect(foo.tag(:param).name).to eq 'a'
+      expect(foo.tag(:return).types).to eq ['Symbol']
+      expect(bar).to_not be_nil
+      expect(bar.signature).to eq 'def bar(value)'
     end
 
     it "should parse lone comments at end of blocks" do
@@ -423,15 +423,15 @@ describe YARD::Parser::SourceParser do
         end
       eof
       foo = Registry.at('Foo#foo')
-      foo.should_not be_nil
-      foo.signature.should == 'def foo(a = "hello")'
+      expect(foo).to_not be_nil
+      expect(foo.signature).to eq 'def foo(a = "hello")'
     end
 
     it "should handle lone comment with no code" do
       YARD.parse_string '# @!method foo(a = "hello")'
       foo = Registry.at('#foo')
-      foo.should_not be_nil
-      foo.signature.should == 'def foo(a = "hello")'
+      expect(foo).to_not be_nil
+      expect(foo.signature).to eq 'def foo(a = "hello")'
     end
 
     it "should handle non-ASCII encoding in heredoc" do
@@ -447,55 +447,55 @@ describe YARD::Parser::SourceParser do
           attr_accessor :foo
         end
       eof
-      Registry.at('Foo').superclass.should == P('Bar')
+      expect(Registry.at('Foo').superclass).to eq P('Bar')
     end
   end
 
   describe '#parse' do
     it "should parse a basic Ruby file" do
       parse_file :example1, __FILE__
-      Registry.at(:Hello).should_not == nil
-      Registry.at("Hello::Hi#me").should_not == nil
-      Registry.at("Hello::Hi#me").docstring.should == "Docstring"
+      expect(Registry.at(:Hello)).to_not eq nil
+      expect(Registry.at("Hello::Hi#me")).to_not eq nil
+      expect(Registry.at("Hello::Hi#me").docstring).to eq "Docstring"
     end
 
     it "should parse a set of file globs" do
-      Dir.should_receive(:[]).with('lib/**/*.rb').and_return([])
+      expect(Dir).to receive(:[]).with('lib/**/*.rb').and_return([])
       YARD.parse('lib/**/*.rb')
     end
 
     it "should parse a set of absolute paths" do
-      Dir.should_not_receive(:[])
-      File.should_receive(:file?).with('/path/to/file').and_return(true)
-      File.should_receive(:read_binary).with('/path/to/file').and_return("")
+      expect(Dir).to_not receive(:[])
+      expect(File).to receive(:file?).with('/path/to/file').and_return(true)
+      expect(File).to receive(:read_binary).with('/path/to/file').and_return("")
       YARD.parse('/path/to/file')
     end
 
     it "should clean paths before parsing" do
-      File.should_receive(:open).and_return("")
+      expect(File).to receive(:open).and_return("")
       parser = Parser::SourceParser.new(:ruby, true)
       parser.parse('a//b//c')
-      parser.file.should == 'a/b/c'
+      expect(parser.file).to eq 'a/b/c'
     end
 
     it "should parse files with '*' in them as globs and others as absolute paths" do
-      Dir.should_receive(:[]).with('*.rb').and_return(['a.rb', 'b.rb'])
-      File.should_receive(:file?).with('/path/to/file').and_return(true)
-      File.should_receive(:file?).with('a.rb').and_return(true)
-      File.should_receive(:file?).with('b.rb').and_return(true)
-      File.should_receive(:read_binary).with('/path/to/file').and_return("")
-      File.should_receive(:read_binary).with('a.rb').and_return("")
-      File.should_receive(:read_binary).with('b.rb').and_return("")
+      expect(Dir).to receive(:[]).with('*.rb').and_return(['a.rb', 'b.rb'])
+      expect(File).to receive(:file?).with('/path/to/file').and_return(true)
+      expect(File).to receive(:file?).with('a.rb').and_return(true)
+      expect(File).to receive(:file?).with('b.rb').and_return(true)
+      expect(File).to receive(:read_binary).with('/path/to/file').and_return("")
+      expect(File).to receive(:read_binary).with('a.rb').and_return("")
+      expect(File).to receive(:read_binary).with('b.rb').and_return("")
       YARD.parse ['/path/to/file', '*.rb']
     end
 
     it "should convert directories into globs" do
-      Dir.should_receive(:[]).with('foo/**/*.{rb,c}').and_return(['foo/a.rb', 'foo/bar/b.rb'])
-      File.should_receive(:directory?).with('foo').and_return(true)
-      File.should_receive(:file?).with('foo/a.rb').and_return(true)
-      File.should_receive(:file?).with('foo/bar/b.rb').and_return(true)
-      File.should_receive(:read_binary).with('foo/a.rb').and_return("")
-      File.should_receive(:read_binary).with('foo/bar/b.rb').and_return("")
+      expect(Dir).to receive(:[]).with('foo/**/*.{rb,c}').and_return(['foo/a.rb', 'foo/bar/b.rb'])
+      expect(File).to receive(:directory?).with('foo').and_return(true)
+      expect(File).to receive(:file?).with('foo/a.rb').and_return(true)
+      expect(File).to receive(:file?).with('foo/bar/b.rb').and_return(true)
+      expect(File).to receive(:read_binary).with('foo/a.rb').and_return("")
+      expect(File).to receive(:read_binary).with('foo/bar/b.rb').and_return("")
       YARD.parse ['foo']
     end
 
@@ -503,17 +503,17 @@ describe YARD::Parser::SourceParser do
       data = 'DATA'
       hash = Registry.checksum_for(data)
       cmock = mock(:cmock)
-      cmock.should_receive(:[]).with('foo/bar').and_return(hash)
-      Registry.should_receive(:checksums).and_return(cmock)
-      File.should_receive(:file?).with('foo/bar').and_return(true)
-      File.should_receive(:read_binary).with('foo/bar').and_return(data)
+      expect(cmock).to receive(:[]).with('foo/bar').and_return(hash)
+      expect(Registry).to receive(:checksums).and_return(cmock)
+      expect(File).to receive(:file?).with('foo/bar').and_return(true)
+      expect(File).to receive(:read_binary).with('foo/bar').and_return(data)
       YARD.parse('foo/bar')
     end
 
     it "should support excluded paths" do
-      File.should_receive(:file?).with('foo/bar').and_return(true)
-      File.should_receive(:file?).with('foo/baz').and_return(true)
-      File.should_not_receive(:read_binary)
+      expect(File).to receive(:file?).with('foo/bar').and_return(true)
+      expect(File).to receive(:file?).with('foo/baz').and_return(true)
+      expect(File).to_not receive(:read_binary)
       YARD.parse(["foo/bar", "foo/baz"], ["foo", /baz$/])
     end
 
@@ -544,12 +544,12 @@ describe YARD::Parser::SourceParser do
         list.each do |src|
           Registry.clear
           parser = Parser::SourceParser.new
-          File.should_receive(:read_binary).with('tmpfile').and_return(src)
+          expect(File).to receive(:read_binary).with('tmpfile').and_return(src)
           result = parser.parse("tmpfile")
           if HAVE_RIPPER && YARD.ruby19?
             if msg == :should_not
               default_encoding = 'UTF-8'
-              result.enumerator[0].source.encoding.to_s.should eq(default_encoding)
+              expect(result.enumerator[0].source.encoding.to_s).to eq(default_encoding)
             else
               ['Shift_JIS', 'Windows-31J', 'UTF-8'].send(msg, include(
                 result.enumerator[0].source.encoding.to_s))
@@ -571,7 +571,7 @@ describe YARD::Parser::SourceParser do
         list.each do |src|
           Registry.clear
           parser = Parser::SourceParser.new
-          File.should_receive(:read_binary).with('tmpfile.c').and_return(src)
+          expect(File).to receive(:read_binary).with('tmpfile.c').and_return(src)
           result = parser.parse("tmpfile.c")
           content = result.instance_variable_get("@content")
           ['UTF-8'].send(msg, include(content.encoding.to_s))
@@ -584,10 +584,10 @@ describe YARD::Parser::SourceParser do
         parser = Parser::SourceParser.new
         src = bom + "class FooBar; end".force_encoding('binary')
         src.force_encoding('binary')
-        File.should_receive(:read_binary).with('tmpfile').and_return(src)
+        expect(File).to receive(:read_binary).with('tmpfile').and_return(src)
         result = parser.parse('tmpfile')
-        Registry.all(:class).first.path.should == "FooBar"
-        result.enumerator[0].source.encoding.to_s.downcase.should == encoding
+        expect(Registry.all(:class).first.path).to eq "FooBar"
+        expect(result.enumerator[0].source.encoding.to_s.downcase).to eq encoding
       end
     end if HAVE_RIPPER && YARD.ruby19?
   end
@@ -601,33 +601,33 @@ describe YARD::Parser::SourceParser do
     it "should attempt to parse files in order" do
       log.enter_level(Logger::DEBUG) do
         msgs = []
-        log.should_receive(:debug) {|m| msgs << m }.at_least(:once)
+        expect(log).to receive(:debug) {|m| msgs << m }.at_least(:once)
         log.stub(:<<)
         in_order_parse 'parse_in_order_001', 'parse_in_order_002'
-        msgs[1].should =~ /Parsing .+parse_in_order_001.+/
-        msgs[2].should =~ /Missing object MyModule/
-        msgs[3].should =~ /Parsing .+parse_in_order_002.+/
-        msgs[4].should =~ /Re-processing .+parse_in_order_001.+/
+        expect(msgs[1]).to match( /Parsing .+parse_in_order_001.+/ )
+        expect(msgs[2]).to match( /Missing object MyModule/ )
+        expect(msgs[3]).to match( /Parsing .+parse_in_order_002.+/ )
+        expect(msgs[4]).to match( /Re-processing .+parse_in_order_001.+/ )
       end
     end
 
     it "should attempt to order files by length for globs (process toplevel files first)" do
       files = %w(a a/b a/b/c)
       files.each do |file|
-        File.should_receive(:file?).with(file).and_return(true)
-        File.should_receive(:read_binary).with(file).ordered.and_return('')
+        expect(File).to receive(:file?).with(file).and_return(true)
+        expect(File).to receive(:read_binary).with(file).ordered.and_return('')
       end
-      Dir.should_receive(:[]).with('a/**/*').and_return(files.reverse)
+      expect(Dir).to receive(:[]).with('a/**/*').and_return(files.reverse)
       YARD.parse 'a/**/*'
     end
 
     it "should allow overriding of length sorting when single file is presented" do
       files = %w(a/b/c a a/b)
       files.each do |file|
-        File.should_receive(:file?).with(file).at_least(1).times.and_return(true)
-        File.should_receive(:read_binary).with(file).ordered.and_return('')
+        expect(File).to receive(:file?).with(file).at_least(1).times.and_return(true)
+        expect(File).to receive(:read_binary).with(file).ordered.and_return('')
       end
-      Dir.should_receive(:[]).with('a/**/*').and_return(files.reverse)
+      expect(Dir).to receive(:[]).with('a/**/*').and_return(files.reverse)
       YARD.parse ['a/b/c', 'a/**/*']
     end
   end
@@ -638,15 +638,15 @@ describe YARD::Parser::SourceParser do
     end
 
     it "should display a warning for invalid parser type" do
-      log.should_receive(:warn).with(/unrecognized file/)
-      log.should_receive(:backtrace)
+      expect(log).to receive(:warn).with(/unrecognized file/)
+      expect(log).to receive(:backtrace)
       YARD::Parser::SourceParser.parse_string("int main() { }", :d)
     end
 
     if HAVE_RIPPER
       it "should display a warning for a syntax error (with new parser)" do
-        log.should_receive(:warn).with(/Syntax error in/)
-        log.should_receive(:backtrace)
+        expect(log).to receive(:warn).with(/Syntax error in/)
+        expect(log).to receive(:backtrace)
         YARD::Parser::SourceParser.parse_string("%!!!", :ruby)
       end
     end
@@ -667,11 +667,11 @@ describe YARD::Parser::SourceParser do
         end
       eof
 
-      Registry.at('A').groups.should == ['Group Name', 'Group 2']
-      Registry.at('A#bar').group.should be_nil
-      Registry.at('A#foo').group.should == "Group Name"
-      Registry.at('A#foo2').group.should == "Group Name"
-      Registry.at('A#baz').group.should == "Group 2"
+      expect(Registry.at('A').groups).to match_array( ['Group Name', 'Group 2'] )
+      expect(Registry.at('A#bar').group).to be_nil
+      expect(Registry.at('A#foo').group).to eq "Group Name"
+      expect(Registry.at('A#foo2').group).to eq "Group Name"
+      expect(Registry.at('A#baz').group).to eq "Group 2"
     end
 
     it 'handles multi-line class/module references' do
@@ -679,7 +679,7 @@ describe YARD::Parser::SourceParser do
         class A::
           B::C; end
       eof
-      Registry.all.should == [P('A::B::C')]
+      expect(Registry.all).to eq [P('A::B::C')]
     end
 
     it 'handles sclass definitions of multi-line class/module references' do
@@ -689,9 +689,9 @@ describe YARD::Parser::SourceParser do
           def foo; end
         end
       eof
-      Registry.all.size.should == 2
-      Registry.at('A::B::C').should_not be_nil
-      Registry.at('A::B::C.foo').should_not be_nil
+      expect(Registry.all.size).to eq 2
+      expect(Registry.at('A::B::C')).to_not be_nil
+      expect(Registry.at('A::B::C.foo')).to_not be_nil
     end
 
     it 'handles lone comment blocks at the end of a namespace' do
@@ -704,14 +704,14 @@ describe YARD::Parser::SourceParser do
           end
         end
       eof
-      Registry.at('A#d').should be_nil
-      Registry.at('A::B#d').should_not be_nil
+      expect(Registry.at('A#d')).to be_nil
+      expect(Registry.at('A::B#d')).to_not be_nil
     end
 
     it 'supports keyword arguments' do
       YARD.parse_string 'def foo(a: 1, b: 2, **kwargs) end'
       args = [['a:', '1'], ['b:', '2'], ['**kwargs', nil]]
-      Registry.at('#foo').parameters.should eq(args)
+      expect(Registry.at('#foo').parameters).to eq(args)
     end if YARD.ruby2?
   end
 end

--- a/spec/parser/tag_parsing_spec.rb
+++ b/spec/parser/tag_parsing_spec.rb
@@ -4,15 +4,15 @@ describe YARD::Parser, "tag handling" do
   before { parse_file :tag_handler_001, __FILE__ }
 
   it "should know the list of all available tags" do
-    P("Foo#foo").tags.should include(P("Foo#foo").tag(:api))
+    expect(P("Foo#foo").tags).to include(P("Foo#foo").tag(:api))
   end
 
   it "should know the text of tags on a method" do
-    P("Foo#foo").tag(:api).text.should == "public"
+    expect(P("Foo#foo").tag(:api).text).to eq "public"
   end
 
   it "should return true when asked whether a tag exists" do
-    P("Foo#foo").has_tag?(:api).should == true
+    expect(P("Foo#foo").has_tag?(:api)).to eq true
   end
 
 end

--- a/spec/rake/yardoc_task_spec.rb
+++ b/spec/rake/yardoc_task_spec.rb
@@ -23,7 +23,7 @@ describe YARD::Rake::YardocTask do
   describe '#initialize' do
     it "should allow separate rake task name to be set" do
       YARD::Rake::YardocTask.new(:notyardoc)
-      ::Rake.application.tasks[0].name.should == "notyardoc"
+      expect(::Rake.application.tasks[0].name).to eq "notyardoc"
     end
   end
 
@@ -33,7 +33,7 @@ describe YARD::Rake::YardocTask do
         t.files = ['a', 'b', 'c']
       end
       run
-      @yardoc.files.should == %w(a b c)
+      expect(@yardoc.files).to eq %w(a b c)
     end
   end
 
@@ -43,7 +43,7 @@ describe YARD::Rake::YardocTask do
         t.options = ['--private', '--protected']
       end
       run
-      @yardoc.visibilities.should == [:public, :private, :protected]
+      expect(@yardoc.visibilities).to eq [:public, :private, :protected]
     end
 
     it "should allow --api and --no-api" do
@@ -59,8 +59,8 @@ describe YARD::Rake::YardocTask do
   describe '#before' do
     it "should allow before callback" do
       proc = lambda { }
-      proc.should_receive(:call)
-      @yardoc.should_receive(:run)
+      expect(proc).to receive(:call)
+      expect(@yardoc).to receive(:run)
       YARD::Rake::YardocTask.new {|t| t.before = proc }
       run
     end
@@ -69,8 +69,8 @@ describe YARD::Rake::YardocTask do
   describe '#after' do
     it "should allow after callback" do
       proc = lambda { }
-      proc.should_receive(:call)
-      @yardoc.should_receive(:run)
+      expect(proc).to receive(:call)
+      expect(@yardoc).to receive(:run)
       YARD::Rake::YardocTask.new {|t| t.after = proc }
       run
     end
@@ -79,8 +79,8 @@ describe YARD::Rake::YardocTask do
   describe '#verifier' do
     it "should allow a verifier proc to be set" do
       verifier = Verifier.new
-      @yardoc.should_receive(:run) do
-        @yardoc.options[:verifier].should == verifier
+      expect(@yardoc).to receive(:run) do
+        expect(@yardoc.options[:verifier]).to eq verifier
       end
       YARD::Rake::YardocTask.new {|t| t.verifier = verifier }
       run
@@ -88,8 +88,8 @@ describe YARD::Rake::YardocTask do
 
     it "should override --query options" do
       verifier = Verifier.new
-      @yardoc.should_receive(:run) do
-        @yardoc.options[:verifier].should == verifier
+      expect(@yardoc).to receive(:run) do
+        expect(@yardoc.options[:verifier]).to eq verifier
       end
       YARD::Rake::YardocTask.new do |t|
         t.options += ['--query', '@return']

--- a/spec/registry_spec.rb
+++ b/spec/registry_spec.rb
@@ -15,69 +15,69 @@ describe YARD::Registry do
     end
 
     it "should return nil if gem isn't found" do
-      Gem.source_index.should_receive(:find_name).with('foo', '>= 0').and_return([])
-      Registry.yardoc_file_for_gem('foo').should == nil
+      expect(Gem.source_index).to receive(:find_name).with('foo', '>= 0').and_return([])
+      expect(Registry.yardoc_file_for_gem('foo')).to eq nil
     end
 
     it "should allow version to be specified" do
-      Gem.source_index.should_receive(:find_name).with('foo', '= 2').and_return([])
-      Registry.yardoc_file_for_gem('foo', '= 2').should == nil
+      expect(Gem.source_index).to receive(:find_name).with('foo', '= 2').and_return([])
+      expect(Registry.yardoc_file_for_gem('foo', '= 2')).to eq nil
     end
 
     it "should return existing .yardoc path for gem when for_writing=false" do
-      File.should_receive(:exist?).and_return(false)
-      File.should_receive(:exist?).with('/path/to/foo/.yardoc').and_return(true)
-      Gem.source_index.should_receive(:find_name).with('foo', '>= 0').and_return([@gem])
-      Registry.yardoc_file_for_gem('foo').should == '/path/to/foo/.yardoc'
+      expect(File).to receive(:exist?).and_return(false)
+      expect(File).to receive(:exist?).with('/path/to/foo/.yardoc').and_return(true)
+      expect(Gem.source_index).to receive(:find_name).with('foo', '>= 0').and_return([@gem])
+      expect(Registry.yardoc_file_for_gem('foo')).to eq '/path/to/foo/.yardoc'
     end
 
     it "should return nil if no .yardoc path exists in gem when for_writing=false" do
-      File.should_receive(:exist?).and_return(false)
-      File.should_receive(:exist?).with('/path/to/foo/.yardoc').and_return(false)
-      Gem.source_index.should_receive(:find_name).with('foo', '>= 0').and_return([@gem])
-      Registry.yardoc_file_for_gem('foo').should == nil
+      expect(File).to receive(:exist?).and_return(false)
+      expect(File).to receive(:exist?).with('/path/to/foo/.yardoc').and_return(false)
+      expect(Gem.source_index).to receive(:find_name).with('foo', '>= 0').and_return([@gem])
+      expect(Registry.yardoc_file_for_gem('foo')).to eq nil
     end
 
     it "should search local gem path first if for_writing=false" do
-      File.should_receive(:exist?).and_return(true)
-      Gem.source_index.should_receive(:find_name).with('foo', '>= 0').and_return([@gem])
-      Registry.yardoc_file_for_gem('foo').should =~ %r{/.yard/gem_index/foo-1.0.yardoc$}
+      expect(File).to receive(:exist?).and_return(true)
+      expect(Gem.source_index).to receive(:find_name).with('foo', '>= 0').and_return([@gem])
+      expect(Registry.yardoc_file_for_gem('foo')).to match( %r{/.yard/gem_index/foo-1.0.yardoc$} )
     end
 
     it "should return global .yardoc path for gem if for_writing=true and dir is writable" do
-      File.should_receive(:writable?).with(@gem.full_gem_path).and_return(true)
-      Gem.source_index.should_receive(:find_name).with('foo', '>= 0').and_return([@gem])
-      Registry.yardoc_file_for_gem('foo', '>= 0', true).should == '/path/to/foo/.yardoc'
+      expect(File).to receive(:writable?).with(@gem.full_gem_path).and_return(true)
+      expect(Gem.source_index).to receive(:find_name).with('foo', '>= 0').and_return([@gem])
+      expect(Registry.yardoc_file_for_gem('foo', '>= 0', true)).to eq '/path/to/foo/.yardoc'
     end
 
     it "should return local .yardoc path for gem if for_writing=true and dir is not writable" do
-      File.should_receive(:writable?).with(@gem.full_gem_path).and_return(false)
-      Gem.source_index.should_receive(:find_name).with('foo', '>= 0').and_return([@gem])
-      Registry.yardoc_file_for_gem('foo', '>= 0', true).should =~ %r{/.yard/gem_index/foo-1.0.yardoc$}
+      expect(File).to receive(:writable?).with(@gem.full_gem_path).and_return(false)
+      expect(Gem.source_index).to receive(:find_name).with('foo', '>= 0').and_return([@gem])
+      expect(Registry.yardoc_file_for_gem('foo', '>= 0', true)).to match( %r{/.yard/gem_index/foo-1.0.yardoc$} )
     end
 
     it "should return gem path if gem starts with yard-doc- and for_writing=false" do
       @gem.stub!(:name).and_return('yard-doc-core')
       @gem.stub!(:full_name).and_return('yard-doc-core-1.0')
       @gem.stub!(:full_gem_path).and_return('/path/to/yard-doc-core')
-      Gem.source_index.should_receive(:find_name).with('yard-doc-core', '>= 0').and_return([@gem])
-      File.should_receive(:exist?).with('/path/to/yard-doc-core/.yardoc').and_return(true)
-      Registry.yardoc_file_for_gem('yard-doc-core').should == '/path/to/yard-doc-core/.yardoc'
+      expect(Gem.source_index).to receive(:find_name).with('yard-doc-core', '>= 0').and_return([@gem])
+      expect(File).to receive(:exist?).with('/path/to/yard-doc-core/.yardoc').and_return(true)
+      expect(Registry.yardoc_file_for_gem('yard-doc-core')).to eq '/path/to/yard-doc-core/.yardoc'
     end
 
     it "should return nil if gem starts with yard-doc- and for_writing=true" do
       @gem.stub!(:name).and_return('yard-doc-core')
       @gem.stub!(:full_name).and_return('yard-doc-core-1.0')
       @gem.stub!(:full_gem_path).and_return('/path/to/yard-doc-core')
-      Gem.source_index.should_receive(:find_name).with('yard-doc-core', '>= 0').and_return([@gem])
-      File.should_receive(:exist?).with('/path/to/yard-doc-core/.yardoc').and_return(true)
-      Registry.yardoc_file_for_gem('yard-doc-core', '>= 0', true).should == nil
+      expect(Gem.source_index).to receive(:find_name).with('yard-doc-core', '>= 0').and_return([@gem])
+      expect(File).to receive(:exist?).with('/path/to/yard-doc-core/.yardoc').and_return(true)
+      expect(Registry.yardoc_file_for_gem('yard-doc-core', '>= 0', true)).to eq nil
     end
   end
 
   describe '.root' do
     it "should have an empty path for root" do
-      Registry.root.path.should == ""
+      expect(Registry.root.path).to eq ""
     end
   end
 
@@ -85,8 +85,8 @@ describe YARD::Registry do
     it "should load locale object" do
       fr_locale = I18n::Locale.new("fr")
       store = Registry.send(:thread_local_store)
-      store.should_receive(:locale).with("fr").and_return(fr_locale)
-      Registry.locale("fr").should == fr_locale
+      expect(store).to receive(:locale).with("fr").and_return(fr_locale)
+      expect(Registry.locale("fr")).to eq fr_locale
     end
   end
 
@@ -95,7 +95,7 @@ describe YARD::Registry do
       o1 = ModuleObject.new(:root, :A)
       o2 = ModuleObject.new(o1, :B)
       o3 = ModuleObject.new(o2, :C)
-      Registry.resolve(o1, "B::C").should == o3
+      expect(Registry.resolve(o1, "B::C")).to eq o3
       Registry.resolve(:root, "A::B::C")
     end
 
@@ -103,9 +103,9 @@ describe YARD::Registry do
       o1 = ModuleObject.new(:root, :A)
       o2 = ModuleObject.new(o1, :B)
       o3 = ModuleObject.new(o2, :C)
-      Registry.resolve(o3, "::A").should == o1
+      expect(Registry.resolve(o3, "::A")).to eq o1
 
-      Registry.resolve(o3, "::String", false, true).should == P(:String)
+      expect(Registry.resolve(o3, "::String", false, true)).to eq P(:String)
     end
 
     it "should resolve instance methods with # prefix" do
@@ -113,14 +113,14 @@ describe YARD::Registry do
       o2 = ModuleObject.new(o1, :B)
       o3 = ModuleObject.new(o2, :C)
       o4 = MethodObject.new(o3, :methname)
-      Registry.resolve(o1, "B::C#methname").should == o4
-      Registry.resolve(o2, "C#methname").should == o4
-      Registry.resolve(o3, "#methname").should == o4
+      expect(Registry.resolve(o1, "B::C#methname")).to eq o4
+      expect(Registry.resolve(o2, "C#methname")).to eq o4
+      expect(Registry.resolve(o3, "#methname")).to eq o4
     end
 
     it "should resolve instance methods in the root without # prefix" do
       o = MethodObject.new(:root, :methname)
-      Registry.resolve(:root, 'methname').should == o
+      expect(Registry.resolve(:root, 'methname')).to eq o
     end
 
     it "should resolve superclass methods when inheritance = true" do
@@ -130,10 +130,10 @@ describe YARD::Registry do
       imeth = MethodObject.new(superyard, :hello)
       cmeth = MethodObject.new(superyard, :class_hello, :class)
 
-      Registry.resolve(yard, "#hello", false).should be_nil
-      Registry.resolve(yard, "#hello", true).should == imeth
-      Registry.resolve(yard, "class_hello", false).should be_nil
-      Registry.resolve(yard, "class_hello", true).should == cmeth
+      expect(Registry.resolve(yard, "#hello", false)).to be_nil
+      expect(Registry.resolve(yard, "#hello", true)).to eq imeth
+      expect(Registry.resolve(yard, "class_hello", false)).to be_nil
+      expect(Registry.resolve(yard, "class_hello", true)).to eq cmeth
     end
 
     it "should resolve mixin methods when inheritance = true" do
@@ -143,10 +143,10 @@ describe YARD::Registry do
       imeth = MethodObject.new(mixin, :hello)
       cmeth = MethodObject.new(mixin, :class_hello, :class)
 
-      Registry.resolve(yard, "#hello", false).should be_nil
-      Registry.resolve(yard, "#hello", true).should == imeth
-      Registry.resolve(yard, "class_hello", false).should be_nil
-      Registry.resolve(yard, "class_hello", true).should == cmeth
+      expect(Registry.resolve(yard, "#hello", false)).to be_nil
+      expect(Registry.resolve(yard, "#hello", true)).to eq imeth
+      expect(Registry.resolve(yard, "class_hello", false)).to be_nil
+      expect(Registry.resolve(yard, "class_hello", true)).to eq cmeth
     end
 
     it "should resolve methods in Object when inheritance = true" do
@@ -156,7 +156,7 @@ describe YARD::Registry do
         class MyObject < A; end
       eof
 
-      Registry.resolve(P('MyObject'), '#foo', true).should == P('Object#foo')
+      expect(Registry.resolve(P('MyObject'), '#foo', true)).to eq P('Object#foo')
     end
 
     it "should resolve methods in BasicObject when inheritance = true" do
@@ -166,7 +166,7 @@ describe YARD::Registry do
         class MyObject < A; end
       eof
 
-      Registry.resolve(P('MyObject'), '#foo', true).should == P('BasicObject#foo')
+      expect(Registry.resolve(P('MyObject'), '#foo', true)).to eq P('BasicObject#foo')
     end
 
     it "should not resolve methods in Object if inheriting BasicObject when inheritance = true" do
@@ -175,13 +175,13 @@ describe YARD::Registry do
         class MyObject < BasicObject; end
       eof
 
-      Registry.resolve(P('MyObject'), '#foo', true).should be_nil
+      expect(Registry.resolve(P('MyObject'), '#foo', true)).to be_nil
     end
 
     it "should allow type=:typename to ensure resolved object is of a certain type" do
       YARD.parse_string "class Foo; end"
-      Registry.resolve(Registry.root, 'Foo').should == Registry.at('Foo')
-      Registry.resolve(Registry.root, 'Foo', false, false, :method).should be_nil
+      expect(Registry.resolve(Registry.root, 'Foo')).to eq Registry.at('Foo')
+      expect(Registry.resolve(Registry.root, 'Foo', false, false, :method)).to be_nil
     end
 
     it "should allow keep trying to find obj where type equals object type" do
@@ -191,27 +191,26 @@ describe YARD::Registry do
           def self.Bar; end
         end
       eof
-      Registry.resolve(P('Foo'), 'Bar').should == Registry.at('Foo::Bar')
-      Registry.resolve(P('Foo'), 'Bar', false, false, :method).should == 
-        Registry.at('Foo.Bar')
+      expect(Registry.resolve(P('Foo'), 'Bar')).to eq Registry.at('Foo::Bar')
+      expect(Registry.resolve(P('Foo'), 'Bar', false, false, :method)).to eq Registry.at('Foo.Bar')
     end
 
     it "should return proxy fallback with given type if supplied" do
       YARD.parse_string "module Foo; end"
       proxy = Registry.resolve(P('Foo'), 'Bar', false, true, :method)
-      proxy.type.should == :method
+      expect(proxy.type).to eq :method
       proxy = Registry.resolve(P('Qux'), 'Bar', false, true, :method)
-      proxy.type.should == :method
+      expect(proxy.type).to eq :method
     end
 
     it "should only check 'Path' in lookup on root namespace" do
-      Registry.should_receive(:at).once.with('Test').and_return(true)
+      expect(Registry).to receive(:at).once.with('Test').and_return(true)
       Registry.resolve(Registry.root, "Test")
     end
 
     it "should not perform lookup by joining namespace and name without separator" do
       yard = ClassObject.new(:root, :YARD)
-      Registry.should_not_receive(:at).with('YARDB')
+      expect(Registry).to_not receive(:at).with('YARDB')
       Registry.resolve(yard, 'B')
     end
   end
@@ -222,7 +221,7 @@ describe YARD::Registry do
       o1 = ClassObject.new(:root, :B)
       o2 = MethodObject.new(:root, :testing)
       r = Registry.all(:method, :class)
-      r.should include(o1, o2)
+      expect(r).to include(o1, o2)
     end
 
     it "should return code objects" do
@@ -230,14 +229,14 @@ describe YARD::Registry do
       o2 = ClassObject.new(:root, :B)
       MethodObject.new(:root, :testing)
       r = Registry.all.select {|t| NamespaceObject === t }
-      r.should include(o1, o2)
+      expect(r).to include(o1, o2)
     end
 
     it "should allow .all to omit list" do
       o1 = ModuleObject.new(:root, :A)
       o2 = ClassObject.new(:root, :B)
       r = Registry.all
-      r.should include(o1, o2)
+      expect(r).to include(o1, o2)
     end
   end
 
@@ -245,36 +244,36 @@ describe YARD::Registry do
     it "should return all object paths" do
       o1 = ModuleObject.new(:root, :A)
       o2 = ClassObject.new(:root, :B)
-      Registry.paths.should include('A', 'B')
+      expect(Registry.paths).to include('A', 'B')
     end
   end
 
   describe '.load_yardoc' do
     it "should delegate load to RegistryStore" do
       store = RegistryStore.new
-      store.should_receive(:load).with('foo')
-      RegistryStore.should_receive(:new).and_return(store)
+      expect(store).to receive(:load).with('foo')
+      expect(RegistryStore).to receive(:new).and_return(store)
       Registry.yardoc_file = 'foo'
       Registry.load_yardoc
     end
 
     it "should return itself" do
-      Registry.load_yardoc.should == Registry
+      expect(Registry.load_yardoc).to eq Registry
     end
 
     it "should maintain hash key equality on loaded objects" do
       Registry.clear
       Registry.load!(File.dirname(__FILE__) + '/serializers/data/serialized_yardoc')
       baz = Registry.at('Foo#baz')
-      Registry.at('Foo').aliases.keys.should include(baz)
-      Registry.at('Foo').aliases.has_key?(baz).should == true
+      expect(Registry.at('Foo').aliases.keys).to include(baz)
+      expect(Registry.at('Foo').aliases.has_key?(baz)).to eq true
     end
   end
 
   ['load', 'load_all', 'load!'].each do |meth|
     describe('.' + meth) do
       it "should return itself" do
-        Registry.send(meth).should == Registry
+        expect(Registry.send(meth)).to eq Registry
       end
     end
   end
@@ -289,24 +288,24 @@ describe YARD::Registry do
     it "should iterate over .all" do
       items = []
       Registry.each {|x| items << x.path }
-      items.sort.should == ['#a', '#b', '#c']
+      expect(items.sort).to eq ['#a', '#b', '#c']
     end
 
     it "should include Enumerable and allow for find, select" do
-      Registry.find {|x| x.path == "#a" }.should be_a(CodeObjects::MethodObject)
+      expect(Registry.find {|x| x.path == "#a" }).to be_a(CodeObjects::MethodObject)
     end
   end
 
   describe '.instance' do
     it "should return itself" do
-      Registry.instance.should == Registry
+      expect(Registry.instance).to eq Registry
     end
   end
 
   describe '.single_object_db' do
     it "should default to nil" do
-      Registry.single_object_db.should == nil
-      Thread.new { Registry.single_object_db.should == nil }.join
+      expect(Registry.single_object_db).to eq nil
+      Thread.new { expect(Registry.single_object_db).to eq nil }.join
     end
   end
 
@@ -322,7 +321,7 @@ describe YARD::Registry do
         while barrier < 2 do
           s = "barrier < 2, spinning"
         end
-        Registry.at('Foo').docstring.should == "docstring 1"
+        expect(Registry.at('Foo').docstring).to eq "docstring 1"
       end
       threads << Thread.new do
         Registry.clear
@@ -331,7 +330,7 @@ describe YARD::Registry do
         while barrier < 2 do
           s = "barrier < 2, spinning"
         end
-        Registry.at('Foo').docstring.should == "docstring 2"
+        expect(Registry.at('Foo').docstring).to eq "docstring 2"
       end
       threads.each {|t| t.join }
     end
@@ -341,19 +340,19 @@ describe YARD::Registry do
       mutex   = Mutex.new
       threads = []
       threads << Thread.new do
-        Registry.yardoc_file.should == '.yardoc'
+        expect(Registry.yardoc_file).to eq '.yardoc'
         Registry.yardoc_file = 'foo'
         mutex.synchronize { barrier += 1 }
         while barrier == 1 do
           s = "barrier = 1, spinning"
         end
-        Registry.yardoc_file.should == 'foo'
+        expect(Registry.yardoc_file).to eq 'foo'
       end
       threads << Thread.new do
         while barrier == 0 do
           s = "barrier = 0, spinning"
         end
-        Registry.yardoc_file.should == '.yardoc'
+        expect(Registry.yardoc_file).to eq '.yardoc'
         mutex.synchronize { barrier += 1 }
         Registry.yardoc_file = 'foo2'
       end
@@ -362,7 +361,7 @@ describe YARD::Registry do
     end
 
     it "should automatically clear in new threads" do
-      Thread.new { Registry.all.should be_empty }.join
+      Thread.new { expect(Registry.all).to be_empty }.join
     end
 
     it "should allow setting of po_dir in separate threads" do
@@ -370,19 +369,19 @@ describe YARD::Registry do
       mutex   = Mutex.new
       threads = []
       threads << Thread.new do
-        Registry.po_dir.should == 'po'
+        expect(Registry.po_dir).to eq 'po'
         Registry.po_dir = 'locale'
         mutex.synchronize { barrier += 1 }
         while barrier == 1 do
           s = "barrier = 1, spinning"
         end
-        Registry.po_dir.should == 'locale'
+        expect(Registry.po_dir).to eq 'locale'
       end
       threads << Thread.new do
         while barrier == 0 do
           s = "barrier = 0, spinning"
         end
-        Registry.po_dir.should == 'po'
+        expect(Registry.po_dir).to eq 'po'
         mutex.synchronize { barrier += 1 }
         Registry.po_dir = '.'
       end

--- a/spec/registry_store_spec.rb
+++ b/spec/registry_store_spec.rb
@@ -12,92 +12,92 @@ describe YARD::RegistryStore do
 
   describe '#load' do
     it "should load root.dat as full object list if it is a Hash" do
-      File.should_receive(:directory?).with('foo').and_return(true)
-      File.should_receive(:file?).with('foo/checksums').and_return(false)
-      File.should_receive(:file?).with('foo/proxy_types').and_return(false)
-      File.should_receive(:file?).with('foo/object_types').and_return(false)
-      @serializer.should_receive(:deserialize).with('root').and_return({:root => @foo, :A => @bar})
-      @store.load('foo').should == true
-      @store.root.should == @foo
-      @store.get('A').should == @bar
+      expect(File).to receive(:directory?).with('foo').and_return(true)
+      expect(File).to receive(:file?).with('foo/checksums').and_return(false)
+      expect(File).to receive(:file?).with('foo/proxy_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/object_types').and_return(false)
+      expect(@serializer).to receive(:deserialize).with('root').and_return({:root => @foo, :A => @bar})
+      expect(@store.load('foo')).to eq true
+      expect(@store.root).to eq @foo
+      expect(@store.get('A')).to eq @bar
     end
 
     it "should load old yardoc format if .yardoc is a file" do
-      File.should_receive(:directory?).with('foo').and_return(false)
-      File.should_receive(:file?).with('foo').and_return(true)
-      File.should_receive(:read_binary).with('foo').and_return('FOO')
-      Marshal.should_receive(:load).with('FOO')
+      expect(File).to receive(:directory?).with('foo').and_return(false)
+      expect(File).to receive(:file?).with('foo').and_return(true)
+      expect(File).to receive(:read_binary).with('foo').and_return('FOO')
+      expect(Marshal).to receive(:load).with('FOO')
 
       @store.load('foo')
     end
 
     it "should load new yardoc format if .yardoc is a directory" do
-      File.should_receive(:directory?).with('foo').and_return(true)
-      File.should_receive(:file?).with('foo/checksums').and_return(false)
-      File.should_receive(:file?).with('foo/proxy_types').and_return(false)
-      File.should_receive(:file?).with('foo/object_types').and_return(false)
-      File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
+      expect(File).to receive(:directory?).with('foo').and_return(true)
+      expect(File).to receive(:file?).with('foo/checksums').and_return(false)
+      expect(File).to receive(:file?).with('foo/proxy_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/object_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/objects/root.dat').and_return(false)
 
-      @store.load('foo').should == true
+      expect(@store.load('foo')).to eq true
     end
 
     it "should return true if .yardoc is loaded (file)" do
-      File.should_receive(:directory?).with('myyardoc').and_return(false)
-      File.should_receive(:file?).with('myyardoc').and_return(true)
-      File.should_receive(:read_binary).with('myyardoc').and_return(Marshal.dump(''))
-      @store.load('myyardoc').should == true
+      expect(File).to receive(:directory?).with('myyardoc').and_return(false)
+      expect(File).to receive(:file?).with('myyardoc').and_return(true)
+      expect(File).to receive(:read_binary).with('myyardoc').and_return(Marshal.dump(''))
+      expect(@store.load('myyardoc')).to eq true
     end
 
     it "should return true if .yardoc is loaded (directory)" do
-      File.should_receive(:directory?).with('foo').and_return(true)
-      File.should_receive(:file?).with('foo/checksums').and_return(false)
-      File.should_receive(:file?).with('foo/proxy_types').and_return(false)
-      File.should_receive(:file?).with('foo/object_types').and_return(false)
-      File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
-      @store.load('foo').should == true
+      expect(File).to receive(:directory?).with('foo').and_return(true)
+      expect(File).to receive(:file?).with('foo/checksums').and_return(false)
+      expect(File).to receive(:file?).with('foo/proxy_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/object_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/objects/root.dat').and_return(false)
+      expect(@store.load('foo')).to eq true
     end
 
     it "should return false if .yardoc does not exist" do
-      @store.load('NONEXIST').should == false
+      expect(@store.load('NONEXIST')).to eq false
     end
 
     it "should return false if there is no file to load" do
-      @store.load(nil).should == false
+      expect(@store.load(nil)).to eq false
     end
 
     it "should load checksums if they exist" do
-      File.should_receive(:directory?).with('foo').and_return(true)
-      File.should_receive(:file?).with('foo/checksums').and_return(true)
-      File.should_receive(:file?).with('foo/proxy_types').and_return(false)
-      File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
-      File.should_receive(:file?).with('foo/object_types').and_return(false)
-      File.should_receive(:readlines).with('foo/checksums').and_return([
+      expect(File).to receive(:directory?).with('foo').and_return(true)
+      expect(File).to receive(:file?).with('foo/checksums').and_return(true)
+      expect(File).to receive(:file?).with('foo/proxy_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/objects/root.dat').and_return(false)
+      expect(File).to receive(:file?).with('foo/object_types').and_return(false)
+      expect(File).to receive(:readlines).with('foo/checksums').and_return([
         'file1 CHECKSUM1', '  file2 CHECKSUM2 '
       ])
-      @store.load('foo').should == true
-      @store.checksums.should == {'file1' => 'CHECKSUM1', 'file2' => 'CHECKSUM2'}
+      expect(@store.load('foo')).to eq true
+      expect(@store.checksums).to eq ({ 'file1' => 'CHECKSUM1', 'file2' => 'CHECKSUM2'} )
     end
 
     it "should load proxy_types if they exist" do
-      File.should_receive(:directory?).with('foo').and_return(true)
-      File.should_receive(:file?).with('foo/checksums').and_return(false)
-      File.should_receive(:file?).with('foo/proxy_types').and_return(true)
-      File.should_receive(:file?).with('foo/object_types').and_return(false)
-      File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
-      File.should_receive(:read_binary).with('foo/proxy_types').and_return(Marshal.dump({'a' => 'b'}))
-      @store.load('foo').should == true
-      @store.proxy_types.should == {'a' => 'b'}
+      expect(File).to receive(:directory?).with('foo').and_return(true)
+      expect(File).to receive(:file?).with('foo/checksums').and_return(false)
+      expect(File).to receive(:file?).with('foo/proxy_types').and_return(true)
+      expect(File).to receive(:file?).with('foo/object_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/objects/root.dat').and_return(false)
+      expect(File).to receive(:read_binary).with('foo/proxy_types').and_return(Marshal.dump({'a' => 'b'}))
+      expect(@store.load('foo')).to eq true
+      expect(@store.proxy_types).to eq ({ 'a' => 'b'} )
     end
 
     it "should load root object if it exists" do
-      File.should_receive(:directory?).with('foo').and_return(true)
-      File.should_receive(:file?).with('foo/checksums').and_return(false)
-      File.should_receive(:file?).with('foo/proxy_types').and_return(false)
-      File.should_receive(:file?).with('foo/object_types').and_return(false)
-      File.should_receive(:file?).with('foo/objects/root.dat').and_return(true)
-      File.should_receive(:read_binary).with('foo/objects/root.dat').and_return(Marshal.dump(@foo))
-      @store.load('foo').should == true
-      @store.root.should == @foo
+      expect(File).to receive(:directory?).with('foo').and_return(true)
+      expect(File).to receive(:file?).with('foo/checksums').and_return(false)
+      expect(File).to receive(:file?).with('foo/proxy_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/object_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/objects/root.dat').and_return(true)
+      expect(File).to receive(:read_binary).with('foo/objects/root.dat').and_return(Marshal.dump(@foo))
+      expect(@store.load('foo')).to eq true
+      expect(@store.root).to eq @foo
     end
   end
 
@@ -113,7 +113,7 @@ describe YARD::RegistryStore do
     end
 
     def saves_to_singledb
-      @serializer.should_receive(:serialize).once.with(instance_of(Hash))
+      expect(@serializer).to receive(:serialize).once.with(instance_of(Hash))
       @store.save(true, 'foo')
     end
 
@@ -123,7 +123,7 @@ describe YARD::RegistryStore do
 
     def saves_to_multidb
       times = @store.keys.size
-      @serializer.should_receive(:serialize).exactly(times).times
+      expect(@serializer).to receive(:serialize).exactly(times).times
       @store.save(true, 'foo')
       @last = times
     end
@@ -160,47 +160,47 @@ describe YARD::RegistryStore do
   describe '#put' do
     it "should assign values" do
       @store.put(:YARD, @foo)
-      @store.get(:YARD).should == @foo
+      expect(@store.get(:YARD)).to eq @foo
     end
 
     it "should treat '' as root" do
       @store.put('', @foo)
-      @store.get(:root).should == @foo
+      expect(@store.get(:root)).to eq @foo
     end
   end
 
   describe '#get' do
     it "should hit cache if object exists" do
       @store.put(:YARD, @foo)
-      @store.get(:YARD).should == @foo
+      expect(@store.get(:YARD)).to eq @foo
     end
 
     it "should hit backstore on cache miss and cache is not fully loaded" do
       serializer = mock(:serializer)
-      serializer.should_receive(:deserialize).once.with(:YARD).and_return(@foo)
+      expect(serializer).to receive(:deserialize).once.with(:YARD).and_return(@foo)
       @store.load('foo')
       @store.instance_variable_set("@loaded_objects", 0)
       @store.instance_variable_set("@available_objects", 100)
       @store.instance_variable_set("@serializer", serializer)
-      @store.get(:YARD).should == @foo
-      @store.get(:YARD).should == @foo
-      @store.instance_variable_get("@loaded_objects").should == 1
+      expect(@store.get(:YARD)).to eq @foo
+      expect(@store.get(:YARD)).to eq @foo
+      expect(@store.instance_variable_get("@loaded_objects")).to eq 1
     end
   end
 
   [:keys, :values].each do |item|
     describe "##{item}" do
       it "should load entire database if reload=true" do
-        File.should_receive(:directory?).with('foo').and_return(true)
+        expect(File).to receive(:directory?).with('foo').and_return(true)
         @store.load('foo')
-        @store.should_receive(:load_all)
+        expect(@store).to receive(:load_all)
         @store.send(item, true)
       end
 
       it "should not load entire database if reload=false" do
-        File.should_receive(:directory?).with('foo').and_return(true)
+        expect(File).to receive(:directory?).with('foo').and_return(true)
         @store.load('foo')
-        @store.should_not_receive(:load_all)
+        expect(@store).to_not receive(:load_all)
         @store.send(item, false)
       end
     end
@@ -210,38 +210,38 @@ describe YARD::RegistryStore do
     after { Registry.clear }
 
     it "should set all object types if not set by object_types" do
-      File.should_receive(:directory?).with('foo').and_return(true)
-      File.should_receive(:file?).with('foo/checksums').and_return(false)
-      File.should_receive(:file?).with('foo/proxy_types').and_return(false)
-      File.should_receive(:file?).with('foo/object_types').and_return(false)
-      @serializer.should_receive(:deserialize).with('root').and_return({:'A#foo' => @foo, :A => @bar})
+      expect(File).to receive(:directory?).with('foo').and_return(true)
+      expect(File).to receive(:file?).with('foo/checksums').and_return(false)
+      expect(File).to receive(:file?).with('foo/proxy_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/object_types').and_return(false)
+      expect(@serializer).to receive(:deserialize).with('root').and_return({:'A#foo' => @foo, :A => @bar})
       @store.load('foo')
-      @store.paths_for_type(:method).should == ['#foo']
-      @store.paths_for_type(:class).should == ['Bar']
+      expect(@store.paths_for_type(:method)).to eq ['#foo']
+      expect(@store.paths_for_type(:class)).to eq ['Bar']
     end
 
     it "should keep track of types when assigning values" do
       @store.put(:abc, @foo)
-      @store.paths_for_type(@foo.type).should == ['abc']
+      expect(@store.paths_for_type(@foo.type)).to eq ['abc']
     end
 
     it "should reassign path if type changes" do
       foo = CodeObjects::ClassObject.new(:root, :Foo)
       @store.put('Foo', foo)
-      @store.get('Foo').type.should == :class
-      @store.paths_for_type(:class).should == ["Foo"]
+      expect(@store.get('Foo').type).to eq :class
+      expect(@store.paths_for_type(:class)).to eq ["Foo"]
       foo = CodeObjects::ModuleObject.new(:root, :Foo)
       @store.put('Foo', foo)
-      @store.get('Foo').type.should == :module
-      @store.paths_for_type(:class).should == []
-      @store.paths_for_type(:module).should == ["Foo"]
+      expect(@store.get('Foo').type).to eq :module
+      expect(@store.paths_for_type(:class)).to eq []
+      expect(@store.paths_for_type(:module)).to eq ["Foo"]
     end
   end
 
   describe '#values_for_type' do
     it "should return all objects with type" do
       @store.put(:abc, @foo)
-      @store.values_for_type(@foo.type).should == [@foo]
+      expect(@store.values_for_type(@foo.type)).to eq [@foo]
     end
   end
 
@@ -251,65 +251,65 @@ describe YARD::RegistryStore do
       barmock = mock(:Bar)
       foomock.stub!(:type).and_return(:class)
       barmock.stub!(:type).and_return(:class)
-      foomock.should_receive(:path).and_return('Foo')
-      barmock.should_receive(:path).and_return('Bar')
-      File.should_receive(:directory?).with('foo').and_return(true)
-      File.should_receive(:file?).with('foo/proxy_types').and_return(false)
-      File.should_receive(:file?).with('foo/object_types').and_return(false)
-      File.should_receive(:file?).with('foo/checksums').and_return(false)
-      File.should_receive(:file?).with('foo/objects/root.dat').and_return(false)
-      @store.should_receive(:all_disk_objects).at_least(1).times.and_return(['foo/objects/foo', 'foo/objects/bar'])
+      expect(foomock).to receive(:path).and_return('Foo')
+      expect(barmock).to receive(:path).and_return('Bar')
+      expect(File).to receive(:directory?).with('foo').and_return(true)
+      expect(File).to receive(:file?).with('foo/proxy_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/object_types').and_return(false)
+      expect(File).to receive(:file?).with('foo/checksums').and_return(false)
+      expect(File).to receive(:file?).with('foo/objects/root.dat').and_return(false)
+      expect(@store).to receive(:all_disk_objects).at_least(1).times.and_return(['foo/objects/foo', 'foo/objects/bar'])
       @store.load('foo')
       serializer = @store.instance_variable_get("@serializer")
-      serializer.should_receive(:deserialize).with('foo/objects/foo', true).and_return(foomock)
-      serializer.should_receive(:deserialize).with('foo/objects/bar', true).and_return(barmock)
+      expect(serializer).to receive(:deserialize).with('foo/objects/foo', true).and_return(foomock)
+      expect(serializer).to receive(:deserialize).with('foo/objects/bar', true).and_return(barmock)
       @store.send(:load_all)
-      @store.instance_variable_get("@available_objects").should == 2
-      @store.instance_variable_get("@loaded_objects").should == 2
-      @store[:Foo].should == foomock
-      @store[:Bar].should == barmock
+      expect(@store.instance_variable_get("@available_objects")).to eq 2
+      expect(@store.instance_variable_get("@loaded_objects")).to eq 2
+      expect(@store[:Foo]).to eq foomock
+      expect(@store[:Bar]).to eq barmock
     end
   end
 
   describe '#destroy' do
     it "should destroy file ending in .yardoc when force=false" do
-      File.should_receive(:file?).with('foo.yardoc').and_return(true)
-      File.should_receive(:unlink).with('foo.yardoc')
+      expect(File).to receive(:file?).with('foo.yardoc').and_return(true)
+      expect(File).to receive(:unlink).with('foo.yardoc')
       @store.instance_variable_set("@file", 'foo.yardoc')
-      @store.destroy.should == true
+      expect(@store.destroy).to eq true
     end
 
     it "should destroy dir ending in .yardoc when force=false" do
-      File.should_receive(:directory?).with('foo.yardoc').and_return(true)
-      FileUtils.should_receive(:rm_rf).with('foo.yardoc')
+      expect(File).to receive(:directory?).with('foo.yardoc').and_return(true)
+      expect(FileUtils).to receive(:rm_rf).with('foo.yardoc')
       @store.instance_variable_set("@file", 'foo.yardoc')
-      @store.destroy.should == true
+      expect(@store.destroy).to eq true
     end
 
     it "should not destroy file/dir not ending in .yardoc when force=false" do
-      File.should_not_receive(:file?).with('foo')
-      File.should_not_receive(:directory?).with('foo')
-      File.should_not_receive(:unlink).with('foo')
-      FileUtils.should_not_receive(:rm_rf).with('foo')
+      expect(File).to_not receive(:file?).with('foo')
+      expect(File).to_not receive(:directory?).with('foo')
+      expect(File).to_not receive(:unlink).with('foo')
+      expect(FileUtils).to_not receive(:rm_rf).with('foo')
       @store.instance_variable_set("@file", 'foo')
-      @store.destroy.should == false
+      expect(@store.destroy).to eq false
     end
 
     it "should destroy any file/dir when force=true" do
-      File.should_receive(:file?).with('foo').and_return(true)
-      File.should_receive(:unlink).with('foo')
+      expect(File).to receive(:file?).with('foo').and_return(true)
+      expect(File).to receive(:unlink).with('foo')
       @store.instance_variable_set("@file", 'foo')
-      @store.destroy(true).should == true
+      expect(@store.destroy(true)).to eq true
     end
   end
 
   describe '#locale' do
     it "should load ./po/LOCALE_NAME.po" do
       fr_locale = I18n::Locale.new("fr")
-      I18n::Locale.should_receive(:new).with("fr").and_return(fr_locale)
-      Registry.should_receive(:po_dir).and_return("po")
-      fr_locale.should_receive(:load).with("po")
-      @store.locale("fr").should == fr_locale
+      expect(I18n::Locale).to receive(:new).with("fr").and_return(fr_locale)
+      expect(Registry).to receive(:po_dir).and_return("po")
+      expect(fr_locale).to receive(:load).with("po")
+      expect(@store.locale("fr")).to eq fr_locale
     end
   end
 end

--- a/spec/rubygems/doc_manager_spec.rb
+++ b/spec/rubygems/doc_manager_spec.rb
@@ -20,12 +20,12 @@ describe Gem::DocManager do
     @doc.stub(:install_rdoc_yard_orig)
   end
 
-  def runs; YARD::CLI::Yardoc.should_receive(:run) end
+  def runs; expect(YARD::CLI::Yardoc).to receive(:run) end
 
   describe '.load_yardoc' do
     it "should properly load YARD" do
-      Gem::DocManager.should_receive(:require) do |path|
-        File.expand_path(path).should == YARD::ROOT + '/yard'
+      expect(Gem::DocManager).to receive(:require) do |path|
+        expect(File.expand_path(path)).to eq YARD::ROOT + '/yard'
       end
       Gem::DocManager.load_yardoc
     end
@@ -34,7 +34,7 @@ describe Gem::DocManager do
   describe '#install_ri_yard' do
     def install
       msg = "Building YARD (yri) index for #{@spec.full_name}..."
-      @doc.should_receive(:say).with(msg)
+      expect(@doc).to receive(:say).with(msg)
       @doc.install_ri_yard
     end
 
@@ -57,52 +57,52 @@ describe Gem::DocManager do
     end
 
     it "should add require_paths if there is no .yardopts" do
-      File.should_receive(:file?).with(@yardopts).and_return(true)
+      expect(File).to receive(:file?).with(@yardopts).and_return(true)
       runs.with('-c', '-n', '--quiet')
       install
     end
 
     it "should add extra_rdoc_files if there is no .yardopts" do
       @spec.extra_rdoc_files = %w(README LICENSE)
-      File.should_receive(:file?).with(@yardopts).and_return(true)
+      expect(File).to receive(:file?).with(@yardopts).and_return(true)
       runs.with('-c', '-n', '--quiet')
       install
     end
 
     it "should switch to directory before running command" do
       old = Dir.pwd
-      Dir.should_receive(:chdir).with(@spec.full_gem_path)
-      Dir.should_receive(:chdir).with(old)
+      expect(Dir).to receive(:chdir).with(@spec.full_gem_path)
+      expect(Dir).to receive(:chdir).with(old)
       install
     end
 
     it "should ensure that directory is switched back at end of command in failure" do
       old = Dir.pwd
-      Dir.should_receive(:chdir).with(@spec.full_gem_path)
-      Dir.should_receive(:chdir).with(old)
-      @doc.ui.errs.should_receive(:puts).with(/ERROR:\s*While generating documentation/)
-      @doc.ui.errs.should_receive(:puts).with(/MESSAGE:\s*foo/)
-      @doc.ui.errs.should_receive(:puts).with(/YARDOC args:\s*-c -n --quiet lib/)
-      @doc.ui.errs.should_receive(:puts).with("(continuing with the rest of the installation)")
-      YARD::CLI::Yardoc.should_receive(:run).and_raise(RuntimeError.new("foo"))
+      expect(Dir).to receive(:chdir).with(@spec.full_gem_path)
+      expect(Dir).to receive(:chdir).with(old)
+      expect(@doc.ui.errs).to receive(:puts).with(/ERROR:\s*While generating documentation/)
+      expect(@doc.ui.errs).to receive(:puts).with(/MESSAGE:\s*foo/)
+      expect(@doc.ui.errs).to receive(:puts).with(/YARDOC args:\s*-c -n --quiet lib/)
+      expect(@doc.ui.errs).to receive(:puts).with("(continuing with the rest of the installation)")
+      expect(YARD::CLI::Yardoc).to receive(:run).and_raise(RuntimeError.new("foo"))
       install
     end
 
     it "should handle permission errors" do
-      YARD::CLI::Yardoc.should_receive(:run).and_raise(Errno::EACCES.new("- dir"))
-      lambda { install }.should raise_error(Gem::FilePermissionError)
+      expect(YARD::CLI::Yardoc).to receive(:run).and_raise(Errno::EACCES.new("- dir"))
+      expect{ install }.to raise_error(Gem::FilePermissionError)
     end
   end
 
   describe '#install_rdoc_yard' do
     def install
       msg = "Installing YARD documentation for #{@spec.full_name}..."
-      @doc.should_receive(:say).with(msg)
+      expect(@doc).to receive(:say).with(msg)
       @doc.install_rdoc_yard
     end
 
     it "should add -o outdir when generating docs" do
-      File.should_receive(:file?).with(@yardopts).and_return(true)
+      expect(File).to receive(:file?).with(@yardopts).and_return(true)
       @spec.has_yardoc = true
       doc_dir = File.join(@doc.instance_variable_get("@doc_dir"), 'rdoc')
       runs.with('-o', doc_dir, '--quiet')

--- a/spec/serializers/file_system_serializer_spec.rb
+++ b/spec/serializers/file_system_serializer_spec.rb
@@ -11,14 +11,14 @@ describe YARD::Serializers::FileSystemSerializer do
   describe '#basepath' do
     it "should default the base path to the 'doc/'" do
       obj = Serializers::FileSystemSerializer.new
-      obj.basepath.should == 'doc'
+      expect(obj.basepath).to eq 'doc'
     end
   end
 
   describe '#extension' do
     it "should default the file extension to .html" do
       obj = Serializers::FileSystemSerializer.new
-      obj.extension.should == "html"
+      expect(obj.extension).to eq "html"
     end
   end
 
@@ -26,17 +26,17 @@ describe YARD::Serializers::FileSystemSerializer do
     it "should allow no extension to be used" do
       obj = Serializers::FileSystemSerializer.new :extension => nil
       yard = CodeObjects::ClassObject.new(nil, :FooBar)
-      obj.serialized_path(yard).should == 'FooBar'
+      expect(obj.serialized_path(yard)).to eq 'FooBar'
     end
 
     it "should serialize to top-level-namespace for root" do
       obj = Serializers::FileSystemSerializer.new :extension => nil
-      obj.serialized_path(Registry.root).should == "top-level-namespace"
+      expect(obj.serialized_path(Registry.root)).to eq "top-level-namespace"
     end
 
     it "should return serialized_path for a String" do
       s = Serializers::FileSystemSerializer.new(:basepath => 'foo', :extension => 'txt')
-      s.serialized_path('test.txt').should == 'test.txt'
+      expect(s.serialized_path('test.txt')).to eq 'test.txt'
     end
 
     it "should remove special chars from path" do
@@ -60,21 +60,21 @@ describe YARD::Serializers::FileSystemSerializer do
         :=~ => '_3D_7E_i.html'
       }.each do |meth, value|
         m.stub!(:name).and_return(meth)
-        s.serialized_path(m).should == value
+        expect(s.serialized_path(m)).to eq value
       end
     end
 
     it "should handle ExtraFileObject's" do
       s = Serializers::FileSystemSerializer.new
       e = CodeObjects::ExtraFileObject.new('filename.txt', '')
-      s.serialized_path(e).should == 'file.filename.html'
+      expect(s.serialized_path(e)).to eq 'file.filename.html'
     end
 
     it "should differentiate instance and class methods from serialized path" do
       s = Serializers::FileSystemSerializer.new
       m1 = CodeObjects::MethodObject.new(nil, 'meth')
       m2 = CodeObjects::MethodObject.new(nil, 'meth', :class)
-      s.serialized_path(m1).should_not == s.serialized_path(m2)
+      expect(s.serialized_path(m1)).to_not eq s.serialized_path(m2)
     end
 
     it "should serialize path from overload tag" do
@@ -87,7 +87,7 @@ describe YARD::Serializers::FileSystemSerializer do
 
       serializer = Serializers::FileSystemSerializer.new
       object = Registry.at('Foo#bar').tag(:overload)
-      serializer.serialized_path(object).should == "Foo/bar_i.html"
+      expect(serializer.serialized_path(object)).to eq "Foo/bar_i.html"
     end
   end
 
@@ -101,8 +101,8 @@ describe YARD::Serializers::FileSystemSerializer do
         'foo/FooBar/baz_i.txt' => meth2,
         'foo/FooBar.txt' => yard }.each do |path, obj|
         io = StringIO.new
-        File.should_receive(:open).with(path, 'wb').and_yield(io)
-        io.should_receive(:write).with("data")
+        expect(File).to receive(:open).with(path, 'wb').and_yield(io)
+        expect(io).to receive(:write).with("data")
 
         s = Serializers::FileSystemSerializer.new(:basepath => 'foo', :extension => 'txt')
         s.serialize(obj, "data")
@@ -115,7 +115,7 @@ describe YARD::Serializers::FileSystemSerializer do
       o3 = CodeObjects::ClassObject.new(o2, :PathName)
       obj = CodeObjects::MethodObject.new(o3, :foo)
 
-      FileUtils.should_receive(:mkdir_p).once.with('doc/Really/Long/PathName')
+      expect(FileUtils).to receive(:mkdir_p).once.with('doc/Really/Long/PathName')
 
       s = Serializers::FileSystemSerializer.new
       s.serialize(obj, "data")

--- a/spec/serializers/yardoc_serializer_spec.rb
+++ b/spec/serializers/yardoc_serializer_spec.rb
@@ -19,17 +19,17 @@ describe YARD::Serializers::YardocSerializer do
   describe '#dump' do
     it "should maintain object equality when loading a dumped object" do
       newfoo = @serializer.internal_dump(@foo)
-      newfoo.should equal(@foo)
-      newfoo.should == @foo
-      @foo.should equal(newfoo)
-      @foo.should == newfoo
-      newfoo.hash.should == @foo.hash
+      expect(newfoo).to equal(@foo)
+      expect(newfoo).to eq @foo
+      expect(@foo).to equal(newfoo)
+      expect(@foo).to eq newfoo
+      expect(newfoo.hash).to eq @foo.hash
     end
 
     it "should maintain hash key equality when loading a dumped object" do
       newfoo = @serializer.internal_dump(@foo)
-      {@foo => 1}.should have_key(newfoo)
-      {newfoo => 1}.should have_key(@foo)
+      expect({@foo => 1}).to have_key(newfoo)
+      expect({newfoo => 1}).to have_key(@foo)
     end
   end
 
@@ -38,8 +38,8 @@ describe YARD::Serializers::YardocSerializer do
       data = {:root => Registry.root}
       marshaldata = Marshal.dump(data)
       filemock = mock(:file)
-      filemock.should_receive(:write).with(marshaldata)
-      File.should_receive(:open!).with('.yardoc/objects/root.dat', 'wb').and_yield(filemock)
+      expect(filemock).to receive(:write).with(marshaldata)
+      expect(File).to receive(:open!).with('.yardoc/objects/root.dat', 'wb').and_yield(filemock)
       @serializer.serialize(data)
     end
   end

--- a/spec/server/adapter_spec.rb
+++ b/spec/server/adapter_spec.rb
@@ -7,23 +7,23 @@ describe YARD::Server::Adapter do
     it "should add a library" do
       lib = LibraryVersion.new('yard')
       a = Adapter.new({})
-      a.libraries.should be_empty
+      expect(a.libraries).to be_empty
       a.add_library(lib)
-      a.libraries['yard'].should == [lib]
+      expect(a.libraries['yard']).to eq [lib]
     end
   end
 
   describe '#start' do
     it "should not implement #start" do
-      lambda { Adapter.new({}).start }.should raise_error(NotImplementedError)
+      expect{ Adapter.new({}).start }.to raise_error(NotImplementedError)
     end
   end
 
   describe '.setup' do
     it 'should add template paths and helpers' do
       Adapter.setup
-      Templates::Template.extra_includes.should include(DocServerHelper)
-      Templates::Engine.template_paths.should include(YARD::ROOT + '/yard/server/templates')
+      expect(Templates::Template.extra_includes).to include(DocServerHelper)
+      expect(Templates::Engine.template_paths).to include(YARD::ROOT + '/yard/server/templates')
     end
   end
 
@@ -31,8 +31,8 @@ describe YARD::Server::Adapter do
     it 'should cleanup template paths and helpers' do
       Adapter.setup
       Adapter.shutdown
-      Templates::Template.extra_includes.should_not include(DocServerHelper)
-      Templates::Engine.template_paths.should_not include(YARD::ROOT + '/yard/server/templates')
+      expect(Templates::Template.extra_includes).to_not include(DocServerHelper)
+      expect(Templates::Engine.template_paths).to_not include(YARD::ROOT + '/yard/server/templates')
     end
   end
 end

--- a/spec/server/commands/base_spec.rb
+++ b/spec/server/commands/base_spec.rb
@@ -16,20 +16,20 @@ describe YARD::Server::Commands::Base do
     end
 
     it "should not cache if caching == false" do
-      File.should_not_receive(:open)
+      expect(File).to_not receive(:open)
       @command.caching = false
       @command.run
     end
 
     it "should require document root to cache" do
-      File.should_not_receive(:open)
+      expect(File).to_not receive(:open)
       @command.adapter.document_root = nil
       @command.run
     end
 
     it "should cache to path/to/file.html and create directories" do
-      FileUtils.should_receive(:mkdir_p).with('/public/path/to')
-      File.should_receive(:open).with('/public/path/to/file.html', anything)
+      expect(FileUtils).to receive(:mkdir_p).with('/public/path/to')
+      expect(File).to receive(:open).with('/public/path/to/file.html', anything)
       @command.request.path = '/path/to/file.html'
       @command.run
     end
@@ -38,8 +38,8 @@ describe YARD::Server::Commands::Base do
   describe '#redirect' do
     it "should return a valid redirection" do
       cmd = MyProcCommand.new { redirect '/foo' }
-      cmd.call(mock_request('/foo')).should ==
-        [302, {"Content-Type" => "text/html", "Location" => "/foo"}, [""]]
+      expect(cmd.call(mock_request('/foo'))).to match_array(
+        [302, {"Content-Type" => "text/html", "Location" => "/foo"}, [""]])
     end
   end
 
@@ -47,41 +47,41 @@ describe YARD::Server::Commands::Base do
     it "should handle a NotFoundError and use message as body" do
       cmd = MyProcCommand.new { raise NotFoundError, "hello world" }
       s, h, b = *cmd.call(mock_request('/foo'))
-      s.should == 404
-      b.should == ["hello world"]
+      expect(s).to eq 404
+      expect(b).to eq ["hello world"]
     end
 
     it "should not use message as body if not provided in NotFoundError" do
       cmd = MyProcCommand.new { raise NotFoundError }
       s, h, b = *cmd.call(mock_request('/foo'))
-      s.should == 404
-      b.should == ["Not found: /foo"]
+      expect(s).to eq 404
+      expect(b).to eq ["Not found: /foo"]
     end
 
     it "should handle 404 status code from #run" do
       cmd = MyProcCommand.new { self.status = 404 }
       s, h, b = *cmd.call(mock_request('/foo'))
-      s.should == 404
-      b.should == ["Not found: /foo"]
+      expect(s).to eq 404
+      expect(b).to eq ["Not found: /foo"]
     end
 
     it "should not override body if status is 404 and body is defined" do
       cmd = MyProcCommand.new { self.body = "foo"; self.status = 404 }
       s, h, b = *cmd.call(mock_request('/bar'))
-      s.should == 404
-      b.should == ['foo']
+      expect(s).to eq 404
+      expect(b).to eq ['foo']
     end
 
     it "should handle body as Array" do
       cmd = MyProcCommand.new { self.body = ['a', 'b', 'c'] }
       s, h, b = *cmd.call(mock_request('/foo'))
-      b.should == %w(a b c)
+      expect(b).to eq %w(a b c)
     end
 
     it "should allow headers to be defined" do
       cmd = MyProcCommand.new { self.headers['Foo'] = 'BAR' }
       s, h, b = *cmd.call(mock_request('/foo'))
-      h['Foo'].should == 'BAR'
+      expect(h['Foo']).to eq 'BAR'
     end
   end
 end

--- a/spec/server/commands/library_command_spec.rb
+++ b/spec/server/commands/library_command_spec.rb
@@ -17,7 +17,7 @@ describe YARD::Server::Commands::LibraryCommand do
   end
 
   def call
-    lambda { @cmd.call(@request) }.should raise_error(NotImplementedError)
+    expect{ @cmd.call(@request) }.to raise_error(NotImplementedError)
   end
 
   describe "#call" do
@@ -28,12 +28,12 @@ describe YARD::Server::Commands::LibraryCommand do
     it "should set :rdoc as the default markup in incremental mode" do
       @cmd.incremental = true
       call
-      @cmd.options[:markup].should == :rdoc
+      expect(@cmd.options[:markup]).to eq :rdoc
     end
 
     it "should set :rdoc as the default markup in regular mode" do
       call
-      @cmd.options[:markup].should == :rdoc
+      expect(@cmd.options[:markup]).to eq :rdoc
     end
   end
 end

--- a/spec/server/commands/static_file_command_spec.rb
+++ b/spec/server/commands/static_file_command_spec.rb
@@ -10,57 +10,57 @@ describe YARD::Server::Commands::StaticFileCommand do
   describe '#run' do
     def run(path, status = nil, body = nil)
       s, h, b = *@cmd.call(mock_request(path))
-      body.should == b.first if body
-      status.should == s if status
+      expect(body).to eq b.first if body
+      expect(status).to eq s if status
       [s, h, b]
     end
 
     it "should search through document root before static paths" do
-      File.should_receive(:exist?).with('/c/path/to/file.txt').ordered.and_return(false)
+      expect(File).to receive(:exist?).with('/c/path/to/file.txt').ordered.and_return(false)
       StaticFileCommand::STATIC_PATHS.reverse.each do |path|
-        File.should_receive(:exist?).with(File.join(path, 'path/to/file.txt')).ordered.and_return(false)
+        expect(File).to receive(:exist?).with(File.join(path, 'path/to/file.txt')).ordered.and_return(false)
       end
       run '/path/to/file.txt'
     end
 
     it "should return file contents if found" do
       tpl = Templates::Engine.template(:default, :fulldoc, :html)
-      File.should_receive(:exist?).with('/c/path/to/file.txt').and_return(false)
-      tpl.should_receive(:find_file).with('/path/to/file.txt').and_return('/path/to/foo')
-      File.should_receive(:read).with('/path/to/foo').and_return('FOO')
+      expect(File).to receive(:exist?).with('/c/path/to/file.txt').and_return(false)
+      expect(tpl).to receive(:find_file).with('/path/to/file.txt').and_return('/path/to/foo')
+      expect(File).to receive(:read).with('/path/to/foo').and_return('FOO')
       run('/path/to/file.txt', 200, 'FOO')
     end
 
     it "should allow registering of new paths and use those before other static paths" do
       Server.register_static_path '/foo'
       path = '/foo/path/to/file.txt'
-      File.should_receive(:exist?).with('/c/path/to/file.txt').and_return(false)
-      File.should_receive(:exist?).with(path).and_return(true)
-      File.should_receive(:read).with(path).and_return('FOO')
+      expect(File).to receive(:exist?).with('/c/path/to/file.txt').and_return(false)
+      expect(File).to receive(:exist?).with(path).and_return(true)
+      expect(File).to receive(:read).with(path).and_return('FOO')
       run('/path/to/file.txt', 200, 'FOO')
     end
 
     it "should not use registered path before docroot" do
       Server.register_static_path '/foo'
       path = '/foo/path/to/file.txt'
-      File.should_receive(:exist?).with('/c/path/to/file.txt').and_return(true)
-      File.should_receive(:read).with('/c/path/to/file.txt').and_return('FOO')
+      expect(File).to receive(:exist?).with('/c/path/to/file.txt').and_return(true)
+      expect(File).to receive(:read).with('/c/path/to/file.txt').and_return('FOO')
       run('/c/path/to/file.txt', 200, 'FOO')
     end
 
     it "should return 404 if not found" do
-      File.should_receive(:exist?).with('/c/path/to/file.txt').ordered.and_return(false)
+      expect(File).to receive(:exist?).with('/c/path/to/file.txt').ordered.and_return(false)
       StaticFileCommand::STATIC_PATHS.reverse.each do |path|
-        File.should_receive(:exist?).with(File.join(path, 'path/to/file.txt')).ordered.and_return(false)
+        expect(File).to receive(:exist?).with(File.join(path, 'path/to/file.txt')).ordered.and_return(false)
       end
       run('/path/to/file.txt', 404)
     end
 
     it "should return text/html for file with no extension" do
-      File.should_receive(:exist?).with('/c/file').and_return(true)
-      File.should_receive(:read).with('/c/file')
+      expect(File).to receive(:exist?).with('/c/file').and_return(true)
+      expect(File).to receive(:read).with('/c/file')
       s, h, b = *run('/file')
-      h['Content-Type'].should == 'text/html'
+      expect(h['Content-Type']).to eq 'text/html'
     end
 
     {
@@ -74,10 +74,10 @@ describe YARD::Server::Commands::StaticFileCommand do
       "unknown" => "application/octet-stream"
     }.each do |ext, mime|
       it "should serve file.#{ext} as #{mime}" do
-        File.should_receive(:exist?).with('/c/file.' + ext).and_return(true)
-        File.should_receive(:read).with('/c/file.' + ext)
+        expect(File).to receive(:exist?).with('/c/file.' + ext).and_return(true)
+        expect(File).to receive(:read).with('/c/file.' + ext)
         s, h, b = *run('/file.' + ext)
-        h['Content-Type'].should == mime
+        expect(h['Content-Type']).to eq mime
       end
     end
   end

--- a/spec/server/doc_server_helper_spec.rb
+++ b/spec/server/doc_server_helper_spec.rb
@@ -34,20 +34,20 @@ describe YARD::Server::DocServerHelper do
   describe '#url_for' do
     it "should not link to /library/ if single_library = true" do
       @helper.single_library = true
-      @helper.url_for(Registry.root).should == "/PREFIX/toplevel"
+      expect(@helper.url_for(Registry.root)).to eq "/PREFIX/toplevel"
     end
 
     it "should return /PREFIX/foo/version if foo has a version" do
       @helper.library = LibraryVersion.new('foo', 'bar')
       @helper.adapter.router.request.version_supplied = true
-      @helper.url_for(P('A')).should == '/PREFIX/foo/bar/A'
+      expect(@helper.url_for(P('A'))).to eq '/PREFIX/foo/bar/A'
     end
   end
 
   describe '#url_for_file' do
     it "should properly link file objects using file/ prefix" do
       file = CodeObjects::ExtraFileObject.new('a/b/FooBar.md', '')
-      @helper.url_for_file(file).should == '/PREFIX/foo/file/a/b/FooBar.md'
+      expect(@helper.url_for_file(file)).to eq '/PREFIX/foo/file/a/b/FooBar.md'
     end
   end
 end

--- a/spec/server/doc_server_serializer_spec.rb
+++ b/spec/server/doc_server_serializer_spec.rb
@@ -10,41 +10,41 @@ describe YARD::Server::DocServerSerializer do
     after(:all) { Server::Adapter.shutdown }
 
     it "should return '/PREFIX/library/toplevel' for root" do
-      @serializer.serialized_path(Registry.root).should == "toplevel"
+      expect(@serializer.serialized_path(Registry.root)).to eq "toplevel"
     end
 
     it "should return /PREFIX/library/Object for Object in a library" do
-      @serializer.serialized_path(P('A::B::C')).should == 'A/B/C'
+      expect(@serializer.serialized_path(P('A::B::C'))).to eq 'A/B/C'
     end
 
     it "should link to instance method as Class:method" do
       obj = CodeObjects::MethodObject.new(:root, :method)
-      @serializer.serialized_path(obj).should == 'toplevel:method'
+      expect(@serializer.serialized_path(obj)).to eq 'toplevel:method'
     end
 
     it "should link to class method as Class.method" do
       obj = CodeObjects::MethodObject.new(:root, :method, :class)
-      @serializer.serialized_path(obj).should == 'toplevel.method'
+      expect(@serializer.serialized_path(obj)).to eq 'toplevel.method'
     end
 
     it "should link to anchor for constant" do
       obj = CodeObjects::ConstantObject.new(:root, :FOO)
-      @serializer.serialized_path(obj).should == 'toplevel#FOO-constant'
+      expect(@serializer.serialized_path(obj)).to eq 'toplevel#FOO-constant'
     end
 
     it "should link to anchor for class variable" do
       obj = CodeObjects::ClassVariableObject.new(:root, :@@foo)
-      @serializer.serialized_path(obj).should == 'toplevel#@@foo-classvariable'
+      expect(@serializer.serialized_path(obj)).to eq 'toplevel#@@foo-classvariable'
     end
 
     it "should link files using file/ prefix" do
       file = CodeObjects::ExtraFileObject.new('a/b/FooBar.md', '')
-      @serializer.serialized_path(file).should == 'file/FooBar'
+      expect(@serializer.serialized_path(file)).to eq 'file/FooBar'
     end
 
     it "should handle unicode data" do
       file = CodeObjects::ExtraFileObject.new("test\u0160", '')
-      @serializer.serialized_path(file).should == 'file/test_C5A0'
+      expect(@serializer.serialized_path(file)).to eq 'file/test_C5A0'
     end if defined?(::Encoding)
   end
 end

--- a/spec/server/rack_adapter_spec.rb
+++ b/spec/server/rack_adapter_spec.rb
@@ -10,11 +10,11 @@ describe "YARD::Server::RackMiddleware" do
   after(:all) { YARD::Server::Adapter.shutdown }
 
   it "should handle requests" do
-    @app.call(Rack::MockRequest.env_for('/'))[0].should == 200
+    expect(@app.call(Rack::MockRequest.env_for('/'))[0]).to eq 200
   end
 
   it "should pass up to the next middleware on 404" do
-    @superapp.should_receive(:call).and_return([200, {}, ['OK']])
-    @app.call(Rack::MockRequest.env_for('/INVALID')).should == [200, {}, ['OK']]
+    expect(@superapp).to receive(:call).and_return([200, {}, ['OK']])
+    expect(@app.call(Rack::MockRequest.env_for('/INVALID'))).to eq [200, {}, ['OK']]
   end
 end

--- a/spec/server/router_spec.rb
+++ b/spec/server/router_spec.rb
@@ -24,27 +24,27 @@ describe YARD::Server::Router do
     end
 
     it "should parse library and version name out of path" do
-      parse('project', '1.0.0').should == [@projects[0], []]
-      @request.version_supplied.should be_true
+      expect(parse('project', '1.0.0')).to eq [@projects[0], []]
+      expect(@request.version_supplied).to be_true
     end
 
     it "should parse library and use latest version if version is not supplied" do
-      parse('project').should == [@projects[1], []]
-      @request.version_supplied.should be_false
+      expect(parse('project')).to eq [@projects[1], []]
+      expect(@request.version_supplied).to be_false
     end
 
     it "should parse library and use latest version if next component is not a version" do
-      parse('project', 'notaversion').should == [@projects[1], ['notaversion']]
-      @request.version_supplied.should be_false
+      expect(parse('project', 'notaversion')).to eq [@projects[1], ['notaversion']]
+      expect(@request.version_supplied).to be_false
     end
 
     it "should return nil library if no library is found" do
-      parse('notproject').should == [nil, ['notproject']]
+      expect(parse('notproject')).to eq [nil, ['notproject']]
     end
 
     it "should not parse library or version if single_library == true" do
       @adapter.stub!(:options).and_return(:single_library => true)
-      parse('notproject').should == [@projects[0], ['notproject']]
+      expect(parse('notproject')).to eq [@projects[0], ['notproject']]
     end
   end
 
@@ -77,42 +77,42 @@ describe YARD::Server::Router do
 
     it "should route /docs/name/version" do
       route_to('/mydocs/foo/project/1.0.0', DisplayObjectCommand)
-      @command.library.should == @projects[0]
+      expect(@command.library).to eq @projects[0]
     end
 
     it "should route /docs/name/ to latest version of library" do
       route_to('/mydocs/foo/project', DisplayObjectCommand)
-      @command.library.should == @projects[1]
+      expect(@command.library).to eq @projects[1]
     end
 
     it "should route /list/name/version/class" do
       route_to('/mylist/foo/project/1.0.0/class', ListCommand)
-      @command.library.should == @projects[0]
+      expect(@command.library).to eq @projects[0]
     end
 
     it "should route /list/name/version/methods" do
       route_to('/mylist/foo/project/1.0.0/methods', ListCommand)
-      @command.library.should == @projects[0]
+      expect(@command.library).to eq @projects[0]
     end
 
     it "should route /list/name/version/files" do
       route_to('/mylist/foo/project/1.0.0/files', ListCommand)
-      @command.library.should == @projects[0]
+      expect(@command.library).to eq @projects[0]
     end
 
     it "should route /list/name to latest version of library" do
       route_to('/mylist/foo/project/class', ListCommand)
-      @command.library.should == @projects[1]
+      expect(@command.library).to eq @projects[1]
     end
 
     it "should route /search/name/version" do
       route_to('/mysearch/foo/project/1.0.0', SearchCommand)
-      @command.library.should == @projects[0]
+      expect(@command.library).to eq @projects[0]
     end
 
     it "should route /search/name to latest version of library" do
       route_to('/mysearch/foo/project', SearchCommand)
-      @command.library.should == @projects[1]
+      expect(@command.library).to eq @projects[1]
     end
 
     it "should search static files for non-existent library" do

--- a/spec/server/static_caching_spec.rb
+++ b/spec/server/static_caching_spec.rb
@@ -9,31 +9,31 @@ describe YARD::Server::StaticCaching do
 
     it "should return nil if document root is not set" do
       adapter.document_root = nil
-      check_static_cache.should be_nil
+      expect(check_static_cache).to be_nil
     end
 
     it "should read a file from document root if path matches file on system" do
       request.path = '/hello/world.html'
-      File.should_receive(:file?).with('/public/hello/world.html').and_return(true)
-      File.should_receive(:open).with('/public/hello/world.html', anything).and_return('body')
+      expect(File).to receive(:file?).with('/public/hello/world.html').and_return(true)
+      expect(File).to receive(:open).with('/public/hello/world.html', anything).and_return('body')
       s, h, b = *check_static_cache
-      s.should == 200
-      b.should == ["body"]
+      expect(s).to eq 200
+      expect(b).to eq ["body"]
     end
 
     it "should read a file if path matches file on system + .html" do
       request.path = '/hello/world'
-      File.should_receive(:file?).with('/public/hello/world.html').and_return(true)
-      File.should_receive(:open).with('/public/hello/world.html', anything).and_return('body')
+      expect(File).to receive(:file?).with('/public/hello/world.html').and_return(true)
+      expect(File).to receive(:open).with('/public/hello/world.html', anything).and_return('body')
       s, h, b = *check_static_cache
-      s.should == 200
-      b.should == ["body"]
+      expect(s).to eq 200
+      expect(b).to eq ["body"]
     end
 
     it "should return nil if no matching file is found" do
       request.path = '/hello/foo'
-      File.should_receive(:file?).with('/public/hello/foo.html').and_return(false)
-      check_static_cache.should == nil
+      expect(File).to receive(:file?).with('/public/hello/foo.html').and_return(false)
+      expect(check_static_cache).to eq nil
     end
   end
 end

--- a/spec/server/webrick_servlet_spec.rb
+++ b/spec/server/webrick_servlet_spec.rb
@@ -12,9 +12,9 @@ describe YARD::Server::WebrickServlet do
       adapter = mock_adapter
       adapter.router = proc { [200, {'Header' => 'foo'}, ['body']]}
       WebrickServlet.new(server, adapter).do_GET(mock_request('/foo'), resp)
-      resp.status.should == 200
-      resp.headers.should == {'Header' => 'foo'}
-      resp.body.should == 'body'
+      expect(resp.status).to eq 200
+      expect(resp.headers).to eq ({ 'Header' => 'foo'} )
+      expect(resp.body).to eq 'body'
     end
   end
 end

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -4,7 +4,7 @@ describe YARD::Server do
   describe '.register_static_path' do
     it "should register a static path" do
       YARD::Server.register_static_path 'foo'
-      YARD::Server::Commands::StaticFileCommand::STATIC_PATHS.last.should == "foo"
+      expect(YARD::Server::Commands::StaticFileCommand::STATIC_PATHS.last).to eq "foo"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -99,7 +99,7 @@ def docspec(objname = self.class.description, klass = self.class.described_type)
     exs.text.split(/\n/).each do |ex|
       begin
         hash = eval("{ #{ex} }")
-        hash.keys.first.should == hash.values.first
+        expect(hash.keys.first).to eq hash.values.first
       rescue => e
         raise e, "#{e.message}\nInvalid spec example in #{objname}:\n\n\t#{ex}\n"
       end

--- a/spec/tags/default_factory_spec.rb
+++ b/spec/tags/default_factory_spec.rb
@@ -5,7 +5,7 @@ describe YARD::Tags::DefaultFactory do
 
   describe '#parse_tag' do
     it "should not have trailing whitespace on a regular freeform tag" do
-      @f.parse_tag('api', 'private     ').text.should == "private"
+      expect(@f.parse_tag('api', 'private     ').text).to eq "private"
     end
   end
 
@@ -15,35 +15,35 @@ describe YARD::Tags::DefaultFactory do
     end
 
     it "should handle one type" do
-      parse_types('[A]').should == [nil, ['A'], ""]
+      expect(parse_types('[A]')).to eq [nil, ['A'], ""]
     end
 
     it "should handle a list of types" do
-      parse_types('[A, B, C]').should == [nil, ['A', 'B', 'C'], ""]
+      expect(parse_types('[A, B, C]')).to eq [nil, ['A', 'B', 'C'], ""]
     end
 
     it "should handle ducktypes" do
-      parse_types('[#foo]').should == [nil, ['#foo'], '']
+      expect(parse_types('[#foo]')).to eq [nil, ['#foo'], '']
     end
 
     %w(#foo= #<< #<=> #>> #== #=== Array<#<=>> Array<#==>).each do |meth|
       it "should handle ducktypes with special method name #{meth}" do
-        parse_types("[#{meth}]").should == [nil, [meth], '']
+        expect(parse_types("[#{meth}]")).to eq [nil, [meth], '']
       end
     end
 
     it "should only parse #ducktypes inside brackets" do
-      parse_types("#ducktype").should == [nil, nil, '#ducktype']
+      expect(parse_types("#ducktype")).to eq [nil, nil, '#ducktype']
     end
 
     it "should return the text before and after the type list" do
-      parse_types(' b <String> description').should == ['b', ['String'], 'description']
-      parse_types('b c <String> description (test)').should == [nil, nil, 'b c <String> description (test)']
+      expect(parse_types(' b <String> description')).to eq ['b', ['String'], 'description']
+      expect(parse_types('b c <String> description (test)')).to eq [nil, nil, 'b c <String> description (test)']
     end
 
     it "should handle a complex list of types" do
       v = parse_types(' [Test, Array<String, Hash, C>, String]')
-      v.should include(["Test", "Array<String, Hash, C>", "String"])
+      expect(v).to include(["Test", "Array<String, Hash, C>", "String"])
     end
 
     it "should handle any of the following start/end delimiting chars: (), <>, {}, []" do
@@ -51,25 +51,25 @@ describe YARD::Tags::DefaultFactory do
       b = parse_types('<a,b,c>')
       c = parse_types('(a,b,c)')
       d = parse_types('{a,b,c}')
-      a.should == b
-      b.should == c
-      c.should == d
-      a.should include(['a','b','c'])
+      expect(a).to eq b
+      expect(b).to eq c
+      expect(c).to eq d
+      expect(a).to include(['a','b','c'])
     end
 
     it "should return the text before the type list as the last element" do
-      parse_types('b[x, y, z]').should == ['b', ['x', 'y', 'z'], '']
-      parse_types('  ! <x>').should == ["!", ['x'], '']
+      expect(parse_types('b[x, y, z]')).to eq ['b', ['x', 'y', 'z'], '']
+      expect(parse_types('  ! <x>')).to eq ["!", ['x'], '']
     end
 
     it "should return text unparsed if there is no type list" do
-      parse_types('').should == [nil, nil, '']
-      parse_types('[]').should == [nil, nil, '[]']
+      expect(parse_types('')).to eq [nil, nil, '']
+      expect(parse_types('[]')).to eq [nil, nil, '[]']
     end
 
     it "should allow A => B syntax" do
       v = parse_types(' [Test, Array<String, Hash{A => {B => C}}, C>, String]')
-      v.should include(["Test", "Array<String, Hash{A => {B => C}}, C>", "String"])
+      expect(v).to include(["Test", "Array<String, Hash{A => {B => C}}, C>", "String"])
     end
   end
 
@@ -79,22 +79,22 @@ describe YARD::Tags::DefaultFactory do
     end
 
     it "should parse given types and description" do
-      YARD::Tags::Tag.should_receive(:new).with("test", "description", ["x", "y", "z"])
+      expect(YARD::Tags::Tag).to receive(:new).with("test", "description", ["x", "y", "z"])
       parse_types(' [x, y, z] description')
     end
 
     it "should parse given types only" do
-      YARD::Tags::Tag.should_receive(:new).with("test", "", ["x", "y", "z"])
+      expect(YARD::Tags::Tag).to receive(:new).with("test", "", ["x", "y", "z"])
       parse_types(' [x, y, z] ')
     end
 
     it "should allow type list to be omitted" do
-      YARD::Tags::Tag.should_receive(:new).with('test', 'description', nil)
+      expect(YARD::Tags::Tag).to receive(:new).with('test', 'description', nil)
       parse_types('  description    ')
     end
 
     it "should raise an error if a name is specified before type list" do
-      lambda { parse_types('b<String> desc') }.should raise_error(YARD::Tags::TagFormatError, 'cannot specify a name before type list for \'@test\'')
+      expect{ parse_types('b<String> desc') }.to raise_error(YARD::Tags::TagFormatError, 'cannot specify a name before type list for \'@test\'')
     end
   end
 
@@ -104,27 +104,27 @@ describe YARD::Tags::DefaultFactory do
     end
 
     it "should parse a standard type list with name before types (no default)" do
-      YARD::Tags::DefaultTag.should_receive(:new).with("test", "description", ["x", "y", "z"], 'NAME', nil)
+      expect(YARD::Tags::DefaultTag).to receive(:new).with("test", "description", ["x", "y", "z"], 'NAME', nil)
       parse_types('NAME [x, y, z] description')
     end
 
     it "should parse a standard type list with name after types (no default)" do
-      YARD::Tags::DefaultTag.should_receive(:new).with("test", "description", ["x", "y", "z"], 'NAME', nil)
+      expect(YARD::Tags::DefaultTag).to receive(:new).with("test", "description", ["x", "y", "z"], 'NAME', nil)
       parse_types('  [x, y, z] NAME description')
     end
 
     it "should parse a tag definition with name, typelist and default" do
-      YARD::Tags::DefaultTag.should_receive(:new).with("test", "description", ["x", "y", "z"], 'NAME', ['default', 'values'])
+      expect(YARD::Tags::DefaultTag).to receive(:new).with("test", "description", ["x", "y", "z"], 'NAME', ['default', 'values'])
       parse_types('  [x, y, z] NAME (default, values) description')
     end
 
     it "should parse a tag definition with name, typelist and default when name is before type list" do
-      YARD::Tags::DefaultTag.should_receive(:new).with("test", "description", ["x", "y", "z"], 'NAME', ['default', 'values'])
+      expect(YARD::Tags::DefaultTag).to receive(:new).with("test", "description", ["x", "y", "z"], 'NAME', ['default', 'values'])
       parse_types(' NAME [x, y, z] (default, values) description')
     end
 
     it "should allow typelist to be omitted" do
-      YARD::Tags::DefaultTag.should_receive(:new).with("test", "description", nil, 'NAME', ['default', 'values'])
+      expect(YARD::Tags::DefaultTag).to receive(:new).with("test", "description", nil, 'NAME', ['default', 'values'])
       parse_types('  NAME (default, values) description')
     end
   end
@@ -136,17 +136,17 @@ describe YARD::Tags::DefaultFactory do
 
     it "should have a name before tag info" do
       t = parse_options("xyz key [Types] (default) description")
-      t.tag_name.should == 'option'
-      t.name.should == 'xyz'
+      expect(t.tag_name).to eq 'option'
+      expect(t.name).to eq 'xyz'
     end
 
     it "should parse the rest of the tag like DefaultTag" do
       t = parse_options("xyz key [Types] (default) description")
-      t.pair.should be_instance_of(Tags::DefaultTag)
-      t.pair.types.should == ["Types"]
-      t.pair.name.should == "key"
-      t.pair.defaults.should == ["default"]
-      t.pair.text.should == "description"
+      expect(t.pair).to be_instance_of(Tags::DefaultTag)
+      expect(t.pair.types).to eq ["Types"]
+      expect(t.pair.name).to eq "key"
+      expect(t.pair.defaults).to eq ["default"]
+      expect(t.pair.text).to eq "description"
     end
   end
 end

--- a/spec/tags/default_tag_spec.rb
+++ b/spec/tags/default_tag_spec.rb
@@ -3,9 +3,9 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe YARD::Tags::DefaultTag do
   it "should create a tag with defaults" do
     o = YARD::Tags::DefaultTag.new('tagname', 'desc', ['types'], 'name', ['defaults'])
-    o.defaults.should == ['defaults']
-    o.tag_name.should == 'tagname'
-    o.name.should == 'name'
-    o.types.should == ['types']
+    expect(o.defaults).to eq ['defaults']
+    expect(o.tag_name).to eq 'tagname'
+    expect(o.name).to eq 'name'
+    expect(o.types).to eq ['types']
   end
 end

--- a/spec/tags/directives_spec.rb
+++ b/spec/tags/directives_spec.rb
@@ -15,8 +15,8 @@ describe YARD::Tags::ParseDirective do
         # Docstring here
         def foo; end
       }
-      Registry.at('#foo').docstring.should == "Docstring here"
-      Registry.at('#foo').file.should == '(stdin)'
+      expect(Registry.at('#foo').docstring).to eq "Docstring here"
+      expect(Registry.at('#foo').file).to eq '(stdin)'
     end
 
     it "should allow parser type to be specified in type" do
@@ -25,7 +25,7 @@ describe YARD::Tags::ParseDirective do
           rb_define_method(rb_cMyClass, "foo", foo, 1);
         }
       }
-      Registry.at('MyClass#foo').should_not be_nil
+      expect(Registry.at('MyClass#foo')).to_not be_nil
     end
 
     it "should parse code in context of current handler" do
@@ -39,7 +39,7 @@ describe YARD::Tags::ParseDirective do
       parser = Parser::SourceParser.new
       parser.file = "myfile.rb"
       parser.parse(StringIO.new(src))
-      Registry.at('A#foo').file.should == 'myfile.rb'
+      expect(Registry.at('A#foo').file).to eq 'myfile.rb'
     end
   end
 end
@@ -53,7 +53,7 @@ describe YARD::Tags::GroupDirective do
     it "should set group value in parser state (with handler)" do
       handler = OpenStruct.new(:extra_state => OpenStruct.new)
       tag_parse("@!group foo", nil, handler)
-      handler.extra_state.group.should == 'foo'
+      expect(handler.extra_state.group).to eq 'foo'
     end
   end
 end
@@ -67,7 +67,7 @@ describe YARD::Tags::EndGroupDirective do
     it "should set group value in parser state (with handler)" do
       handler = OpenStruct.new(:extra_state => OpenStruct.new(:group => "foo"))
       tag_parse("@!endgroup", nil, handler)
-      handler.extra_state.group.should be_nil
+      expect(handler.extra_state.group).to be_nil
     end
   end
 end
@@ -86,63 +86,63 @@ describe YARD::Tags::MacroDirective do
   describe '#call' do
     it "should define new macro when [new] is provided" do
       tag_parse("@!macro [new] foo\n  foo")
-      CodeObjects::MacroObject.find('foo').macro_data.should == 'foo'
+      expect(CodeObjects::MacroObject.find('foo').macro_data).to eq 'foo'
     end
 
     it "should define new macro if text block is provided" do
       tag_parse("@!macro bar\n  bar")
-      CodeObjects::MacroObject.find('bar').macro_data.should == 'bar'
+      expect(CodeObjects::MacroObject.find('bar').macro_data).to eq 'bar'
     end
 
     it "should expand macros and return #expanded_text to tag parser" do
       tag_parse("@!macro [new] foo\n  foo")
-      tag_parse("@!macro foo").text.should == 'foo'
+      expect(tag_parse("@!macro foo").text).to eq 'foo'
     end
 
     it "should not expand new macro if docstring is unattached" do
-      tag_parse("@!macro [new] foo\n  foo").text.should_not == 'foo'
+      expect(tag_parse("@!macro [new] foo\n  foo").text).to_not eq 'foo'
     end
 
     it "should expand new anonymous macro even if docstring is unattached" do
-      tag_parse("@!macro\n  foo").text.should == 'foo'
+      expect(tag_parse("@!macro\n  foo").text).to eq 'foo'
     end
 
     it "should allow multiple macros to be expanded" do
       tag_parse("@!macro [new] foo\n  foo")
       tag_parse("@!macro bar\n  bar")
-      tag_parse("@!macro foo\n@!macro bar").text.should == "foo\nbar"
+      expect(tag_parse("@!macro foo\n@!macro bar").text).to eq "foo\nbar"
     end
 
     it "should allow anonymous macros" do
       tag_parse("@!macro\n  a b c", nil, handler)
-      @parser.text.should == 'a b c'
+      expect(@parser.text).to eq 'a b c'
     end
 
     it "should expand call_params and caller_method using $N when handler is provided" do
       tag_parse("@!macro\n  $1 $2 $3", nil, handler)
-      @parser.text.should == 'a b c'
+      expect(@parser.text).to eq 'a b c'
     end
 
     it "should attach macro to method if one exists" do
       tag_parse("@!macro [attach] attached\n  $1 $2 $3", nil, handler)
       macro = CodeObjects::MacroObject.find('attached')
-      macro.method_object.should == P('Foo::Bar.foo')
+      expect(macro.method_object).to eq P('Foo::Bar.foo')
     end
 
     it "should not expand new attached macro if defined on class method" do
       baz = CodeObjects::MethodObject.new(P('Foo::Bar'), :baz, :class)
-      baz.visibility.should == :public
+      expect(baz.visibility).to eq :public
       tag_parse("@!macro [attach] attached2\n  @!visibility private", baz, handler)
       macro = CodeObjects::MacroObject.find('attached2')
-      macro.method_object.should == P('Foo::Bar.baz')
-      baz.visibility.should == :public
+      expect(macro.method_object).to eq P('Foo::Bar.baz')
+      expect(baz.visibility).to eq :public
     end
 
     it "should expand macro if defined on class method and there is no data block" do
       tag_parse("@!macro [new] attached3\n  expanded_data")
       baz = CodeObjects::MethodObject.new(P('Foo::Bar'), :baz, :class)
       doc = DocstringParser.new.parse('@!macro attached3', baz, handler).to_docstring
-      doc.should == 'expanded_data'
+      expect(doc).to eq 'expanded_data'
     end
 
     it "should not attempt to expand macro values if handler = nil" do
@@ -163,8 +163,8 @@ describe YARD::Tags::MethodDirective do
           # @!scope class
         end
       eof
-      Registry.at('Foo.foo').should be_a(CodeObjects::MethodObject)
-      Registry.at('Foo.bar').should be_a(CodeObjects::MethodObject)
+      expect(Registry.at('Foo.foo')).to be_a(CodeObjects::MethodObject)
+      expect(Registry.at('Foo.bar')).to be_a(CodeObjects::MethodObject)
     end
 
     it "should handle indented block text in @!method" do
@@ -176,9 +176,9 @@ describe YARD::Tags::MethodDirective do
         # @param [String] a
       eof
       foo = Registry.at('#foo')
-      foo.docstring.should == "Docstring here"
-      foo.docstring.tag(:return).should_not be_nil
-      foo.tag(:param).should be_nil
+      expect(foo.docstring).to eq "Docstring here"
+      expect(foo.docstring.tag(:return)).to_not be_nil
+      expect(foo.tag(:param)).to be_nil
     end
 
     it "should execute directives on object in indented block" do
@@ -193,9 +193,9 @@ describe YARD::Tags::MethodDirective do
         end
       eof
       foo = Registry.at('Foo.foo')
-      foo.visibility.should == :private
+      expect(foo.visibility).to eq :private
       bar = Registry.at('Foo#bar')
-      bar.visibility.should == :public
+      expect(bar.visibility).to eq :public
     end
 
     it "should be able to define multiple @methods in docstring" do
@@ -213,9 +213,9 @@ describe YARD::Tags::MethodDirective do
       foo1 = Registry.at('Foo#foo1')
       foo2 = Registry.at('Foo#foo2')
       foo3 = Registry.at('Foo.foo3')
-      foo1.docstring.should == 'Docstring1'
-      foo2.docstring.should == 'Docstring2'
-      foo3.docstring.should == 'Docstring3'
+      expect(foo1.docstring).to eq 'Docstring1'
+      expect(foo2.docstring).to eq 'Docstring2'
+      expect(foo3.docstring).to eq 'Docstring3'
     end
 
     it "should define the method inside namespace if attached to namespace object" do
@@ -229,8 +229,8 @@ describe YARD::Tags::MethodDirective do
           end
         end
       eof
-      Registry.at('Foo::Bar#foo').docstring.should == 'Docstring1'
-      Registry.at('Foo::Bar#bar').docstring.should == 'Docstring2'
+      expect(Registry.at('Foo::Bar#foo').docstring).to eq 'Docstring1'
+      expect(Registry.at('Foo::Bar#bar').docstring).to eq 'Docstring2'
     end
 
     it "should set scope to class if signature has 'self.' prefix" do
@@ -242,7 +242,7 @@ describe YARD::Tags::MethodDirective do
         end
       eof
       %w(foo bar baz).each do |name|
-        Registry.at("Foo.#{name}").should be_a(CodeObjects::MethodObject)
+        expect(Registry.at("Foo.#{name}")).to be_a(CodeObjects::MethodObject)
       end
     end
 
@@ -250,7 +250,7 @@ describe YARD::Tags::MethodDirective do
       YARD.parse_string <<-eof
         # @!method foo(a, b, c = nil)
       eof
-      Registry.at('#foo').parameters.should == [['a', nil], ['b', nil], ['c', 'nil']]
+      expect(Registry.at('#foo').parameters).to eq [['a', nil], ['b', nil], ['c', 'nil']]
     end
 
     it "should be able to define method with module scope (module function)" do
@@ -264,11 +264,11 @@ describe YARD::Tags::MethodDirective do
       eof
       foo_c = Registry.at('Foo.foo')
       foo_i = Registry.at('Foo#foo')
-      foo_c.should_not be_nil
-      foo_i.should_not be_nil
-      foo_c.should be_module_function
-      foo_c.docstring.should == foo_i.docstring
-      foo_c.tag(:return).text.should == foo_i.tag(:return).text
+      expect(foo_c).to_not be_nil
+      expect(foo_i).to_not be_nil
+      expect(foo_c).to be_module_function
+      expect(foo_c.docstring).to eq foo_i.docstring
+      expect(foo_c.tag(:return).text).to eq foo_i.tag(:return).text
     end
   end
 end
@@ -285,8 +285,8 @@ describe YARD::Tags::AttributeDirective do
           # @!scope class
         end
       eof
-      Registry.at('Foo.foo').should be_reader
-      Registry.at('Foo.bar').should be_reader
+      expect(Registry.at('Foo.foo')).to be_reader
+      expect(Registry.at('Foo.bar')).to be_reader
     end
 
     it "should handle indented block in @!attribute" do
@@ -298,10 +298,10 @@ describe YARD::Tags::AttributeDirective do
         # @param [String] a
       eof
       foo = Registry.at('#foo')
-      foo.is_attribute?.should == true
-      foo.docstring.should == "Docstring here"
-      foo.docstring.tag(:return).should_not be_nil
-      foo.tag(:param).should be_nil
+      expect(foo.is_attribute?).to eq true
+      expect(foo.docstring).to eq "Docstring here"
+      expect(foo.docstring.tag(:return)).to_not be_nil
+      expect(foo.tag(:param)).to be_nil
     end
 
     it "should be able to define multiple @attributes in docstring" do
@@ -320,15 +320,15 @@ describe YARD::Tags::AttributeDirective do
       foo2 = Registry.at('Foo#foo2=')
       foo3 = Registry.at('Foo.foo3')
       foo4 = Registry.at('Foo.foo3=')
-      foo1.should be_reader
-      foo2.should be_writer
-      foo3.should be_reader
-      foo1.docstring.should == 'Docstring1'
-      foo2.docstring.should == 'Docstring2'
-      foo3.docstring.should == 'Docstring3'
-      foo4.should be_writer
-      foo1.attr_info[:write].should be_nil
-      foo2.attr_info[:read].should be_nil
+      expect(foo1).to be_reader
+      expect(foo2).to be_writer
+      expect(foo3).to be_reader
+      expect(foo1.docstring).to eq 'Docstring1'
+      expect(foo2.docstring).to eq 'Docstring2'
+      expect(foo3.docstring).to eq 'Docstring3'
+      expect(foo4).to be_writer
+      expect(foo1.attr_info[:write]).to be_nil
+      expect(foo2.attr_info[:read]).to be_nil
     end
 
     it "should define the attr inside namespace if attached to namespace object" do
@@ -340,8 +340,8 @@ describe YARD::Tags::AttributeDirective do
           end
         end
       eof
-      Registry.at('Foo::Bar#foo').should be_reader
-      Registry.at('Foo::Bar#bar').should be_reader
+      expect(Registry.at('Foo::Bar#foo')).to be_reader
+      expect(Registry.at('Foo::Bar#bar')).to be_reader
     end
   end
 
@@ -354,7 +354,7 @@ describe YARD::Tags::AttributeDirective do
       end
     eof
     %w(foo bar baz).each do |name|
-      Registry.at("Foo.#{name}").should be_reader
+      expect(Registry.at("Foo.#{name}")).to be_reader
     end
   end
 end
@@ -365,33 +365,33 @@ describe YARD::Tags::ScopeDirective do
 
     it "should set state on tag parser if object = nil" do
       tag_parse("@!scope class")
-      @parser.state.scope.should == :class
+      expect(@parser.state.scope).to eq :class
     end
 
     it "should set state on tag parser if object is namespace" do
       object = CodeObjects::ClassObject.new(:root, 'Foo')
       tag_parse("@!scope class", object)
-      object[:scope].should be_nil
-      @parser.state.scope.should == :class
+      expect(object[:scope]).to be_nil
+      expect(@parser.state.scope).to eq :class
     end
 
     it "should set scope on object if object is a method object" do
       object = CodeObjects::MethodObject.new(:root, 'foo')
       tag_parse("@!scope class", object)
-      object.scope.should == :class
+      expect(object.scope).to eq :class
     end
 
     %w(class instance module).each do |type|
       it "should allow #{type} as value" do
         tag_parse("@!scope #{type}")
-        @parser.state.scope.should == type.to_sym
+        expect(@parser.state.scope).to eq type.to_sym
       end
     end
 
     %w(invalid foo FOO CLASS INSTANCE).each do |type|
       it "should not allow #{type} as value" do
         tag_parse("@!scope #{type}")
-        @parser.state.scope.should be_nil
+        expect(@parser.state.scope).to be_nil
       end
     end
   end
@@ -403,33 +403,33 @@ describe YARD::Tags::VisibilityDirective do
 
     it "should set visibility on tag parser if object = nil" do
       tag_parse("@!visibility private")
-      @parser.state.visibility.should == :private
+      expect(@parser.state.visibility).to eq :private
     end
 
     it "should set state on tag parser if object is namespace" do
       object = CodeObjects::ClassObject.new(:root, 'Foo')
       tag_parse("@!visibility protected", object)
-      object.visibility.should == :protected
-      @parser.state.visibility.should be_nil
+      expect(object.visibility).to eq :protected
+      expect(@parser.state.visibility).to be_nil
     end
 
     it "should set visibility on object if object is a method object" do
       object = CodeObjects::MethodObject.new(:root, 'foo')
       tag_parse("@!visibility private", object)
-      object.visibility.should == :private
+      expect(object.visibility).to eq :private
     end
 
     %w(public private protected).each do |type|
       it "should allow #{type} as value" do
         tag_parse("@!visibility #{type}")
-        @parser.state.visibility.should == type.to_sym
+        expect(@parser.state.visibility).to eq type.to_sym
       end
     end
 
     %w(invalid foo FOO PRIVATE INSTANCE).each do |type|
       it "should not allow #{type} as value" do
         tag_parse("@!visibility #{type}")
-        @parser.state.visibility.should be_nil
+        expect(@parser.state.visibility).to be_nil
       end
     end
 
@@ -446,7 +446,7 @@ describe YARD::Tags::VisibilityDirective do
         end
       eof
       %w(foo bar baz).each do |name|
-        Registry.at("Foo##{name}").visibility.should == :private
+        expect(Registry.at("Foo##{name}").visibility).to eq :private
       end
     end if YARD::Parser::SourceParser.parser_type == :ruby
   end

--- a/spec/tags/library_spec.rb
+++ b/spec/tags/library_spec.rb
@@ -7,17 +7,17 @@ describe YARD::Tags::Library do
 
   describe '#see_tag' do
     it "should take a URL" do
-      tag("@see http://example.com").name.should == "http://example.com"
+      expect(tag("@see http://example.com").name).to eq "http://example.com"
     end
 
     it "should take an object path" do
-      tag("@see String#reverse").name.should == "String#reverse"
+      expect(tag("@see String#reverse").name).to eq "String#reverse"
     end
 
     it "should take a description after the url/object" do
       tag = tag("@see http://example.com An Example Site")
-      tag.name.should == "http://example.com"
-      tag.text.should == "An Example Site"
+      expect(tag.name).to eq "http://example.com"
+      expect(tag.text).to eq "An Example Site"
     end
   end
 
@@ -25,10 +25,10 @@ describe YARD::Tags::Library do
     it "should allow defining tags with '.' in the name (x.y.z defines method x_y_z)" do
       Tags::Library.define_tag("foo", 'x.y.z')
       Tags::Library.define_tag("foo2", 'x.y.zz', Tags::OverloadTag)
-      Tags::Library.instance.method(:x_y_z_tag).should_not be_nil
-      Tags::Library.instance.method(:x_y_zz_tag).should_not be_nil
-      tag('@x.y.z foo bar').text.should == 'foo bar'
-      tag('@x.y.zz foo(bar)').signature.should == 'foo(bar)'
+      expect(Tags::Library.instance.method(:x_y_z_tag)).to_not be_nil
+      expect(Tags::Library.instance.method(:x_y_zz_tag)).to_not be_nil
+      expect(tag('@x.y.z foo bar').text).to eq 'foo bar'
+      expect(tag('@x.y.zz foo(bar)').signature).to eq 'foo(bar)'
     end
   end
 end

--- a/spec/tags/overload_tag_spec.rb
+++ b/spec/tags/overload_tag_spec.rb
@@ -11,43 +11,43 @@ describe YARD::Tags::OverloadTag do
   end
 
   it "should parse the first line as a method signature" do
-    @tag.signature.should == "def bar(a, b = 1, &block)"
-    @tag.parameters.should == [['a', nil], ['b', "1"], ['&block', nil]]
+    expect(@tag.signature).to eq "def bar(a, b = 1, &block)"
+    expect(@tag.parameters).to eq [['a', nil], ['b', "1"], ['&block', nil]]
   end
 
   it "should parse the rest of the text as a new Docstring" do
-    @tag.docstring.should be_instance_of(Docstring)
-    @tag.docstring.should == "Hello world"
+    expect(@tag.docstring).to be_instance_of(Docstring)
+    expect(@tag.docstring).to eq "Hello world"
   end
 
   it "should set Docstring's object after #object= is called" do
     m = mock(:object)
     @tag.object = m
-    @tag.docstring.object.should == m
+    expect(@tag.docstring.object).to eq m
   end
 
   it "should respond to #tag, #tags and #has_tag?" do
     @tag.object = mock(:object)
-    @tag.tags.size.should == 2
-    @tag.tag(:param).name.should == "a"
-    @tag.has_tag?(:return).should == true
+    expect(@tag.tags.size).to eq 2
+    expect(@tag.tag(:param).name).to eq "a"
+    expect(@tag.has_tag?(:return)).to eq true
   end
 
   it "should not be a CodeObjects::Base when not hooked up to an object" do
     @tag.object = nil
-    @tag.is_a?(CodeObjects::Base).should == false
+    expect(@tag.is_a?(CodeObjects::Base)).to eq false
   end
 
   it "should be a CodeObjects::Base when hooked up to an object" do
     @tag.object = mock(:object)
-    @tag.object.should_receive(:is_a?).at_least(3).times.with(CodeObjects::Base).and_return(true)
-    @tag.is_a?(CodeObjects::Base).should == true
-    @tag.kind_of?(CodeObjects::Base).should == true
-    (CodeObjects::Base === @tag).should == true
+    expect(@tag.object).to receive(:is_a?).at_least(3).times.with(CodeObjects::Base).and_return(true)
+    expect(@tag.is_a?(CodeObjects::Base)).to eq true
+    expect(@tag.kind_of?(CodeObjects::Base)).to eq true
+    expect((CodeObjects::Base === @tag)).to eq true
   end
 
   it "should not parse 'def' out of method name" do
     tag = Tags::OverloadTag.new(:overload, "default")
-    tag.signature.should == "default"
+    expect(tag.signature).to eq "default"
   end
 end

--- a/spec/tags/ref_tag_list_spec.rb
+++ b/spec/tags/ref_tag_list_spec.rb
@@ -5,12 +5,12 @@ describe YARD::Tags::RefTagList do
 
   it "should accept symbol or string as owner's path and convert it into a proxy" do
     t = Tags::RefTagList.new('author', :String)
-    t.owner.should == P(:String)
+    expect(t.owner).to eq P(:String)
   end
 
   it "should accept proxy object as owner" do
     t = Tags::RefTagList.new('author', P(:String))
-    t.owner.should == P(:String)
+    expect(t.owner).to eq P(:String)
   end
 
   it "should return tags from a proxy object" do
@@ -19,8 +19,8 @@ describe YARD::Tags::RefTagList do
     o.docstring.add_tag(t)
 
     ref = Tags::RefTagList.new('author', :String)
-    ref.tags.should == [t]
-    ref.tags.first.text.should == 'foo'
+    expect(ref.tags).to eq [t]
+    expect(ref.tags.first.text).to eq 'foo'
   end
 
   it "should return named tags from a proxy object" do
@@ -32,8 +32,8 @@ describe YARD::Tags::RefTagList do
     o.docstring.add_tag(p1, t1, p2, p3)
 
     ref = Tags::RefTagList.new('param', :String, 'foo')
-    ref.tags.should == [p1, p2]
-    ref.tags.first.text.should == 'bar1'
+    expect(ref.tags).to eq [p1, p2]
+    expect(ref.tags.first.text).to eq 'bar1'
   end
 
   it "all tags should respond to #owner and be a RefTag" do
@@ -46,8 +46,8 @@ describe YARD::Tags::RefTagList do
 
     ref = Tags::RefTagList.new('param', :String)
     ref.tags.each do |t|
-      t.should be_kind_of(Tags::RefTag)
-      t.owner.should == o
+      expect(t).to be_kind_of(Tags::RefTag)
+      expect(t.owner).to eq o
     end
   end
 end

--- a/spec/templates/engine_spec.rb
+++ b/spec/templates/engine_spec.rb
@@ -4,61 +4,61 @@ describe YARD::Templates::Engine do
   describe '.register_template_path' do
     it "should register a String path" do
       Engine.register_template_path('.')
-      Engine.template_paths.pop.should == '.'
+      expect(Engine.template_paths.pop).to eq '.'
     end
   end
 
   describe '.template!' do
     it "should create a module including Template" do
       mod = Engine.template!('path/to/template')
-      mod.should include(Template)
-      mod.full_path.to_s.should == 'path/to/template'
+      expect(mod).to include(Template)
+      expect(mod.full_path.to_s).to eq 'path/to/template'
     end
 
     it "should create a module including Template with full_path" do
       mod = Engine.template!('path/to/template2', '/full/path/to/template2')
-      mod.should include(Template)
-      mod.full_path.to_s.should == '/full/path/to/template2'
+      expect(mod).to include(Template)
+      expect(mod.full_path.to_s).to eq '/full/path/to/template2'
     end
   end
 
   describe '.template' do
     it "should raise an error if the template is not found" do
-      lambda { Engine.template(:a, :b, :c) }.should raise_error(ArgumentError)
+      expect{ Engine.template(:a, :b, :c) }.to raise_error(ArgumentError)
     end
 
     it "should create a module including Template" do
       mock = mock(:template)
-      Engine.should_receive(:find_template_paths).with(nil, 'template/name').and_return(['/full/path/template/name'])
-      Engine.should_receive(:template!).with('template/name', ['/full/path/template/name']).and_return(mock)
-      Engine.template('template/name').should == mock
+      expect(Engine).to receive(:find_template_paths).with(nil, 'template/name').and_return(['/full/path/template/name'])
+      expect(Engine).to receive(:template!).with('template/name', ['/full/path/template/name']).and_return(mock)
+      expect(Engine.template('template/name')).to eq mock
     end
 
     it "should create a Template from a relative Template path" do
-      Engine.should_receive(:template_paths).and_return([])
-      File.should_receive(:directory?).with("/full/path/template/notname").and_return(true)
+      expect(Engine).to receive(:template_paths).and_return([])
+      expect(File).to receive(:directory?).with("/full/path/template/notname").and_return(true)
       start_template = mock(:start_template)
       start_template.stub!(:full_path).and_return('/full/path/template/name')
       start_template.stub!(:full_paths).and_return(['/full/path/template/name'])
-      start_template.should_receive(:is_a?).with(Template).and_return(true)
+      expect(start_template).to receive(:is_a?).with(Template).and_return(true)
       mod = Engine.template(start_template, '..', 'notname')
-      mod.should include(Template)
-      mod.full_path.to_s.should == "/full/path/template/notname"
+      expect(mod).to include(Template)
+      expect(mod.full_path.to_s).to eq "/full/path/template/notname"
     end
 
     it "should create a Template including other matching templates in path" do
       paths = ['/full/path/template/name', '/full/path2/template/name']
-      Engine.should_receive(:find_template_paths).with(nil, 'template').at_least(1).times.and_return([])
-      Engine.should_receive(:find_template_paths).with(nil, 'template/name').and_return(paths)
+      expect(Engine).to receive(:find_template_paths).with(nil, 'template').at_least(1).times.and_return([])
+      expect(Engine).to receive(:find_template_paths).with(nil, 'template/name').and_return(paths)
       ancestors = Engine.template('template/name').ancestors.map {|m| m.class_name }
-      ancestors.should include("Template__full_path2_template_name")
+      expect(ancestors).to include("Template__full_path2_template_name")
     end
 
     it "should include parent directories before other template paths" do
       paths = ['/full/path/template/name', '/full/path2/template/name']
-      Engine.should_receive(:find_template_paths).with(nil, 'template/name').and_return(paths)
+      expect(Engine).to receive(:find_template_paths).with(nil, 'template/name').and_return(paths)
       ancestors = Engine.template('template/name').ancestors.map {|m| m.class_name }
-      ancestors[0, 4].should == ["Template__full_path_template_name", "Template__full_path_template",
+      expect(ancestors[0, 4]).to eq ["Template__full_path_template_name", "Template__full_path_template",
         "Template__full_path2_template_name", "Template__full_path2_template"]
     end
   end
@@ -70,15 +70,15 @@ describe YARD::Templates::Engine do
       options.reset_defaults
       options.objects = [:a, :b, :c]
       options.object = Registry.root
-      mod.should_receive(:run).with(options)
-      Engine.should_receive(:template).with(:default, :fulldoc, :text).and_return(mod)
+      expect(mod).to receive(:run).with(options)
+      expect(Engine).to receive(:template).with(:default, :fulldoc, :text).and_return(mod)
       Engine.generate([:a, :b, :c])
     end
   end
 
   describe '.render' do
     def loads_template(*args)
-      Engine.should_receive(:template).with(*args).and_return(@template)
+      expect(Engine).to receive(:template).with(*args).and_return(@template)
     end
 
     before(:all) do
@@ -92,7 +92,7 @@ describe YARD::Templates::Engine do
       @options.type = @object.type
       @template = mock(:template)
       @template.stub!(:include)
-      @template.should_receive(:run).with(@options)
+      expect(@template).to receive(:run).with(@options)
     end
 
     it "should accept method call with no parameters" do

--- a/spec/templates/helpers/base_helper_spec.rb
+++ b/spec/templates/helpers/base_helper_spec.rb
@@ -6,9 +6,9 @@ describe YARD::Templates::Helpers::BaseHelper do
   describe '#run_verifier' do
     it "should run verifier proc against list if provided" do
       mock = Verifier.new
-      mock.should_receive(:call).with(1)
-      mock.should_receive(:call).with(2)
-      mock.should_receive(:call).with(3)
+      expect(mock).to receive(:call).with(1)
+      expect(mock).to receive(:call).with(2)
+      expect(mock).to receive(:call).with(3)
       should_receive(:options).at_least(1).times.and_return(Options.new.update(:verifier => mock))
       run_verifier [1, 2, 3]
     end
@@ -16,50 +16,50 @@ describe YARD::Templates::Helpers::BaseHelper do
     it "should prune list if lambda returns false and only false" do
       mock = Verifier.new
       should_receive(:options).at_least(1).times.and_return(Options.new.update(:verifier => mock))
-      mock.should_receive(:call).with(1).and_return(false)
-      mock.should_receive(:call).with(2).and_return(true)
-      mock.should_receive(:call).with(3).and_return(nil)
-      mock.should_receive(:call).with(4).and_return("value")
-      run_verifier([1, 2, 3, 4]).should == [2, 3, 4]
+      expect(mock).to receive(:call).with(1).and_return(false)
+      expect(mock).to receive(:call).with(2).and_return(true)
+      expect(mock).to receive(:call).with(3).and_return(nil)
+      expect(mock).to receive(:call).with(4).and_return("value")
+      expect(run_verifier([1, 2, 3, 4])).to eq [2, 3, 4]
     end
 
     it "should return list if no verifier exists" do
       should_receive(:options).at_least(1).times.and_return(Options.new)
-      run_verifier([1, 2, 3]).should == [1, 2, 3]
+      expect(run_verifier([1, 2, 3])).to eq [1, 2, 3]
     end
   end
 
   describe '#h' do
     it "should return just the text" do
-      h("hello world").should == "hello world"
-      h(nil).should == nil
+      expect(h("hello world")).to eq "hello world"
+      expect(h(nil)).to eq nil
     end
   end
 
   describe '#link_object' do
     it "should return the title if provided" do
-      link_object(1, "title").should == "title"
-      link_object(Registry.root, "title").should == "title"
+      expect(link_object(1, "title")).to eq "title"
+      expect(link_object(Registry.root, "title")).to eq "title"
     end
 
     it "should return a path if argument is a Proxy or object" do
-      link_object(Registry.root).should == "Top Level Namespace"
-      link_object(P("Array")).should == "Array"
+      expect(link_object(Registry.root)).to eq "Top Level Namespace"
+      expect(link_object(P("Array"))).to eq "Array"
     end
 
     it "should should return path of Proxified object if argument is a String or Symbol" do
-      link_object("Array").should == "Array"
-      link_object(:"A::B").should == "A::B"
+      expect(link_object("Array")).to eq "Array"
+      expect(link_object(:"A::B")).to eq "A::B"
     end
 
     it "should return the argument if not an object, proxy, String or Symbol" do
-      link_object(1).should == 1
+      expect(link_object(1)).to eq 1
     end
   end
 
   describe '#link_url' do
     it "should return the URL" do
-      link_url("http://url").should == "http://url"
+      expect(link_url("http://url")).to eq "http://url"
     end
   end
 
@@ -90,8 +90,8 @@ describe YARD::Templates::Helpers::BaseHelper do
     end
 
     it "should return empty string and warn if object does not exist" do
-      log.should_receive(:warn).with(/Cannot find object .* for inclusion/)
-      linkify('include:NotExist').should == ''
+      expect(log).to receive(:warn).with(/Cannot find object .* for inclusion/)
+      expect(linkify('include:NotExist')).to eq ''
     end
 
     it "should pass off to #link_url if argument is recognized as a URL" do
@@ -107,34 +107,34 @@ describe YARD::Templates::Helpers::BaseHelper do
     end
 
     it "should call #link_include_file for include:file:path/to/file" do
-      File.should_receive(:file?).with('path/to/file').and_return(true)
-      File.should_receive(:read).with('path/to/file').and_return('FOO')
-      linkify('include:file:path/to/file').should == 'FOO'
+      expect(File).to receive(:file?).with('path/to/file').and_return(true)
+      expect(File).to receive(:read).with('path/to/file').and_return('FOO')
+      expect(linkify('include:file:path/to/file')).to eq 'FOO'
     end
 
     it "should not allow include:file for path above pwd" do
-      log.should_receive(:warn).with("Cannot include file from path `a/b/../../../../file'")
-      linkify('include:file:a/b/../../../../file').should == ''
+      expect(log).to receive(:warn).with("Cannot include file from path `a/b/../../../../file'")
+      expect(linkify('include:file:a/b/../../../../file')).to eq ''
     end
 
     it "should warn if include:file:path does not exist" do
-      log.should_receive(:warn).with(/Cannot find file .+ for inclusion/)
-      linkify('include:file:notexist').should == ''
+      expect(log).to receive(:warn).with(/Cannot find file .+ for inclusion/)
+      expect(linkify('include:file:notexist')).to eq ''
     end
   end
 
   describe '#format_types' do
     it "should return the list of types separated by commas surrounded by brackets" do
-      format_types(['a', 'b', 'c']).should == '(a, b, c)'
+      expect(format_types(['a', 'b', 'c'])).to eq '(a, b, c)'
     end
 
     it "should return the list of types without brackets if brackets=false" do
-      format_types(['a', 'b', 'c'], false).should == 'a, b, c'
+      expect(format_types(['a', 'b', 'c'], false)).to eq 'a, b, c'
     end
 
     it "should should return an empty string if list is empty or nil" do
-      format_types(nil).should == ""
-      format_types([]).should == ""
+      expect(format_types(nil)).to eq ""
+      expect(format_types([])).to eq ""
     end
   end
 
@@ -143,33 +143,33 @@ describe YARD::Templates::Helpers::BaseHelper do
       obj = mock(:object)
       obj.stub!(:is_a?).with(YARD::CodeObjects::ClassObject).and_return(true)
       obj.stub!(:is_exception?).and_return(true)
-      format_object_type(obj).should == "Exception"
+      expect(format_object_type(obj)).to eq "Exception"
     end
 
     it "should return Class if type is Class" do
       obj = mock(:object)
       obj.stub!(:is_a?).with(YARD::CodeObjects::ClassObject).and_return(true)
       obj.stub!(:is_exception?).and_return(false)
-      format_object_type(obj).should == "Class"
+      expect(format_object_type(obj)).to eq "Class"
     end
 
     it "should return object type in other cases" do
       obj = mock(:object)
       obj.stub!(:type).and_return("value")
-      format_object_type(obj).should == "Value"
+      expect(format_object_type(obj)).to eq "Value"
     end
   end
 
   describe '#format_object_title' do
     it "should return Top Level Namespace for root object" do
-      format_object_title(Registry.root).should == "Top Level Namespace"
+      expect(format_object_title(Registry.root)).to eq "Top Level Namespace"
     end
 
     it "should return 'type: title' in other cases" do
       obj = mock(:object)
       obj.stub!(:type).and_return(:class)
       obj.stub!(:title).and_return("A::B::C")
-      format_object_title(obj).should == "Class: A::B::C"
+      expect(format_object_title(obj)).to eq "Class: A::B::C"
     end
   end
 end

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -16,53 +16,53 @@ describe YARD::Templates::Helpers::HtmlHelper do
 
   describe '#h' do
     it "should use #h to escape HTML" do
-      h('Usage: foo "bar" <baz>').should == "Usage: foo &quot;bar&quot; &lt;baz&gt;"
+      expect(h('Usage: foo "bar" <baz>')).to eq "Usage: foo &quot;bar&quot; &lt;baz&gt;"
     end
   end
 
   describe '#charset' do
     it "should return foo if LANG=foo" do
-      ENV.should_receive(:[]).with('LANG').and_return('shift_jis') if YARD.ruby18?
-      Encoding.default_external.should_receive(:name).and_return('shift_jis') if defined?(Encoding)
-      charset.should == 'shift_jis'
+      expect(ENV).to receive(:[]).with('LANG').and_return('shift_jis') if YARD.ruby18?
+      expect(Encoding.default_external).to receive(:name).and_return('shift_jis') if defined?(Encoding)
+      expect(charset).to eq 'shift_jis'
     end
 
     ['US-ASCII', 'ASCII-7BIT', 'ASCII-8BIT'].each do |type|
       it "should convert #{type} to iso-8859-1" do
-        ENV.should_receive(:[]).with('LANG').and_return(type) if YARD.ruby18?
-        Encoding.default_external.should_receive(:name).and_return(type) if defined?(Encoding)
-        charset.should == 'iso-8859-1'
+        expect(ENV).to receive(:[]).with('LANG').and_return(type) if YARD.ruby18?
+        expect(Encoding.default_external).to receive(:name).and_return(type) if defined?(Encoding)
+        expect(charset).to eq 'iso-8859-1'
       end
     end
 
     it "should support utf8 as an encoding value for utf-8" do
       type = 'utf8'
-      ENV.should_receive(:[]).with('LANG').and_return(type) if YARD.ruby18?
-      Encoding.default_external.should_receive(:name).and_return(type) if defined?(Encoding)
-      charset.should == 'utf-8'
+      expect(ENV).to receive(:[]).with('LANG').and_return(type) if YARD.ruby18?
+      expect(Encoding.default_external).to receive(:name).and_return(type) if defined?(Encoding)
+      expect(charset).to eq 'utf-8'
     end
 
     it "should take file encoding if there is a file" do
       @file = OpenStruct.new(:contents => 'foo'.force_encoding('sjis'))
       # not the correct charset name, but good enough
-      ['Shift_JIS', 'Windows-31J'].should include(charset)
+      expect(['Shift_JIS', 'Windows-31J']).to include(charset)
     end if YARD.ruby19?
 
     it "should take file encoding if there is a file" do
       ENV.stub!(:[]).with('LANG').and_return('utf-8') if YARD.ruby18?
       @file = OpenStruct.new(:contents => 'foo')
-      charset.should == 'utf-8'
+      expect(charset).to eq 'utf-8'
     end if YARD.ruby18?
 
     if YARD.ruby18?
       it "should return utf-8 if no LANG env is set" do
-        ENV.should_receive(:[]).with('LANG').and_return(nil)
-        charset.should == 'utf-8'
+        expect(ENV).to receive(:[]).with('LANG').and_return(nil)
+        expect(charset).to eq 'utf-8'
       end
 
       it "should only return charset part of lang" do
-        ENV.should_receive(:[]).with('LANG').and_return('en_US.UTF-8')
-        charset.should == 'utf-8'
+        expect(ENV).to receive(:[]).with('LANG').and_return('en_US.UTF-8')
+        expect(charset).to eq 'utf-8'
       end
     end
   end
@@ -71,14 +71,14 @@ describe YARD::Templates::Helpers::HtmlHelper do
     it "should include brackets by default" do
       text = ["String"]
       should_receive(:linkify).at_least(1).times.with("String", "String").and_return("String")
-      format_types(text).should == format_types(text, true)
-      format_types(text).should == "(<tt>String</tt>)"
+      expect(format_types(text)).to eq format_types(text, true)
+      expect(format_types(text)).to eq "(<tt>String</tt>)"
     end
 
     it "should avoid brackets if brackets=false" do
       should_receive(:linkify).with("String", "String").and_return("String")
       should_receive(:linkify).with("Symbol", "Symbol").and_return("Symbol")
-      format_types(["String", "Symbol"], false).should == "<tt>String</tt>, <tt>Symbol</tt>"
+      expect(format_types(["String", "Symbol"], false)).to eq "<tt>String</tt>, <tt>Symbol</tt>"
     end
 
     { "String" => [["String"],
@@ -97,7 +97,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
         should_receive(:h).with('<').at_least(text.count('<')).times.and_return("&lt;")
         should_receive(:h).with('>').at_least(text.count('>')).times.and_return("&gt;")
         values[0].each {|v| should_receive(:linkify).with(v, v).and_return("<a href=''>#{v}</a>") }
-        format_types([text], false).should == values[1]
+        expect(format_types([text], false)).to eq values[1]
       end
     end
   end
@@ -105,12 +105,12 @@ describe YARD::Templates::Helpers::HtmlHelper do
   describe '#htmlify' do
     it "should not use hard breaks for textile markup (RedCloth specific)" do
       begin; require 'redcloth'; rescue LoadError; pending 'test requires redcloth gem' end
-      htmlify("A\nB", :textile).should_not include("<br")
+      expect(htmlify("A\nB", :textile)).to_not include("<br")
     end
 
     it "should use hard breaks for textile_strict markup (RedCloth specific)" do
       begin; require 'redcloth'; rescue LoadError; pending 'test requires redcloth gem' end
-      htmlify("A\nB", :textile_strict).should include("<br")
+      expect(htmlify("A\nB", :textile_strict)).to include("<br")
     end
 
     it "should handle various encodings" do
@@ -125,26 +125,26 @@ describe YARD::Templates::Helpers::HtmlHelper do
     end
 
     it "should return pre-formatted text with :pre markup" do
-      htmlify("fo\no\n\nbar<>", :pre).should == "<pre>fo\no\n\nbar&lt;&gt;</pre>"
+      expect(htmlify("fo\no\n\nbar<>", :pre)).to eq "<pre>fo\no\n\nbar&lt;&gt;</pre>"
     end
 
     it "should return regular text with :text markup" do
-      htmlify("fo\no\n\nbar<>", :text).should == "fo<br/>o<br/><br/>bar&lt;&gt;"
+      expect(htmlify("fo\no\n\nbar<>", :text)).to eq "fo<br/>o<br/><br/>bar&lt;&gt;"
     end
 
     it "should return unmodified text with :none markup" do
-      htmlify("fo\no\n\nbar<>", :none).should == "fo\no\n\nbar&lt;&gt;"
+      expect(htmlify("fo\no\n\nbar<>", :none)).to eq "fo\no\n\nbar&lt;&gt;"
     end
 
     it "should highlight ruby if markup is :ruby" do
-      htmlify("class Foo; end", :ruby).should =~ /\A<pre class="code ruby"><span/
+      expect(htmlify("class Foo; end", :ruby)).to match( /\A<pre class="code ruby"><span/ )
     end
 
     it "should include file and htmlify it" do
       load_markup_provider(:rdoc)
-      File.should_receive(:file?).with('foo.rdoc').and_return(true)
-      File.should_receive(:read).with('foo.rdoc').and_return('HI')
-      htmlify("{include:file:foo.rdoc}", :rdoc).gsub(/\s+/, '').should == "<p><p>HI</p></p>"
+      expect(File).to receive(:file?).with('foo.rdoc').and_return(true)
+      expect(File).to receive(:read).with('foo.rdoc').and_return('HI')
+      expect(htmlify("{include:file:foo.rdoc}", :rdoc).gsub(/\s+/, '')).to eq "<p><p>HI</p></p>"
     end
 
     it "should autolink URLs (markdown specific)" do
@@ -153,18 +153,18 @@ describe YARD::Templates::Helpers::HtmlHelper do
           pending 'This test depends on a markdown engine that supports autolinking'
         end
       end
-      htmlify('http://example.com', :markdown).chomp.gsub('&#47;', '/').should ==
-        '<p><a href="http://example.com">http://example.com</a></p>'
+      expect(htmlify('http://example.com', :markdown).chomp.gsub('&#47;', '/'))
+        .to eq '<p><a href="http://example.com">http://example.com</a></p>'
     end
 
     it "should not autolink URLs inside of {} (markdown specific)" do
       log.enter_level(Logger::FATAL) do
         pending 'This test depends on markdown' unless markup_class(:markdown)
       end
-      htmlify('{http://example.com Title}', :markdown).chomp.should =~
-        %r{<p><a href="http://example.com".*>Title</a></p>}
-      htmlify('{http://example.com}', :markdown).chomp.should =~
-        %r{<p><a href="http://example.com".*>http://example.com</a></p>}
+      expect(htmlify('{http://example.com Title}', :markdown).chomp).to match(
+        %r{<p><a href="http://example.com".*>Title</a></p>} )
+      expect(htmlify('{http://example.com}', :markdown).chomp).to match(
+        %r{<p><a href="http://example.com".*>http://example.com</a></p>} )
     end
   end
 
@@ -175,12 +175,12 @@ describe YARD::Templates::Helpers::HtmlHelper do
 
     it "should return the object path if there's no serializer and no title" do
       stub!(:serializer).and_return nil
-      link_object(CodeObjects::NamespaceObject.new(nil, :YARD)).should == "YARD"
+      expect(link_object(CodeObjects::NamespaceObject.new(nil, :YARD))).to eq "YARD"
     end
 
     it "should return the title if there's a title but no serializer" do
       stub!(:serializer).and_return nil
-      link_object(CodeObjects::NamespaceObject.new(nil, :YARD), 'title').should == "title"
+      expect(link_object(CodeObjects::NamespaceObject.new(nil, :YARD), 'title')).to eq "title"
     end
 
     it "should link objects from overload tag" do
@@ -199,7 +199,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       serializer = Serializers::FileSystemSerializer.new
       stub!(:serializer).and_return(serializer)
       stub!(:object).and_return(obj)
-      link_object("Bar#a").should =~ %r{href="Bar.html#a-instance_method"}
+      expect(link_object("Bar#a")).to match( %r{href="Bar.html#a-instance_method"} )
     end
 
     it "should use relative path in title" do
@@ -208,7 +208,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       stub!(:object).and_return(CodeObjects::ModuleObject.new(P('YARD'), :Foo))
       serializer = Serializers::FileSystemSerializer.new
       stub!(:serializer).and_return(serializer)
-      link_object("Bar").should =~ %r{>Bar</a>}
+      expect(link_object("Bar")).to match( %r{>Bar</a>} )
     end
 
     it "should use #title if overridden" do
@@ -218,7 +218,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       stub!(:object).and_return(Registry.at('YARD::Bar'))
       serializer = Serializers::FileSystemSerializer.new
       stub!(:serializer).and_return(serializer)
-      link_object("Bar").should =~ %r{>TITLE!</a>}
+      expect(link_object("Bar")).to match( %r{>TITLE!</a>} )
     end
 
     it "should use relative path to parent class in title" do
@@ -227,7 +227,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       stub!(:object).and_return(obj)
       serializer = Serializers::FileSystemSerializer.new
       stub!(:serializer).and_return(serializer)
-      link_object("YARD").should =~ %r{>YARD</a>}
+      expect(link_object("YARD")).to match( %r{>YARD</a>} )
     end
 
     it "should use Klass.foo when linking to class method in current namespace" do
@@ -236,7 +236,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       stub!(:object).and_return(root)
       serializer = Serializers::FileSystemSerializer.new
       stub!(:serializer).and_return(serializer)
-      link_object("foo").should =~ %r{>Klass.foo</a>}
+      expect(link_object("foo")).to match( %r{>Klass.foo</a>} )
     end
 
     it "should escape method name in title" do
@@ -250,7 +250,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       serializer = Serializers::FileSystemSerializer.new
       stub!(:serializer).and_return(serializer)
       stub!(:object).and_return(obj)
-      link_object("Array#&").should =~ %r{title="Array#&amp; \(method\)"}
+      expect(link_object("Array#&")).to match( %r{title="Array#&amp; \(method\)"} )
     end
   end
 
@@ -260,7 +260,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
     it "should return nil if serializer is nil" do
       stub!(:serializer).and_return nil
       stub!(:object).and_return Registry.root
-      url_for(P("Mod::Class#meth")).should be_nil
+      expect(url_for(P("Mod::Class#meth"))).to be_nil
     end
 
     it "should return nil if object is hidden" do
@@ -270,13 +270,13 @@ describe YARD::Templates::Helpers::HtmlHelper do
       stub!(:object).and_return Registry.root
       stub!(:options).and_return OpenStruct.new(:verifier => Verifier.new('false'))
 
-      url_for(yard).should be_nil
+      expect(url_for(yard)).to be_nil
     end
 
     it "should return nil if serializer does not implement #serialized_path" do
       stub!(:serializer).and_return Serializers::Base.new
       stub!(:object).and_return Registry.root
-      url_for(P("Mod::Class#meth")).should be_nil
+      expect(url_for(P("Mod::Class#meth"))).to be_nil
     end
 
     it "should link to a path/file for a namespace object" do
@@ -284,7 +284,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       stub!(:object).and_return Registry.root
 
       yard = CodeObjects::ModuleObject.new(:root, :YARD)
-      url_for(yard).should == 'YARD.html'
+      expect(url_for(yard)).to eq 'YARD.html'
     end
 
     it "should link to the object's namespace path/file and use the object as the anchor" do
@@ -293,7 +293,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
 
       yard = CodeObjects::ModuleObject.new(:root, :YARD)
       meth = CodeObjects::MethodObject.new(yard, :meth)
-      url_for(meth).should == 'YARD.html#meth-instance_method'
+      expect(url_for(meth)).to eq 'YARD.html#meth-instance_method'
     end
 
     it "should properly urlencode methods with punctuation in links" do
@@ -302,21 +302,21 @@ describe YARD::Templates::Helpers::HtmlHelper do
       serializer.stub!(:serialized_path).and_return("file.html")
       stub!(:serializer).and_return(serializer)
       stub!(:object).and_return(obj)
-      url_for(obj).should == "#%2F-instance_method"
+      expect(url_for(obj)).to eq "#%2F-instance_method"
     end
   end
 
   describe '#anchor_for' do
     it "should not urlencode data when called directly" do
       obj = CodeObjects::MethodObject.new(nil, :/)
-      anchor_for(obj).should == "/-instance_method"
+      expect(anchor_for(obj)).to eq "/-instance_method"
     end
   end
 
   describe '#resolve_links' do
     def parse_link(link)
       results = {}
-      link =~ /<a (.+?)>(.+?)<\/a>/m
+      link.match( /<a (.+?)>(.+?)<\/a>/m )
       params, results[:inner_text] = $1, $2
       params.scan(/\s*(\S+?)=['"](.+?)['"]\s*/).each do |key, value|
         results[key.to_sym] = value.gsub(/^["'](.+)["']$/, '\1')
@@ -327,74 +327,74 @@ describe YARD::Templates::Helpers::HtmlHelper do
     it "should escape {} syntax with backslash (\\{foo bar})" do
       input  = '\{foo bar} \{XYZ} \{file:FOO} $\{N-M}'
       output = '{foo bar} {XYZ} {file:FOO} ${N-M}'
-      resolve_links(input).should == output
+      expect(resolve_links(input)).to eq output
     end
 
     it "should escape {} syntax with ! (!{foo bar})" do
       input  = '!{foo bar} !{XYZ} !{file:FOO} $!{N-M}'
       output = '{foo bar} {XYZ} {file:FOO} ${N-M}'
-      resolve_links(input).should == output
+      expect(resolve_links(input)).to eq output
     end
 
     it "should link static files with file: prefix" do
       stub!(:serializer).and_return Serializers::FileSystemSerializer.new
       stub!(:object).and_return Registry.root
 
-      parse_link(resolve_links("{file:TEST.txt#abc}")).should == {
+      expect(parse_link(resolve_links("{file:TEST.txt#abc}"))).to eq ({
         :inner_text => "TEST",
         :title => "TEST",
         :href => "file.TEST.html#abc"
-      }
-      parse_link(resolve_links("{file:TEST.txt title}")).should == {
+      })
+      expect(parse_link(resolve_links("{file:TEST.txt title}"))).to eq ({
         :inner_text => "title",
         :title => "title",
         :href => "file.TEST.html"
-      }
+      })
     end
 
     it "should create regular links with http:// or https:// prefixes" do
-      parse_link(resolve_links("{http://example.com}")).should == {
+      expect(parse_link(resolve_links("{http://example.com}"))).to eq( {
         :inner_text => "http://example.com",
         :target => "_parent",
         :href => "http://example.com",
         :title => "http://example.com"
-      }
-      parse_link(resolve_links("{http://example.com title}")).should == {
+      } )
+      expect(parse_link(resolve_links("{http://example.com title}"))).to eq( {
         :inner_text => "title",
         :target => "_parent",
         :href => "http://example.com",
         :title => "title"
-      }
+      } )
     end
 
     it "should create mailto links with mailto: prefixes" do
-      parse_link(resolve_links('{mailto:joanna@example.com}')).should == {
+      expect(parse_link(resolve_links('{mailto:joanna@example.com}'))).to eq( {
         :inner_text => 'mailto:joanna@example.com',
         :target => '_parent',
         :href => 'mailto:joanna@example.com',
         :title => 'mailto:joanna@example.com'
-      }
-      parse_link(resolve_links('{mailto:steve@example.com Steve}')).should == {
+      })
+      expect(parse_link(resolve_links('{mailto:steve@example.com Steve}'))).to eq( {
         :inner_text => 'Steve',
         :target => '_parent',
         :href => 'mailto:steve@example.com',
         :title => 'Steve'
-      }
+      })
     end
 
     it "should ignore {links} that begin with |...|" do
-      resolve_links("{|x|x == 1}").should == "{|x|x == 1}"
+      expect(resolve_links("{|x|x eq 1}")).to eq "{|x|x eq 1}"
     end
 
     it "should gracefully ignore {} in links" do
       should_receive(:linkify).with('Foo', 'Foo').and_return('FOO')
-      resolve_links("{} {} {Foo Foo}").should == '{} {} FOO'
+      expect(resolve_links("{} {} {Foo Foo}")).to eq '{} {} FOO'
     end
 
     %w(tt code pre).each do |tag|
       it "should ignore links in <#{tag}>" do
         text = "<#{tag}>{Foo}</#{tag}>"
-        resolve_links(text).should == text
+        expect(resolve_links(text)).to eq text
       end
     end
 
@@ -409,12 +409,12 @@ describe YARD::Templates::Helpers::HtmlHelper do
     end
 
     it "should resolve link with newline in title-part" do
-      parse_link(resolve_links("{http://example.com foo\nbar}")).should == {
+      expect(parse_link(resolve_links("{http://example.com foo\nbar}"))).to eq ({
         :inner_text => "foo bar",
         :target => "_parent",
         :href => "http://example.com",
         :title => "foo bar"
-      }
+      })
     end
 
     it "should resolve links to methods whose names have been escaped" do
@@ -429,8 +429,8 @@ describe YARD::Templates::Helpers::HtmlHelper do
         class MyObject; end
       eof
       logger = mock(:log)
-      logger.should_receive(:warn).ordered.with("In file `(stdin)':2: Cannot resolve link to InvalidObject from text:")
-      logger.should_receive(:warn).ordered.with("...{InvalidObject}")
+      expect(logger).to receive(:warn).ordered.with("In file `(stdin)':2: Cannot resolve link to InvalidObject from text:")
+      expect(logger).to receive(:warn).ordered.with("...{InvalidObject}")
       stub!(:log).and_return(logger)
       stub!(:object).and_return(Registry.at('MyObject'))
       resolve_links(object.docstring)
@@ -445,14 +445,14 @@ describe YARD::Templates::Helpers::HtmlHelper do
         class MyObject; end
       eof
       logger = mock(:log)
-      logger.should_receive(:warn).ordered.with("In file `(stdin)':1: Cannot resolve link to InvalidObject1 from text:")
-      logger.should_receive(:warn).ordered.with("{InvalidObject1}...")
-      logger.should_receive(:warn).ordered.with("In file `(stdin)':2: Cannot resolve link to InvalidObject2 from text:")
-      logger.should_receive(:warn).ordered.with("...{InvalidObject2}")
-      logger.should_receive(:warn).ordered.with("In file `(stdin)':3: Cannot resolve link to InvalidObject3 from text:")
-      logger.should_receive(:warn).ordered.with("...{InvalidObject3}...")
-      logger.should_receive(:warn).ordered.with("In file `(stdin)':4: Cannot resolve link to InvalidObject4 from text:")
-      logger.should_receive(:warn).ordered.with("{InvalidObject4}")
+      expect(logger).to receive(:warn).ordered.with("In file `(stdin)':1: Cannot resolve link to InvalidObject1 from text:")
+      expect(logger).to receive(:warn).ordered.with("{InvalidObject1}...")
+      expect(logger).to receive(:warn).ordered.with("In file `(stdin)':2: Cannot resolve link to InvalidObject2 from text:")
+      expect(logger).to receive(:warn).ordered.with("...{InvalidObject2}")
+      expect(logger).to receive(:warn).ordered.with("In file `(stdin)':3: Cannot resolve link to InvalidObject3 from text:")
+      expect(logger).to receive(:warn).ordered.with("...{InvalidObject3}...")
+      expect(logger).to receive(:warn).ordered.with("In file `(stdin)':4: Cannot resolve link to InvalidObject4 from text:")
+      expect(logger).to receive(:warn).ordered.with("{InvalidObject4}")
       stub!(:log).and_return(logger)
       stub!(:object).and_return(Registry.at('MyObject'))
       resolve_links(object.docstring)
@@ -461,8 +461,8 @@ describe YARD::Templates::Helpers::HtmlHelper do
     it "should warn about missing reference for file template (no object)" do
       @file = CodeObjects::ExtraFileObject.new('myfile.txt', '')
       logger = mock(:log)
-      logger.should_receive(:warn).ordered.with("In file `myfile.txt':3: Cannot resolve link to InvalidObject from text:")
-      logger.should_receive(:warn).ordered.with("...{InvalidObject Some Title}")
+      expect(logger).to receive(:warn).ordered.with("In file `myfile.txt':3: Cannot resolve link to InvalidObject from text:")
+      expect(logger).to receive(:warn).ordered.with("...{InvalidObject Some Title}")
       stub!(:log).and_return(logger)
       stub!(:object).and_return(Registry.root)
       resolve_links(<<-eof)
@@ -510,8 +510,8 @@ describe YARD::Templates::Helpers::HtmlHelper do
       serializer.stub!(:serialized_path).with(Registry.at('Foo')).and_return('')
       stub!(:serializer).and_return(serializer)
       stub!(:object).and_return(Registry.at('Foo'))
-      signature(Registry.at('Foo#foo').tag(:overload), true).should ==
-        "<a href=\"#foo-instance_method\" title=\"#bar (instance method)\">- <strong>bar</strong>(a, b, c) </a>"
+      expect(signature(Registry.at('Foo#foo').tag(:overload), true)).to eq (
+        "<a href=\"#foo-instance_method\" title=\"#bar (instance method)\">- <strong>bar</strong>(a, b, c) </a>")
     end
   end
 
@@ -525,88 +525,88 @@ describe YARD::Templates::Helpers::HtmlHelper do
     end
 
     it "should return empty string on nil input" do
-      subject.html_syntax_highlight(nil).should == ''
+      expect(subject.html_syntax_highlight(nil)).to eq ''
     end
 
     it "should call #html_syntax_highlight_ruby by default" do
       Registry.root.source_type = nil
-      subject.should_receive(:html_syntax_highlight_ruby).with('def x; end')
+      expect(subject).to receive(:html_syntax_highlight_ruby).with('def x; end')
       subject.html_syntax_highlight('def x; end')
     end
 
     it "should call #html_syntax_highlight_NAME if there's an object with a #source_type" do
       subject.object = OpenStruct.new(:source_type => :NAME)
-      subject.should_receive(:respond_to?).with('html_markup_html').and_return(true)
-      subject.should_receive(:respond_to?).with('html_syntax_highlight_NAME').and_return(true)
-      subject.should_receive(:html_syntax_highlight_NAME).and_return("foobar")
-      subject.htmlify('<pre><code>def x; end</code></pre>', :html).should ==
-        '<pre class="code NAME"><code class="NAME">foobar</code></pre>'
+      expect(subject).to receive(:respond_to?).with('html_markup_html').and_return(true)
+      expect(subject).to receive(:respond_to?).with('html_syntax_highlight_NAME').and_return(true)
+      expect(subject).to receive(:html_syntax_highlight_NAME).and_return("foobar")
+      expect(subject.htmlify('<pre><code>def x; end</code></pre>', :html)).to eq (
+        '<pre class="code NAME"><code class="NAME">foobar</code></pre>')
     end
 
     it "should add !!!LANG to className in outputted pre tag" do
       subject.object = OpenStruct.new(:source_type => :LANG)
-      subject.should_receive(:respond_to?).with('html_markup_html').and_return(true)
-      subject.should_receive(:respond_to?).with('html_syntax_highlight_LANG').and_return(true)
-      subject.should_receive(:html_syntax_highlight_LANG).and_return("foobar")
-      subject.htmlify("<pre><code>!!!LANG\ndef x; end</code></pre>", :html).should ==
-        '<pre class="code LANG"><code class="LANG">foobar</code></pre>'
+      expect(subject).to receive(:respond_to?).with('html_markup_html').and_return(true)
+      expect(subject).to receive(:respond_to?).with('html_syntax_highlight_LANG').and_return(true)
+      expect(subject).to receive(:html_syntax_highlight_LANG).and_return("foobar")
+      expect(subject.htmlify("<pre><code>!!!LANG\ndef x; end</code></pre>", :html)).to eq (
+        '<pre class="code LANG"><code class="LANG">foobar</code></pre>')
     end
 
     it "should call html_syntax_highlight_NAME if source starts with !!!NAME" do
-      subject.should_receive(:respond_to?).with('html_syntax_highlight_NAME').and_return(true)
-      subject.should_receive(:html_syntax_highlight_NAME).and_return("foobar")
-      subject.html_syntax_highlight(<<-eof
+      expect(subject).to receive(:respond_to?).with('html_syntax_highlight_NAME').and_return(true)
+      expect(subject).to receive(:html_syntax_highlight_NAME).and_return("foobar")
+      expect(subject.html_syntax_highlight(<<-eof
         !!!NAME
         def x; end
       eof
-      ).should == "foobar"
+      )).to eq "foobar"
     end
 
     it "should not highlight if highlight option is false" do
       subject.options.highlight = false
-      subject.should_not_receive(:html_syntax_highlight_ruby)
-      subject.html_syntax_highlight('def x; end').should == 'def x; end'
+      expect(subject).to_not receive(:html_syntax_highlight_ruby)
+      expect(subject.html_syntax_highlight('def x; end')).to eq 'def x; end'
     end
 
     it "should not highlight if there is no highlight method specified by !!!NAME" do
-      subject.should_receive(:respond_to?).with('html_syntax_highlight_NAME').and_return(false)
-      subject.should_not_receive(:html_syntax_highlight_NAME)
-      subject.html_syntax_highlight("!!!NAME\ndef x; end").should == "def x; end"
+      expect(subject).to receive(:respond_to?).with('html_syntax_highlight_NAME').and_return(false)
+      expect(subject).to_not receive(:html_syntax_highlight_NAME)
+      expect(subject.html_syntax_highlight("!!!NAME\ndef x; end")).to eq "def x; end"
     end
 
     it "should highlight as ruby if htmlify(text, :ruby) is called" do
-      subject.should_receive(:html_syntax_highlight_ruby).with('def x; end').and_return('x')
-      subject.htmlify('def x; end', :ruby).should == '<pre class="code ruby">x</pre>'
+      expect(subject).to receive(:html_syntax_highlight_ruby).with('def x; end').and_return('x')
+      expect(subject.htmlify('def x; end', :ruby)).to eq '<pre class="code ruby">x</pre>'
     end
 
     it "should not prioritize object source type when called directly" do
-      subject.should_receive(:html_syntax_highlight_ruby).with('def x; end').and_return('x')
+      expect(subject).to receive(:html_syntax_highlight_ruby).with('def x; end').and_return('x')
       subject.object = OpenStruct.new(:source_type => :c)
-      subject.html_syntax_highlight("def x; end").should == "x"
+      expect(subject.html_syntax_highlight("def x; end")).to eq "x"
     end
 
     it "shouldn't escape code snippets twice" do
-      subject.htmlify('<pre lang="foo"><code>{"foo" => 1}</code></pre>', :html).should ==
-        '<pre class="code foo"><code class="foo">{&quot;foo&quot; =&gt; 1}</code></pre>'
+      expect(subject.htmlify('<pre lang="foo"><code>{"foo" => 1}</code></pre>', :html)).to eq (
+        '<pre class="code foo"><code class="foo">{&quot;foo&quot; =&gt; 1}</code></pre>')
     end
 
     it "should highlight source when matching a pre lang= tag" do
-      subject.htmlify('<pre lang="foo"><code>x = 1</code></pre>', :html).should ==
-        '<pre class="code foo"><code class="foo">x = 1</code></pre>'
+      expect(subject.htmlify('<pre lang="foo"><code>x = 1</code></pre>', :html)).to eq (
+        '<pre class="code foo"><code class="foo">x = 1</code></pre>')
     end
 
     it "should highlight source when matching a code class= tag" do
-      subject.htmlify('<pre><code class="foo">x = 1</code></pre>', :html).should ==
-        '<pre class="code foo"><code class="foo">x = 1</code></pre>'
+      expect(subject.htmlify('<pre><code class="foo">x = 1</code></pre>', :html)).to eq (
+        '<pre class="code foo"><code class="foo">x = 1</code></pre>')
     end
   end
 
   describe '#link_url' do
     it "should add target if scheme is provided" do
-      link_url("http://url.com").should include(" target=\"_parent\"")
-      link_url("https://url.com").should include(" target=\"_parent\"")
-      link_url("irc://url.com").should include(" target=\"_parent\"")
-      link_url("../not/scheme").should_not include("target")
+      expect(link_url("http://url.com")).to include(" target=\"_parent\"")
+      expect(link_url("https://url.com")).to include(" target=\"_parent\"")
+      expect(link_url("irc://url.com")).to include(" target=\"_parent\"")
+      expect(link_url("../not/scheme")).to_not include("target")
     end
   end
 end

--- a/spec/templates/helpers/html_syntax_highlight_helper_spec.rb
+++ b/spec/templates/helpers/html_syntax_highlight_helper_spec.rb
@@ -12,7 +12,7 @@ describe YARD::Templates::Helpers::HtmlSyntaxHighlightHelper do
 
     it "should not highlight source if options.highlight is false" do
       should_receive(:options).and_return(Options.new.update(:highlight => false))
-      html_syntax_highlight("def x\nend").should == "def x\nend"
+      expect(html_syntax_highlight("def x\nend")).to eq "def x\nend"
     end
 
     it "should highlight source (legacy)" do
@@ -42,12 +42,12 @@ describe YARD::Templates::Helpers::HtmlSyntaxHighlightHelper do
 
     it "should return escaped unhighlighted source if a syntax error is found (ripper)" do
       should_receive(:options).and_return(Options.new.update(:highlight => true))
-      html_syntax_highlight("def &x; ... end").should == "def &amp;x; ... end"
+      expect(html_syntax_highlight("def &x; ... end")).to eq "def &amp;x; ... end"
     end if HAVE_RIPPER
 
     it "should return escaped unhighlighted source if a syntax error is found (ripper)" do
       should_receive(:options).and_return(Options.new.update(:highlight => true))
-      html_syntax_highlight("$ git clone http://url").should == "$ git clone http://url"
+      expect(html_syntax_highlight("$ git clone http://url")).to eq "$ git clone http://url"
     end if HAVE_RIPPER
   end
 end

--- a/spec/templates/helpers/markup/rdoc_markup_spec.rb
+++ b/spec/templates/helpers/markup/rdoc_markup_spec.rb
@@ -27,21 +27,21 @@ describe YARD::Templates::Helpers::Markup::RDocMarkup do
 
     it "should load RDoc2.x if rdoc/markup is present" do
       @good_libs += ['rdoc/markup', 'rdoc/markup/to_html']
-      load_markup.should == :RDoc2
+      expect(load_markup).to eq :RDoc2
     end
 
     it "should fail on RDoc2.x if rdoc/markup/to_html is not present" do
       @good_libs += ['rdoc/markup']
-      lambda { load_markup }.should raise_error(NameError)
+      expect{ load_markup }.to raise_error(NameError)
     end
 
     it "should load RDoc1.x if RDoc2 fails and rdoc/markup/simple_markup is present" do
       @good_libs += ['rdoc/markup/simple_markup', 'rdoc/markup/simple_markup/to_html']
-      load_markup.should == :RDoc1
+      expect(load_markup).to eq :RDoc1
     end
 
     it "should error on loading if neither lib is present" do
-      lambda { load_markup }.should raise_error(NameError)
+      expect{ load_markup }.to raise_error(NameError)
     end
   end
 
@@ -52,7 +52,7 @@ describe YARD::Templates::Helpers::Markup::RDocMarkup do
     end
 
     it 'handles typewriter text' do
-      to_html('Hello +<code>+').should == '<p>Hello <tt>&lt;code&gt;</tt></p>'
+      expect(to_html('Hello +<code>+')).to eq '<p>Hello <tt>&lt;code&gt;</tt></p>'
     end
   end
 
@@ -62,32 +62,32 @@ describe YARD::Templates::Helpers::Markup::RDocMarkup do
     end
 
     it "should use #fix_typewriter to convert +text+ to <tt>text</tt>" do
-      fix_typewriter("Some +typewriter text &lt;+.").should ==
-        "Some <tt>typewriter text &lt;</tt>."
-      fix_typewriter("Not +typewriter text.").should ==
-        "Not +typewriter text."
-      fix_typewriter("Alternating +type writer+ text +here+.").should ==
-        "Alternating <tt>type writer</tt> text <tt>here</tt>."
-      fix_typewriter("No ++problem.").should ==
-        "No ++problem."
-      fix_typewriter("Math + stuff +is ok+").should ==
-        "Math + stuff <tt>is ok</tt>"
-      fix_typewriter("Hello +{Foo}+ World").should == "Hello <tt>{Foo}</tt> World"
+      expect(fix_typewriter("Some +typewriter text &lt;+.")).to eq(
+        "Some <tt>typewriter text &lt;</tt>.")
+      expect(fix_typewriter("Not +typewriter text.")).to eq(
+        "Not +typewriter text.")
+      expect(fix_typewriter("Alternating +type writer+ text +here+.")).to eq(
+        "Alternating <tt>type writer</tt> text <tt>here</tt>.")
+      expect(fix_typewriter("No ++problem.")).to eq(
+        "No ++problem.")
+      expect(fix_typewriter("Math + stuff +is ok+")).to eq(
+        "Math + stuff <tt>is ok</tt>")
+      expect(fix_typewriter("Hello +{Foo}+ World")).to eq "Hello <tt>{Foo}</tt> World"
     end
 
     it "should not apply to code blocks" do
-      fix_typewriter("<code>Hello +hello+</code>").should == "<code>Hello +hello+</code>"
+      expect(fix_typewriter("<code>Hello +hello+</code>")).to eq "<code>Hello +hello+</code>"
     end
 
     it "should not apply to HTML tag attributes" do
-      fix_typewriter("<a href='http://foo.com/A+b+c'>A+b+c</a>").should ==
-        "<a href='http://foo.com/A+b+c'>A+b+c</a>"
-      fix_typewriter("<foo class='foo+bar+baz'/>").should ==
-        "<foo class='foo+bar+baz'/>"
+      expect(fix_typewriter("<a href='http://foo.com/A+b+c'>A+b+c</a>")).to eq(
+        "<a href='http://foo.com/A+b+c'>A+b+c</a>")
+      expect(fix_typewriter("<foo class='foo+bar+baz'/>")).to eq(
+        "<foo class='foo+bar+baz'/>")
     end
 
     it "should still apply inside of other tags" do
-      fix_typewriter("<p>+foo+</p>").should == "<p><tt>foo</tt></p>"
+      expect(fix_typewriter("<p>+foo+</p>")).to eq "<p><tt>foo</tt></p>"
     end
   end
 end

--- a/spec/templates/helpers/markup_helper_spec.rb
+++ b/spec/templates/helpers/markup_helper_spec.rb
@@ -26,85 +26,85 @@ describe YARD::Templates::Helpers::MarkupHelper do
 
     it "should exit on an invalid markup type" do
       @gen.options.markup = :invalid
-      @gen.load_markup_provider.should == false
+      expect(@gen.load_markup_provider).to eq false
     end
 
     it "should fail on when an invalid markup provider is specified" do
       @gen.options.update(:markup => :markdown, :markup_provider => :invalid)
-      @gen.load_markup_provider.should == false
-      @gen.markup_class.should == nil
+      expect(@gen.load_markup_provider).to eq false
+      expect(@gen.markup_class).to eq nil
     end
 
     it "should load RDocMarkup if rdoc is specified and it is installed" do
       @gen.options.markup = :rdoc
-      @gen.load_markup_provider.should == true
-      @gen.markup_class.should == YARD::Templates::Helpers::Markup::RDocMarkup
+      expect(@gen.load_markup_provider).to eq true
+      expect(@gen.markup_class).to eq YARD::Templates::Helpers::Markup::RDocMarkup
     end
 
     it "should fail if RDoc cannot be loaded" do
       @gen.options.markup = :rdoc
-      @gen.should_receive(:eval).with('::YARD::Templates::Helpers::Markup::RDocMarkup').and_raise(NameError)
-      @gen.load_markup_provider.should == false
-      @gen.markup_provider.should == nil
+      expect(@gen).to receive(:eval).with('::YARD::Templates::Helpers::Markup::RDocMarkup').and_raise(NameError)
+      expect(@gen.load_markup_provider).to eq false
+      expect(@gen.markup_provider).to eq nil
     end
 
     it "should search through available markup providers for the markup type if none is set" do
-      @gen.should_receive(:eval).with('::RedcarpetCompat').and_return(mock(:bluecloth))
-      @gen.should_receive(:require).with('redcarpet').and_return(true)
-      @gen.should_not_receive(:require).with('maruku')
+      expect(@gen).to receive(:eval).with('::RedcarpetCompat').and_return(mock(:bluecloth))
+      expect(@gen).to receive(:require).with('redcarpet').and_return(true)
+      expect(@gen).to_not receive(:require).with('maruku')
       @gen.options.markup = :markdown
       # this only raises an exception because we mock out require to avoid
       # loading any libraries but our implementation tries to return the library
       # name as a constant
-      @gen.load_markup_provider.should == true
-      @gen.markup_provider.should == :redcarpet
+      expect(@gen.load_markup_provider).to eq true
+      expect(@gen.markup_provider).to eq :redcarpet
     end
 
     it "should continue searching if some of the providers are unavailable" do
-      @gen.should_receive(:require).with('redcarpet').and_raise(LoadError)
-      @gen.should_receive(:require).with('rdiscount').and_raise(LoadError)
-      @gen.should_receive(:require).with('kramdown').and_raise(LoadError)
-      @gen.should_receive(:require).with('bluecloth').and_raise(LoadError)
-      @gen.should_receive(:require).with('maruku').and_raise(LoadError)
-      @gen.should_receive(:require).with('rpeg-markdown').and_return(true)
-      @gen.should_receive(:eval).with('::PEGMarkdown').and_return(true)
+      expect(@gen).to receive(:require).with('redcarpet').and_raise(LoadError)
+      expect(@gen).to receive(:require).with('rdiscount').and_raise(LoadError)
+      expect(@gen).to receive(:require).with('kramdown').and_raise(LoadError)
+      expect(@gen).to receive(:require).with('bluecloth').and_raise(LoadError)
+      expect(@gen).to receive(:require).with('maruku').and_raise(LoadError)
+      expect(@gen).to receive(:require).with('rpeg-markdown').and_return(true)
+      expect(@gen).to receive(:eval).with('::PEGMarkdown').and_return(true)
       @gen.options.markup = :markdown
       # this only raises an exception because we mock out require to avoid
       # loading any libraries but our implementation tries to return the library
       # name as a constant
-      @gen.load_markup_provider.should rescue nil
-      @gen.markup_provider.should == :"rpeg-markdown"
+      expect(@gen.load_markup_provider).to rescue nil
+      expect(@gen.markup_provider).to eq :"rpeg-markdown"
     end
 
     it "should override the search if `:markup_provider` is set in options" do
-      @gen.should_receive(:require).with('rdiscount').and_return(true)
-      @gen.should_receive(:eval).with('::RDiscount').and_return(true)
+      expect(@gen).to receive(:require).with('rdiscount').and_return(true)
+      expect(@gen).to receive(:eval).with('::RDiscount').and_return(true)
       @gen.options.update(:markup => :markdown, :markup_provider => :rdiscount)
-      @gen.load_markup_provider.should rescue nil
-      @gen.markup_provider.should == :rdiscount
+      expect(@gen.load_markup_provider).to rescue nil
+      expect(@gen.markup_provider).to eq :rdiscount
     end
 
     it "should fail if no provider is found" do
       YARD::Templates::Helpers::MarkupHelper::MARKUP_PROVIDERS[:markdown].each do |p|
-        @gen.should_receive(:require).with(p[:lib].to_s).and_raise(LoadError)
+        expect(@gen).to receive(:require).with(p[:lib].to_s).and_raise(LoadError)
       end
       @gen.options.markup = :markdown
-      @gen.load_markup_provider.should == false
-      @gen.markup_provider.should == nil
+      expect(@gen.load_markup_provider).to eq false
+      expect(@gen.markup_provider).to eq nil
     end
 
     it "should fail if overridden provider is not found" do
-      @gen.should_receive(:require).with('rdiscount').and_raise(LoadError)
+      expect(@gen).to receive(:require).with('rdiscount').and_raise(LoadError)
       @gen.options.update(:markup => :markdown, :markup_provider => :rdiscount)
-      @gen.load_markup_provider.should == false
-      @gen.markup_provider.should == nil
+      expect(@gen.load_markup_provider).to eq false
+      expect(@gen.markup_provider).to eq nil
     end
 
     it "should fail if the markup type is not found" do
-      log.should_receive(:error).with(/Invalid markup/)
+      expect(log).to receive(:error).with(/Invalid markup/)
       @gen.options.markup = :xxx
-      @gen.load_markup_provider.should == false
-      @gen.markup_provider.should == nil
+      expect(@gen.load_markup_provider).to eq false
+      expect(@gen.markup_provider).to eq nil
     end
   end
 
@@ -112,22 +112,22 @@ describe YARD::Templates::Helpers::MarkupHelper do
     include YARD::Templates::Helpers::MarkupHelper
 
     it "should look for a shebang line" do
-      markup_for_file("#!text\ntext here", 'file.rdoc').should == :text
+      expect(markup_for_file("#!text\ntext here", 'file.rdoc')).to eq :text
     end
 
     it "should return the default markup type if no shebang is found or no valid ext is found" do
       stub!(:options).and_return(Options.new.update(:markup => :default_type))
-      markup_for_file('', 'filename').should == :default_type
+      expect(markup_for_file('', 'filename')).to eq :default_type
     end
 
     it "should look for a file extension if no shebang is found" do
-      markup_for_file('', 'filename.MD').should == :markdown
+      expect(markup_for_file('', 'filename.MD')).to eq :markdown
     end
 
     Templates::Helpers::MarkupHelper::MARKUP_EXTENSIONS.each do |type, exts|
       exts.each do |ext|
         it "should recognize .#{ext} as #{type} markup type" do
-          markup_for_file('', "filename.#{ext}").should == type
+          expect(markup_for_file('', "filename.#{ext}")).to eq type
         end
       end
     end

--- a/spec/templates/helpers/method_helper_spec.rb
+++ b/spec/templates/helpers/method_helper_spec.rb
@@ -9,7 +9,7 @@ describe YARD::Templates::Helpers::MethodHelper do
       params = [['a:', '1'], ['b:', '2'], ['**kwargs', nil]]
       YARD.parse_string 'def foo; end'
       Registry.at('#foo').stub(:parameters) { params }
-      format_args(Registry.at('#foo')).should == '(a: 1, b: 2, **kwargs)'
+      expect(format_args(Registry.at('#foo'))).to eq '(a: 1, b: 2, **kwargs)'
     end
 
     it "should not show &blockarg if no @param tag and has @yield" do
@@ -17,7 +17,7 @@ describe YARD::Templates::Helpers::MethodHelper do
         # @yield blah
         def foo(&block); end
       eof
-      format_args(Registry.at('#foo')).should == ''
+      expect(format_args(Registry.at('#foo'))).to eq ''
     end
 
     it "should not show &blockarg if no @param tag and has @yieldparam" do
@@ -25,7 +25,7 @@ describe YARD::Templates::Helpers::MethodHelper do
         # @yieldparam blah test
         def foo(&block); end
       eof
-      format_args(Registry.at('#foo')).should == ''
+      expect(format_args(Registry.at('#foo'))).to eq ''
     end
 
     it "should show &blockarg if @param block is documented (even with @yield)" do
@@ -35,7 +35,7 @@ describe YARD::Templates::Helpers::MethodHelper do
         # @param block test
         def foo(&block) end
       eof
-      format_args(Registry.at('#foo')).should == '(&block)'
+      expect(format_args(Registry.at('#foo'))).to eq '(&block)'
     end
   end
 
@@ -46,7 +46,7 @@ describe YARD::Templates::Helpers::MethodHelper do
       YARD.parse_string <<-'eof'
         def foo; yield(a, b, c) end
       eof
-      format_block(Registry.at('#foo')).should == "{|a, b, c| ... }"
+      expect(format_block(Registry.at('#foo'))).to eq "{|a, b, c| ... }"
     end
 
     it "should show block for method with @yieldparam tags" do
@@ -54,7 +54,7 @@ describe YARD::Templates::Helpers::MethodHelper do
         # @yieldparam _self me!
         def foo; end
       eof
-      format_block(Registry.at('#foo')).should == "{|_self| ... }"
+      expect(format_block(Registry.at('#foo'))).to eq "{|_self| ... }"
     end
 
     it "should show block for method with @yield but no types" do
@@ -66,8 +66,8 @@ describe YARD::Templates::Helpers::MethodHelper do
         # @yield blah
         def foo2; end
       eof
-      format_block(Registry.at('#foo')).should == "{|a| ... }"
-      format_block(Registry.at('#foo2')).should == "{ ... }"
+      expect(format_block(Registry.at('#foo'))).to eq "{|a| ... }"
+      expect(format_block(Registry.at('#foo2'))).to eq "{ ... }"
     end
 
     it "should show block for method with @yield and types" do
@@ -76,7 +76,7 @@ describe YARD::Templates::Helpers::MethodHelper do
         # @yieldparam a
         def foo; end
       eof
-      format_block(Registry.at('#foo')).should == "{|a, b, c| ... }"
+      expect(format_block(Registry.at('#foo'))).to eq "{|a, b, c| ... }"
     end
   end
 end

--- a/spec/templates/helpers/shared_signature_examples.rb
+++ b/spec/templates/helpers/shared_signature_examples.rb
@@ -8,24 +8,24 @@ shared_examples_for "signature" do
 
   it "should show signature for regular instance method" do
     YARD.parse_string "def foo; end"
-    signature(Registry.at('#foo')).should == @results[:regular]
+    expect(signature(Registry.at('#foo'))).to eq @results[:regular]
   end
 
   it "should allow default return type to be changed" do
     @options.default_return = "Hello"
     YARD.parse_string "def foo; end"
-    signature(Registry.at('#foo')).should == @results[:default_return]
+    expect(signature(Registry.at('#foo'))).to eq @results[:default_return]
   end
 
   it "should allow default return type to be omitted" do
     @options.default_return = ""
     YARD.parse_string "def foo; end"
-    signature(Registry.at('#foo')).should == @results[:no_default_return]
+    expect(signature(Registry.at('#foo'))).to eq @results[:no_default_return]
   end
 
   it "should show signature for private class method" do
     YARD.parse_string "class A; private; def self.foo; end end"
-    signature(Registry.at('A.foo')).should == @results[:private_class]
+    expect(signature(Registry.at('A.foo'))).to eq @results[:private_class]
   end
 
   it "should show return type for single type" do
@@ -33,7 +33,7 @@ shared_examples_for "signature" do
       # @return [String]
       def foo; end
     eof
-    signature(Registry.at('#foo')).should == @results[:single]
+    expect(signature(Registry.at('#foo'))).to eq @results[:single]
   end
 
   it "should show return type for 2 types" do
@@ -41,7 +41,7 @@ shared_examples_for "signature" do
       # @return [String, Symbol]
       def foo; end
     eof
-    signature(Registry.at('#foo')).should == @results[:two_types]
+    expect(signature(Registry.at('#foo'))).to eq @results[:two_types]
   end
 
   it "should show return type for 2 types over multiple tags" do
@@ -50,7 +50,7 @@ shared_examples_for "signature" do
       # @return [Symbol]
       def foo; end
     eof
-    signature(Registry.at('#foo')).should == @results[:two_types_multitag]
+    expect(signature(Registry.at('#foo'))).to eq @results[:two_types_multitag]
   end
 
   it "should show 'Type?' if return types are [Type, nil]" do
@@ -58,7 +58,7 @@ shared_examples_for "signature" do
       # @return [Type, nil]
       def foo; end
     eof
-    signature(Registry.at('#foo')).should == @results[:type_nil]
+    expect(signature(Registry.at('#foo'))).to eq @results[:type_nil]
   end
 
   it "should show 'Type?' if return types are [Type, nil, nil] (extra nil)" do
@@ -67,7 +67,7 @@ shared_examples_for "signature" do
       # @return [nil]
       def foo; end
     eof
-    signature(Registry.at('#foo')).should == @results[:type_nil]
+    expect(signature(Registry.at('#foo'))).to eq @results[:type_nil]
   end
 
   it "should show 'Type+' if return types are [Type, Array<Type>]" do
@@ -75,7 +75,7 @@ shared_examples_for "signature" do
       # @return [Type, <Type>]
       def foo; end
     eof
-    signature(Registry.at('#foo')).should == @results[:type_array]
+    expect(signature(Registry.at('#foo'))).to eq @results[:type_array]
   end
 
   it "should (Type, ...) for more than 2 return types" do
@@ -84,7 +84,7 @@ shared_examples_for "signature" do
       # @return [AnotherType]
       def foo; end
     eof
-    signature(Registry.at('#foo')).should == @results[:multitype]
+    expect(signature(Registry.at('#foo'))).to eq @results[:multitype]
   end
 
   it "should show (void) for @return [void] by default" do
@@ -92,7 +92,7 @@ shared_examples_for "signature" do
       # @return [void]
       def foo; end
     eof
-    signature(Registry.at('#foo')).should == @results[:void]
+    expect(signature(Registry.at('#foo'))).to eq @results[:void]
   end
 
   it "should not show return for @return [void] if :hide_void_return is true" do
@@ -101,14 +101,14 @@ shared_examples_for "signature" do
       # @return [void]
       def foo; end
     eof
-    signature(Registry.at('#foo')).should == @results[:hide_void]
+    expect(signature(Registry.at('#foo'))).to eq @results[:hide_void]
   end
 
   it "should show block for method with yield" do
     YARD.parse_string <<-'eof'
       def foo; yield(a, b, c) end
     eof
-    signature(Registry.at('#foo')).should == @results[:block]
+    expect(signature(Registry.at('#foo'))).to eq @results[:block]
   end
 
   it "should use regular return tag if the @overload is empty" do
@@ -118,6 +118,6 @@ shared_examples_for "signature" do
       # @return [String]
       def foo; end
     eof
-    signature(Registry.at('#foo').tag(:overload)).should == @results[:empty_overload]
+    expect(signature(Registry.at('#foo').tag(:overload))).to eq @results[:empty_overload]
   end
 end

--- a/spec/templates/helpers/text_helper_spec.rb
+++ b/spec/templates/helpers/text_helper_spec.rb
@@ -33,12 +33,12 @@ describe YARD::Templates::Helpers::TextHelper do
   describe '#align_right' do
     it "should align text right" do
       text = "Method: #some_method (SomeClass)"
-      align_right(text).should == ' ' * 40 + text
+      expect(align_right(text)).to eq ' ' * 40 + text
     end
 
     it "should truncate text that is longer than allowed width" do
       text = "(Defined in: /home/user/.rip/.packages/some_gem-2460672e333ac07b9190ade88ec9a91c/long/path.rb)"
-      align_right(text).should == ' ' + text[0,68] + '...'
+      expect(align_right(text)).to eq ' ' + text[0,68] + '...'
     end
   end
 end

--- a/spec/templates/module_spec.rb
+++ b/spec/templates/module_spec.rb
@@ -82,7 +82,7 @@ describe YARD::Templates::Engine.template(:default, :module) do
   end
 
   it "should render dot format correctly" do
-    Registry.at('A').format(:format => :dot, :dependencies => true, :full => true).should == example_contents(:module001, 'dot')
+    expect(Registry.at('A').format(:format => :dot, :dependencies => true, :full => true)).to eq example_contents(:module001, 'dot')
   end
 
   it "should render groups correctly in html" do

--- a/spec/templates/onefile_spec.rb
+++ b/spec/templates/onefile_spec.rb
@@ -54,11 +54,11 @@ describe YARD::Templates::Engine.template(:default, :onefile) do
 
   it "should render html" do
     render
-    @files.should == ['index.html']
-    @output.should include("This is a code comment")
-    @output.should include("This is a license!")
-    @output.should include("Class: A")
-    @output.should include("Foo method")
-    @output.should include("Bar method")
+    expect(@files).to eq ['index.html']
+    expect(@output).to include("This is a code comment")
+    expect(@output).to include("This is a license!")
+    expect(@output).to include("Class: A")
+    expect(@output).to include("Foo method")
+    expect(@output).to include("Bar method")
   end
 end

--- a/spec/templates/section_spec.rb
+++ b/spec/templates/section_spec.rb
@@ -6,105 +6,105 @@ describe YARD::Templates::Section do
   describe '#initialize' do
     it "should convert first argument to splat if it is array" do
       s = Section.new(:name, [:foo, :bar])
-      s.name.should == :name
-      s[0].name.should == :foo
-      s[1].name.should == :bar
+      expect(s.name).to eq :name
+      expect(s[0].name).to eq :foo
+      expect(s[1].name).to eq :bar
     end
 
     it "should allow initialization with Section objects" do
       s = Section.new(:name, [:foo, Section.new(:bar)])
-      s.name.should == :name
-      s[0].should == Section.new(:foo)
-      s[1].should == Section.new(:bar)
+      expect(s.name).to eq :name
+      expect(s[0]).to eq Section.new(:foo)
+      expect(s[1]).to eq Section.new(:bar)
     end
 
     it "should make a list of sections" do
       s = Section.new(:name, [:foo, [:bar]])
-      s.should == Section.new(:name, Section.new(:foo, Section.new(:bar)))
+      expect(s).to eq Section.new(:name, Section.new(:foo, Section.new(:bar)))
     end
   end
 
   describe '#[]' do
     it "should use Array#[] if argument is integer" do
-      Section.new(:name, [:foo, :bar])[0].name.should == :foo
+      expect(Section.new(:name, [:foo, :bar])[0].name).to eq :foo
     end
 
     it "should return new Section object if more than one argument" do
-      Section.new(:name, :foo, :bar, :baz)[1, 2].should ==
-        Section.new(:name, :bar, :baz)
+      expect(Section.new(:name, :foo, :bar, :baz)[1, 2])
+        .to eq Section.new(:name, :bar, :baz)
     end
 
     it "should return new Section object if arg is Range" do
-      Section.new(:name, :foo, :bar, :baz)[1..2].should ==
-        Section.new(:name, :bar, :baz)
+      expect(Section.new(:name, :foo, :bar, :baz)[1..2])
+        .to eq Section.new(:name, :bar, :baz)
     end
 
     it "should look for section by name if arg is object" do
-      Section.new(:name, :foo, :bar, [:baz])[:bar][:baz].should ==
-        Section.new(:baz)
+      expect(Section.new(:name, :foo, :bar, [:baz])[:bar][:baz])
+        .to eq Section.new(:baz)
     end
   end
 
   describe '#eql?' do
     it "should check for equality of two equal sections" do
-      Section.new(:foo, [:a, :b]).should be_eql(Section.new(:foo, :a, :b))
-      Section.new(:foo, [:a, :b]).should == Section.new(:foo, :a, :b)
+      expect(Section.new(:foo, [:a, :b])).to be_eql(Section.new(:foo, :a, :b))
+      expect(Section.new(:foo, [:a, :b])).to eq Section.new(:foo, :a, :b)
     end
 
     it "should not be equal if section names are different" do
-      Section.new(:foo, [:a, :b]).should_not be_eql(Section.new(:bar, :a, :b))
-      Section.new(:foo, [:a, :b]).should_not == Section.new(:bar, :a, :b)
+      expect(Section.new(:foo, [:a, :b])).to_not be_eql(Section.new(:bar, :a, :b))
+      expect(Section.new(:foo, [:a, :b])).to_not eq Section.new(:bar, :a, :b)
     end
   end
 
   describe '#==' do
     it "should allow comparison to Symbol" do
-      Section.new(:foo, 2, 3).should == :foo
+      expect(Section.new(:foo, 2, 3)).to eq :foo
     end
 
     it "should allow comparison to String" do
-      Section.new("foo", 2, 3).should == "foo"
+      expect(Section.new("foo", 2, 3)).to eq "foo"
     end
 
     it "should allow comparison to Template" do
       t = YARD::Templates::Engine.template!(:xyzzy, '/full/path/xyzzy')
-      Section.new(t, 2, 3).should == t
+      expect(Section.new(t, 2, 3)).to eq t
     end
 
     it "should allow comparison to Section" do
-      Section.new(1, [2, 3]).should == Section.new(1, 2, 3)
+      expect(Section.new(1, [2, 3])).to eq Section.new(1, 2, 3)
     end
 
     it "should allow comparison to Object" do
-      Section.new(1, [2, 3]).should == 1
+      expect(Section.new(1, [2, 3])).to eq 1
     end
 
     it "should allow comparison to Array" do
-      Section.new(1, 2, [3]).should == [1, [2, [3]]]
+      expect(Section.new(1, 2, [3])).to eq [1, [2, [3]]]
     end
   end
 
   describe '#to_a' do
     it "should convert Section to regular Array list" do
       arr = Section.new(1, 2, [3, [4]]).to_a
-      arr.class.should == Array
-      arr.should == [1, [2, [3, [4]]]]
+      expect(arr.class).to eq Array
+      expect(arr).to eq [1, [2, [3, [4]]]]
     end
   end
 
   describe '#place' do
     it "should place objects as Sections" do
-      Section.new(1, 2, 3).place(4).before(3).should == [1, [2, 4, 3]]
+      expect(Section.new(1, 2, 3).place(4).before(3)).to eq [1, [2, 4, 3]]
     end
 
     it "should place objects anywhere inside Section with before/after_any" do
-      Section.new(1, 2, [3, [4]]).place(5).after_any(4).should == [1, [2, [3, [4, 5]]]]
-      Section.new(1, 2, [3, [4]]).place(5).before_any(4).should == [1, [2, [3, [5, 4]]]]
+      expect(Section.new(1, 2, [3, [4]]).place(5).after_any(4)).to eq [1, [2, [3, [4, 5]]]]
+      expect(Section.new(1, 2, [3, [4]]).place(5).before_any(4)).to eq [1, [2, [3, [5, 4]]]]
     end
 
     it "should allow multiple sections to be placed" do
-      Section.new(1, 2, 3).place(4, 5).after(3).to_a.should == [1, [2, 3, 4, 5]]
-      Section.new(1, 2, 3).place(4, [5]).after(3).to_a.should == [1, [2, 3, 4, [5]]]
+      expect(Section.new(1, 2, 3).place(4, 5).after(3).to_a).to eq [1, [2, 3, 4, 5]]
+      expect(Section.new(1, 2, 3).place(4, [5]).after(3).to_a).to eq [1, [2, 3, 4, [5]]]
     end
   end
 
@@ -112,13 +112,13 @@ describe YARD::Templates::Section do
     it "should push objects as Sections" do
       s = Section.new(:foo)
       s.push :bar
-      s[0].should == Section.new(:bar)
+      expect(s[0]).to eq Section.new(:bar)
     end
 
     it "should alias to #<<" do
       s = Section.new(1)
       s << :index
-      s[:index].should be_a(Section)
+      expect(s[:index]).to be_a(Section)
     end
   end
 
@@ -126,7 +126,7 @@ describe YARD::Templates::Section do
     it "should unshift objects as Sections" do
       s = Section.new(:foo)
       s.unshift :bar
-      s[0].should == Section.new(:bar)
+      expect(s[0]).to eq Section.new(:bar)
     end
   end
 
@@ -134,13 +134,13 @@ describe YARD::Templates::Section do
     it "should find item inside sections" do
       s = Section.new(:foo, Section.new(:bar, Section.new(:bar)))
       s.any(:bar).push(:baz)
-      s.to_a.should == [:foo, [:bar, [:bar, :baz]]]
+      expect(s.to_a).to eq [:foo, [:bar, [:bar, :baz]]]
     end
 
     it "should find item in any deeply nested set of sections" do
       s = Section.new(:foo, Section.new(:bar, Section.new(:baz)))
       s.any(:baz).push(:qux)
-      s.to_a.should == [:foo, [:bar, [:baz, [:qux]]]]
+      expect(s.to_a).to eq [:foo, [:bar, [:baz, [:qux]]]]
     end
   end
 end

--- a/spec/templates/spec_helper.rb
+++ b/spec/templates/spec_helper.rb
@@ -15,7 +15,7 @@ def text_equals(result, expected_example)
 end
 
 def text_equals_string(result, expected)
-  result.should == expected
+  expect(result).to eq expected
 end
 
 def html_equals(result, expected_example)

--- a/spec/templates/tag_spec.rb
+++ b/spec/templates/tag_spec.rb
@@ -45,7 +45,7 @@ describe YARD::Templates::Engine.template(:default, :tags) do
       eof
 
       proc = lambda { Registry.at('Foo').format(html_options) }
-      proc.should_not raise_error(NoMethodError)
+      expect(proc).to_not raise_error(NoMethodError)
     end
   end
 end

--- a/spec/templates/template_spec.rb
+++ b/spec/templates/template_spec.rb
@@ -12,93 +12,93 @@ describe YARD::Templates::Template do
   describe '.include_parent' do
     it "should not include parent directory if parent directory is a template root path" do
       mod = template('q')
-      mod.should_not include(template(''))
+      expect(mod).to_not include(template(''))
     end
 
     it "should include overridden parent directory" do
       Engine.stub!(:template_paths).and_return(['/foo', '/bar'])
-      File.should_receive(:directory?).with('/foo/a/b').and_return(true)
-      File.should_receive(:directory?).with('/bar/a/b').and_return(false)
-      File.should_receive(:directory?).with('/foo/a').at_least(1).times.and_return(true)
-      File.should_receive(:directory?).with('/bar/a').at_least(1).times.and_return(true)
+      expect(File).to receive(:directory?).with('/foo/a/b').and_return(true)
+      expect(File).to receive(:directory?).with('/bar/a/b').and_return(false)
+      expect(File).to receive(:directory?).with('/foo/a').at_least(1).times.and_return(true)
+      expect(File).to receive(:directory?).with('/bar/a').at_least(1).times.and_return(true)
       ancestors = Engine.template('a/b').ancestors.map {|c| c.class_name }
-      ancestors[0, 3].should == %w( Template__foo_a_b Template__bar_a Template__foo_a )
+      expect(ancestors[0, 3]).to eq %w( Template__foo_a_b Template__bar_a Template__foo_a )
     end
 
     it "should include parent directory template if exists" do
       mod1 = template('x')
       mod2 = template('x/y')
-      mod2.should include(mod1)
+      expect(mod2).to include(mod1)
     end
   end
 
   describe '.full_paths' do
     it "should list full_path" do
       mod = template(:a)
-      mod.full_paths.should == ['/full/path/a']
+      expect(mod.full_paths).to eq ['/full/path/a']
     end
 
     it "should list paths of included modules" do
       mod = template(:a)
       mod.send(:include, template(:b))
-      mod.full_paths.should == ['/full/path/a', '/full/path/b']
+      expect(mod.full_paths).to eq ['/full/path/a', '/full/path/b']
     end
 
     it "should list paths from modules of included modules" do
       mod = template(:c)
       mod.send(:include, template(:d))
       mod.send(:include, template(:a))
-      mod.full_paths.should == ['c', 'a', 'b', 'd'].map {|o| '/full/path/' + o }
+      expect(mod.full_paths).to eq ['c', 'a', 'b', 'd'].map {|o| '/full/path/' + o }
     end
 
     it "should only list full paths of modules that respond to full_paths" do
       mod = template(:d)
       mod.send(:include, Enumerable)
-      mod.full_paths.should == ['/full/path/d']
+      expect(mod.full_paths).to eq ['/full/path/d']
     end
   end
 
   describe '.load_setup_rb' do
     it "should load setup.rb file for module" do
-      File.should_receive(:file?).with('/full/path/e/setup.rb').and_return(true)
-      File.should_receive(:read).with('/full/path/e/setup.rb').and_return('def success; end')
-      template(:e).new.should respond_to(:success)
+      expect(File).to receive(:file?).with('/full/path/e/setup.rb').and_return(true)
+      expect(File).to receive(:read).with('/full/path/e/setup.rb').and_return('def success; end')
+      expect(template(:e).new).to respond_to(:success)
     end
   end
 
   describe '.T' do
     it "should load template from absolute path" do
       mod = template(:a)
-      Engine.should_receive(:template).with('other')
+      expect(Engine).to receive(:template).with('other')
       mod.T('other')
     end
   end
 
   describe '.find_file' do
     it "should find file in module's full_path" do
-      File.should_receive(:file?).with('/full/path/a/basename').and_return(false)
-      File.should_receive(:file?).with('/full/path/b/basename').and_return(true)
-      template(:a).find_file('basename').should == '/full/path/b/basename'
+      expect(File).to receive(:file?).with('/full/path/a/basename').and_return(false)
+      expect(File).to receive(:file?).with('/full/path/b/basename').and_return(true)
+      expect(template(:a).find_file('basename')).to eq '/full/path/b/basename'
     end
 
     it "should return nil if no file is found" do
-      File.should_receive(:file?).with('/full/path/a/basename').and_return(false)
-      File.should_receive(:file?).with('/full/path/b/basename').and_return(false)
-      template(:a).find_file('basename').should be_nil
+      expect(File).to receive(:file?).with('/full/path/a/basename').and_return(false)
+      expect(File).to receive(:file?).with('/full/path/b/basename').and_return(false)
+      expect(template(:a).find_file('basename')).to be_nil
     end
   end
 
   describe '.find_nth_file' do
     it "should find 2nd existing file in template paths" do
-      File.should_receive(:file?).with('/full/path/a/basename').and_return(true)
-      File.should_receive(:file?).with('/full/path/b/basename').and_return(true)
-      template(:a).find_nth_file('basename', 2).should == '/full/path/b/basename'
+      expect(File).to receive(:file?).with('/full/path/a/basename').and_return(true)
+      expect(File).to receive(:file?).with('/full/path/b/basename').and_return(true)
+      expect(template(:a).find_nth_file('basename', 2)).to eq '/full/path/b/basename'
     end
 
     it "should return nil if no file is found" do
-      File.should_receive(:file?).with('/full/path/a/basename').and_return(true)
-      File.should_receive(:file?).with('/full/path/b/basename').and_return(true)
-      template(:a).find_nth_file('basename', 3).should be_nil
+      expect(File).to receive(:file?).with('/full/path/a/basename').and_return(true)
+      expect(File).to receive(:file?).with('/full/path/b/basename').and_return(true)
+      expect(template(:a).find_nth_file('basename', 3)).to be_nil
     end
   end
 
@@ -106,27 +106,27 @@ describe YARD::Templates::Template do
     it "should be included when a module is initialized" do
       module MyModule; end
       Template.extra_includes << MyModule
-      template(:e).new.should be_kind_of(MyModule)
+      expect(template(:e).new).to be_kind_of(MyModule)
     end
 
     it "should support lambdas in list" do
       module MyModule2; end
       Template.extra_includes << lambda {|opts| MyModule2 if opts.format == :html }
-      template(:f).new(:format => :html).should be_kind_of(MyModule2)
+      expect(template(:f).new(:format => :html)).to be_kind_of(MyModule2)
       metaclass = (class << template(:g).new(:format => :text); self end)
-      metaclass.ancestors.should_not include(MyModule2)
+      expect(metaclass.ancestors).to_not include(MyModule2)
     end
   end
 
   describe '.is_a?' do
     it "should be kind of Template" do
-      template(:e).is_a?(Template).should == true
+      expect(template(:e).is_a?(Template)).to eq true
     end
   end
 
   describe '#T' do
     it "should delegate to class method" do
-      template(:e).should_receive(:T).with('test')
+      expect(template(:e)).to receive(:T).with('test')
       template(:e).new.T('test')
     end
   end
@@ -136,55 +136,55 @@ describe YARD::Templates::Template do
       module YARD::Templates::Engine::Template__full_path_e
         def init; sections 1, 2, 3 end
       end
-      template(:e).new.sections.should == Section.new(nil, 1, 2, 3)
+      expect(template(:e).new.sections).to eq Section.new(nil, 1, 2, 3)
     end
   end
 
   describe '#file' do
     it "should read the file if it exists" do
-      File.should_receive(:file?).with('/full/path/e/abc').and_return(true)
-      IO.should_receive(:read).with('/full/path/e/abc').and_return('hello world')
-      template(:e).new.file('abc').should == 'hello world'
+      expect(File).to receive(:file?).with('/full/path/e/abc').and_return(true)
+      expect(IO).to receive(:read).with('/full/path/e/abc').and_return('hello world')
+      expect(template(:e).new.file('abc')).to eq 'hello world'
     end
 
     it "should raise ArgumentError if the file does not exist" do
-      File.should_receive(:file?).with('/full/path/e/abc').and_return(false)
-      lambda { template(:e).new.file('abc') }.should raise_error(ArgumentError)
+      expect(File).to receive(:file?).with('/full/path/e/abc').and_return(false)
+      expect{ template(:e).new.file('abc') }.to raise_error(ArgumentError)
     end
 
     it "should replace {{{__super__}}} with inherited template contents if allow_inherited=true" do
-      File.should_receive(:file?).with('/full/path/a/abc').twice.and_return(true)
-      File.should_receive(:file?).with('/full/path/b/abc').and_return(true)
-      IO.should_receive(:read).with('/full/path/a/abc').and_return('foo {{{__super__}}}')
-      IO.should_receive(:read).with('/full/path/b/abc').and_return('bar')
-      template(:a).new.file('abc', true).should == "foo bar"
+      expect(File).to receive(:file?).with('/full/path/a/abc').twice.and_return(true)
+      expect(File).to receive(:file?).with('/full/path/b/abc').and_return(true)
+      expect(IO).to receive(:read).with('/full/path/a/abc').and_return('foo {{{__super__}}}')
+      expect(IO).to receive(:read).with('/full/path/b/abc').and_return('bar')
+      expect(template(:a).new.file('abc', true)).to eq "foo bar"
     end
 
     it "should not replace {{{__super__}}} with inherited template contents if allow_inherited=false" do
-      File.should_receive(:file?).with('/full/path/a/abc').and_return(true)
-      IO.should_receive(:read).with('/full/path/a/abc').and_return('foo {{{__super__}}}')
-      template(:a).new.file('abc').should == "foo {{{__super__}}}"
+      expect(File).to receive(:file?).with('/full/path/a/abc').and_return(true)
+      expect(IO).to receive(:read).with('/full/path/a/abc').and_return('foo {{{__super__}}}')
+      expect(template(:a).new.file('abc')).to eq "foo {{{__super__}}}"
     end
   end
 
   describe '#superb' do
     it "should return the inherited erb template contents" do
-      File.should_receive(:file?).with('/full/path/a/test.erb').and_return(true)
-      File.should_receive(:file?).with('/full/path/b/test.erb').and_return(true)
-      IO.should_receive(:read).with('/full/path/b/test.erb').and_return('bar')
+      expect(File).to receive(:file?).with('/full/path/a/test.erb').and_return(true)
+      expect(File).to receive(:file?).with('/full/path/b/test.erb').and_return(true)
+      expect(IO).to receive(:read).with('/full/path/b/test.erb').and_return('bar')
       template = template(:a).new
       template.section = :test
-      template.superb.should == "bar"
+      expect(template.superb).to eq "bar"
     end
 
     it "should work inside an erb template" do
-      File.should_receive(:file?).with('/full/path/a/test.erb').twice.and_return(true)
-      File.should_receive(:file?).with('/full/path/b/test.erb').and_return(true)
-      IO.should_receive(:read).with('/full/path/a/test.erb').and_return('foo<%= superb %>!')
-      IO.should_receive(:read).with('/full/path/b/test.erb').and_return('bar')
+      expect(File).to receive(:file?).with('/full/path/a/test.erb').twice.and_return(true)
+      expect(File).to receive(:file?).with('/full/path/b/test.erb').and_return(true)
+      expect(IO).to receive(:read).with('/full/path/a/test.erb').and_return('foo<%= superb %>!')
+      expect(IO).to receive(:read).with('/full/path/b/test.erb').and_return('bar')
       template = template(:a).new
       template.section = :test
-      template.erb(:test).should == "foobar!"
+      expect(template.erb(:test)).to eq "foobar!"
     end
   end
 
@@ -192,40 +192,40 @@ describe YARD::Templates::Template do
     it "should allow sections to be set if arguments are provided" do
       mod = template(:e).new
       mod.sections 1, 2, [3]
-      mod.sections.should == Section.new(nil, 1, 2, [3])
+      expect(mod.sections).to eq Section.new(nil, 1, 2, [3])
     end
   end
 
   describe '#run' do
     it "should render all sections" do
       mod = template(:e).new
-      mod.should_receive(:render_section).with(Section.new(:a)).and_return('a')
-      mod.should_receive(:render_section).with(Section.new(:b)).and_return('b')
-      mod.should_receive(:render_section).with(Section.new(:c)).and_return('c')
+      expect(mod).to receive(:render_section).with(Section.new(:a)).and_return('a')
+      expect(mod).to receive(:render_section).with(Section.new(:b)).and_return('b')
+      expect(mod).to receive(:render_section).with(Section.new(:c)).and_return('c')
       mod.sections :a, :b, :c
-      mod.run.should == 'abc'
+      expect(mod.run).to eq 'abc'
     end
 
     it "should render all sections with options" do
       mod = template(:e).new
-      mod.should_receive(:render_section).with(Section.new(:a)).and_return('a')
-      mod.should_receive(:add_options).with(:a => 1).and_yield
+      expect(mod).to receive(:render_section).with(Section.new(:a)).and_return('a')
+      expect(mod).to receive(:add_options).with(:a => 1).and_yield
       mod.sections :a
-      mod.run(:a => 1).should == 'a'
+      expect(mod.run(:a => 1)).to eq 'a'
     end
 
     it "should run section list if provided" do
       mod = template(:e).new
-      mod.should_receive(:render_section).with(Section.new(:q))
-      mod.should_receive(:render_section).with(Section.new(:x))
+      expect(mod).to receive(:render_section).with(Section.new(:q))
+      expect(mod).to receive(:render_section).with(Section.new(:x))
       mod.run({}, [:q, :x])
     end
 
     it "should accept a nil section as empty string" do
       mod = template(:e).new
-      mod.should_receive(:render_section).with(Section.new(:a))
+      expect(mod).to receive(:render_section).with(Section.new(:a))
       mod.sections :a
-      mod.run.should == ""
+      expect(mod.run).to eq ""
     end
   end
 
@@ -233,42 +233,42 @@ describe YARD::Templates::Template do
     it "should set instance variables in addition to options" do
       mod = template(:f).new
       mod.send(:add_options, {:a => 1, :b => 2})
-      mod.options.should == {:a => 1, :b => 2}
-      mod.instance_variable_get("@a").should == 1
-      mod.instance_variable_get("@b").should == 2
+      expect(mod.options).to eq ({ :a => 1, :b => 2} )
+      expect(mod.instance_variable_get("@a")).to eq 1
+      expect(mod.instance_variable_get("@b")).to eq 2
     end
 
     it "should set instance variables and options only for the block" do
       mod = template(:f).new
       mod.send(:add_options, {:a => 100, :b => 200}) do
-        mod.options.should == {:a => 100, :b => 200}
+        expect(mod.options).to eq ({ :a => 100, :b => 200} )
       end
-      mod.options.should_not == {:a => 100, :b => 200}
+      expect(mod.options).to_not eq ({:a => 100, :b => 200})
     end
   end
 
   describe '#render_section' do
     it "should call method if method exists by section name as Symbol" do
       mod = template(:f).new
-      mod.should_receive(:respond_to?).with(:a).and_return(true)
-      mod.should_receive(:respond_to?).with('a').and_return(true)
-      mod.should_receive(:send).with(:a).and_return('a')
-      mod.should_receive(:send).with('a').and_return('a')
-      mod.run({}, [:a, 'a']).should == 'aa'
+      expect(mod).to receive(:respond_to?).with(:a).and_return(true)
+      expect(mod).to receive(:respond_to?).with('a').and_return(true)
+      expect(mod).to receive(:send).with(:a).and_return('a')
+      expect(mod).to receive(:send).with('a').and_return('a')
+      expect(mod.run({}, [:a, 'a'])).to eq 'aa'
     end
 
     it "should call erb if no method exists by section name" do
       mod = template(:f).new
-      mod.should_receive(:respond_to?).with(:a).and_return(false)
-      mod.should_receive(:respond_to?).with('a').and_return(false)
-      mod.should_receive(:erb).with(:a).and_return('a')
-      mod.should_receive(:erb).with('a').and_return('a')
-      mod.run({}, [:a, 'a']).should == 'aa'
+      expect(mod).to receive(:respond_to?).with(:a).and_return(false)
+      expect(mod).to receive(:respond_to?).with('a').and_return(false)
+      expect(mod).to receive(:erb).with(:a).and_return('a')
+      expect(mod).to receive(:erb).with('a').and_return('a')
+      expect(mod.run({}, [:a, 'a'])).to eq 'aa'
     end
 
     it "should run a template if section is one" do
       mod2 = template(:g)
-      mod2.should_receive(:run)
+      expect(mod2).to receive(:run)
       mod = template(:f).new
       mod.sections mod2
       mod.run
@@ -276,7 +276,7 @@ describe YARD::Templates::Template do
 
     it "should run a template instance if section is one" do
       mod2 = template(:g).new
-      mod2.should_receive(:run)
+      expect(mod2).to receive(:run)
       mod = template(:f).new
       mod.sections mod2
       mod.run
@@ -293,7 +293,7 @@ describe YARD::Templates::Template do
         def c; "c" end
       end
 
-      mod.run.should == "(b)"
+      expect(mod.run).to eq "(b)"
     end
 
     it "should yield a subsection within a yielded subsection" do
@@ -305,7 +305,7 @@ describe YARD::Templates::Template do
         def c; "c" end
       end
 
-      mod.run.should == "(c)"
+      expect(mod.run).to eq "(c)"
     end
 
     it "should support arbitrary nesting" do
@@ -319,7 +319,7 @@ describe YARD::Templates::Template do
         def e; "e" end
       end
 
-      mod.run.should == "(e)"
+      expect(mod.run).to eq "(e)"
     end
 
     it "should yield first two elements if yield is called twice" do
@@ -331,7 +331,7 @@ describe YARD::Templates::Template do
         def c; "c" end
       end
 
-      mod.run.should == "(bc)"
+      expect(mod.run).to eq "(bc)"
     end
 
     it "should ignore any subsections inside subsection yields" do
@@ -343,7 +343,7 @@ describe YARD::Templates::Template do
         def d; "d" end
       end
 
-      mod.run.should == "(bd)"
+      expect(mod.run).to eq "(bd)"
     end
 
     it "should allow extra options passed via yield" do
@@ -354,7 +354,7 @@ describe YARD::Templates::Template do
         def b; options.x + @x end
       end
 
-      mod.run.should == "(aa)"
+      expect(mod.run).to eq "(aa)"
     end
   end
 
@@ -370,7 +370,7 @@ describe YARD::Templates::Template do
         def e; 'e' end
       end
 
-      mod.run.should == "(bdec)"
+      expect(mod.run).to eq "(bdec)"
     end
 
     it "should yield options to all subsections" do
@@ -381,7 +381,7 @@ describe YARD::Templates::Template do
         def b; @x end
         def c; @x end
       end
-      mod.run.should == "(22)"
+      expect(mod.run).to eq "(22)"
     end
 
     it "should yield all subsections more than once" do
@@ -392,7 +392,7 @@ describe YARD::Templates::Template do
         def b; "b" end
       end
 
-      mod.run.should == "(bb)"
+      expect(mod.run).to eq "(bb)"
     end
 
     it "should not yield if no yieldall is called" do
@@ -403,7 +403,7 @@ describe YARD::Templates::Template do
         def b; "b" end
       end
 
-      mod.run.should == "()"
+      expect(mod.run).to eq "()"
     end
   end
 end

--- a/spec/verifier_spec.rb
+++ b/spec/verifier_spec.rb
@@ -4,59 +4,59 @@ describe YARD::Verifier do
   describe '#parse_expressions' do
     it "should create #__execute method" do
       v = Verifier.new("expr1")
-      v.should respond_to(:__execute)
+      expect(v).to respond_to(:__execute)
     end
 
     it "should parse @tagname into tag('tagname')" do
       obj = mock(:object)
-      obj.should_receive(:tag).with('return')
+      expect(obj).to receive(:tag).with('return')
       Verifier.new('@return').call(obj)
     end
 
     it "should parse @@tagname into object.tags('tagname')" do
       obj = mock(:object)
-      obj.should_receive(:tags).with('return')
+      expect(obj).to receive(:tags).with('return')
       Verifier.new('@@return').call(obj)
     end
 
     it "should allow namespaced tag using @{} syntax" do
       obj = mock(:object)
-      obj.should_receive(:tag).with('yard.return')
+      expect(obj).to receive(:tag).with('yard.return')
       Verifier.new('@{yard.return}').call(obj)
     end
 
     it "should allow namespaced tags using @{} syntax" do
       obj = mock(:object)
-      obj.should_receive(:tags).with('yard.return')
+      expect(obj).to receive(:tags).with('yard.return')
       Verifier.new('@@{yard.return}').call(obj)
     end
 
     it "should call methods on tag object" do
       obj = mock(:object)
       obj2 = mock(:tag)
-      obj.should_receive(:tag).with('return').and_return obj2
-      obj2.should_receive(:foo)
+      expect(obj).to receive(:tag).with('return').and_return obj2
+      expect(obj2).to receive(:foo)
       Verifier.new('@return.foo').call(obj)
     end
 
     it "should send any missing methods to object" do
       obj = mock(:object)
-      obj.should_receive(:has_tag?).with('return')
+      expect(obj).to receive(:has_tag?).with('return')
       Verifier.new('has_tag?("return")').call(obj)
     end
 
     it "should allow multiple expressions" do
       obj = mock(:object)
-      obj.should_receive(:tag).with('return').and_return(true)
-      obj.should_receive(:tag).with('param').and_return(false)
-      Verifier.new('@return', '@param').call(obj).should == false
+      expect(obj).to receive(:tag).with('return').and_return(true)
+      expect(obj).to receive(:tag).with('param').and_return(false)
+      expect(Verifier.new('@return', '@param').call(obj)).to eq false
     end
   end
 
   describe '#o' do
     it "should alias object to o" do
       obj = mock(:object)
-      obj.should_receive(:a).ordered
+      expect(obj).to receive(:a).ordered
       Verifier.new('o.a').call(obj)
     end
   end
@@ -64,30 +64,30 @@ describe YARD::Verifier do
   describe '#call' do
     it "should mock a nonexistent tag so that exceptions are not raised" do
       obj = mock(:object)
-      obj.should_receive(:tag).and_return(nil)
-      Verifier.new('@return.text').call(obj).should == false
+      expect(obj).to receive(:tag).and_return(nil)
+      expect(Verifier.new('@return.text').call(obj)).to eq false
     end
 
     it "should not fail if no expressions were added" do
-      lambda { Verifier.new.call(nil) }.should_not raise_error
+      expect{ Verifier.new.call(nil) }.to_not raise_error
     end
 
     it "should always ignore proxy objects and return true" do
       v = Verifier.new('tag(:x)')
-      lambda { v.call(P('foo')).should == true }.should_not raise_error
+      expect{ expect(v.call(P('foo'))).to be true }.to_not raise_error
     end
   end
 
   describe '#expressions' do
     it "should maintain a list of all unparsed expressions" do
-      Verifier.new('@return.text', '@private').expressions.should == ['@return.text', '@private']
+      expect(Verifier.new('@return.text', '@private').expressions).to eq ['@return.text', '@private']
     end
   end
 
   describe '#expressions=' do
     it "should recompile expressions when attribute is modified" do
       obj = mock(:object)
-      obj.should_receive(:tag).with('return')
+      expect(obj).to receive(:tag).with('return')
       v = Verifier.new
       v.expressions = ['@return']
       v.call(obj)
@@ -97,7 +97,7 @@ describe YARD::Verifier do
   describe '#add_expressions' do
     it "should add new expressions and recompile" do
       obj = mock(:object)
-      obj.should_receive(:tag).with('return')
+      expect(obj).to receive(:tag).with('return')
       v = Verifier.new
       v.add_expressions '@return'
       v.call(obj)


### PR DESCRIPTION
Also changed ==  to eq and =~ to match (or match_array) and from lambda to {}
As you may well know, using 'expect' over 'should' is a recommended practice because of dealing with delegate/proxy objects as detailed in http://myronmars.to/n/dev-blog/2012/06/rspecs-new-expectation-syntax.
As detailed in the blog post "In the future, we plan to change the defaults so that only expect is available unless you explicitly enable should. We may do this as soon as RSpec 3.0, but we want to give users plenty of time to get acquianted with it."
I noticed that expect is now being used in many of the major gems that use rspec. 
I changed the pattern matchers from =~ to match() or match_array() as required for this change and while at it I also took the opportunity to change the == format to eq as recommended in the post.
All tests still pass after this change.

Note: There is currently a lot of deprecation warnings about using stub!  I can fix them but I whould do that in a separate branch and would like to see if this branch will be merged into master first.  Thanks!
