### PR TITLE
yard.rb: Fixed a typo that was causing Windows detection to always fail

### DIFF
--- a/lib/yard.rb
+++ b/lib/yard.rb
@@ -33,7 +33,7 @@ module YARD
     return @windows if defined? @windows
     require 'rbconfig'
     if ::RbConfig::CONFIG['host_os'] =~ /mingw|win32|cygwin/
-      @wnidows = true
+      @windows = true
     else
       @windows = false
     end


### PR DESCRIPTION
This two-letter pull request fixes YARD's Windows detection.  With this fix, it no longer tries to display those progress indicators with the broken ANSI escape sequences when I run `yard doc`.
