### PR TITLE
Handle mutex deadlocks in logger.

### DIFF
--- a/lib/yard/logging.rb
+++ b/lib/yard/logging.rb
@@ -95,9 +95,12 @@ module YARD
         @progress_indicator %= PROGRESS_INDICATORS.size
       end
       Thread.new do
-        sleep(0.05)
-        @mutex.synchronize do
-          progress(msg + ".", nil) if @progress_msg == msg
+        begin
+          sleep(0.05)
+          @mutex.synchronize do
+            progress(msg + ".", nil) if @progress_msg == msg
+          end
+        rescue ThreadError
         end
       end
     end


### PR DESCRIPTION
I was gettintg this error when trying to use the rake task:

```
deadlock; recursive locking
<internal:prelude>:8:in `lock'
<internal:prelude>:8:in `synchronize'
vendor/bundle/ruby/1.9.1/gems/yard-0.8.7.3/lib/yard/logging.rb:92:in `progress'
vendor/bundle/ruby/1.9.1/gems/yard-0.8.7.3/lib/yard/logging.rb:101:in `block (2 levels) in progress'
<internal:prelude>:10:in `synchronize'
vendor/bundle/ruby/1.9.1/gems/yard-0.8.7.3/lib/yard/logging.rb:100:in `block in progress'
```

However, I did not get that error when running yard directly.

Looking at https://github.com/lsegal/yard/blob/master/lib/yard/logging.rb#L92, line 97 starts a new thread, and then within a `@mutex.synchronize` it calls the current method recursively. When that thread hits line 92, it's trying to use the same `@mutex` instance before it has been released.

This appears to be throwing constant exceptions, but they are silent. If `Thread.abort_on_exception = true`. is added, you get the error above almost instantly.

I discovered that this was failing for me because a gem is loaded in my Rakefile that has `Thread.abort_on_exception = true`.

Handling the exception seems a sensible enough fix.
