### PR TITLE
Rubygems 2.0+ integration

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -1,4 +1,8 @@
-unless defined?(Gem::DocManager.load_yardoc)
-  require File.expand_path(File.dirname(__FILE__) + '/yard/rubygems/specification')
-  require File.expand_path(File.dirname(__FILE__) + '/yard/rubygems/doc_manager')
+if defined?(Gem::VERSION) && Gem::VERSION >= "2.0."
+  require File.expand_path(File.dirname(__FILE__) + '/yard/rubygems/hook')
+else
+  unless defined?(Gem::DocManager.load_yardoc)
+    require File.expand_path(File.dirname(__FILE__) + '/yard/rubygems/specification')
+    require File.expand_path(File.dirname(__FILE__) + '/yard/rubygems/doc_manager')
+  end
 end

--- a/lib/yard/registry.rb
+++ b/lib/yard/registry.rb
@@ -61,10 +61,12 @@ module YARD
 
         if for_writing
           global_yardoc_file(spec, for_writing) ||
+            old_global_yardoc_file(spec, for_writing) ||
             local_yardoc_file(spec, for_writing)
         else
           local_yardoc_file(spec, for_writing) ||
-            global_yardoc_file(spec, for_writing)
+            global_yardoc_file(spec, for_writing) ||
+            old_global_yardoc_file(spec, for_writing)
         end
       end
 
@@ -402,6 +404,16 @@ module YARD
       # @group Retrieving yardoc File Locations
 
       def global_yardoc_file(spec, for_writing = false)
+        path = spec.doc_dir
+        yfile = spec.doc_dir(DEFAULT_YARDOC_FILE)
+        if for_writing && File.writable?(path)
+          return yfile
+        elsif !for_writing && File.exist?(yfile)
+          return yfile
+        end
+      end
+
+      def old_global_yardoc_file(spec, for_writing = false)
         path = spec.full_gem_path
         yfile = File.join(path, DEFAULT_YARDOC_FILE)
         if for_writing && File.writable?(path)

--- a/lib/yard/rubygems/hook.rb
+++ b/lib/yard/rubygems/hook.rb
@@ -84,7 +84,7 @@ module YARD
       @generate_yri = generate_yri
 
       @yard_dir = spec.doc_dir('yard')
-      @yri_dir = spec.doc_dir('yri')
+      @yri_dir = spec.doc_dir('.yardoc')
     end
 
     def run_yardoc(*args)
@@ -121,6 +121,8 @@ module YARD
     end
 
     def install_yri
+      FileUtils.rm_rf @yri_dir
+
       say "Building YARD (yri) index for #{@spec.full_name}..."
       run_yardoc '-c', '-n', '--db', @yri_dir
     end

--- a/lib/yard/rubygems/hook.rb
+++ b/lib/yard/rubygems/hook.rb
@@ -1,0 +1,163 @@
+require 'rubygems'
+require 'rubygems/user_interaction'
+require 'fileutils'
+
+##
+# Gem::YARDoc provides methods to generate YARDoc and yri data for installed gems
+# upon gem installation.
+#
+# This file is automatically required by RubyGems 1.9 and newer.
+
+module YARD
+  class RubygemsHook
+
+    include Gem::UserInteraction
+    extend Gem::UserInteraction
+
+    @yard_version = nil
+
+    ##
+    # Force installation of documentation?
+
+    attr_accessor :force
+
+    ##
+    # Generate yard?
+
+    attr_accessor :generate_yard
+
+    ##
+    # Generate yri data?
+
+    attr_accessor :generate_yri
+
+    class << self
+
+      ##
+      # Loaded version of YARD. Set by ::load_yard
+
+      attr_reader :yard_version
+
+    end
+
+    ##
+    # Post installs hook that generates documentation for each specification in
+    # +specs+
+
+    def self.generation_hook(installer, specs)
+      start = Time.now
+      types = installer.document
+      puts types.inspect
+
+      generate_yard = types.include?('yardoc') || types.include?('yard')
+      generate_yri = types.include? 'yri'
+
+      specs.each do |spec|
+        new(spec, generate_yard, generate_yri).generate
+      end
+
+      return unless generate_yard or generate_yri
+
+      duration = (Time.now - start).to_i
+      names = specs.map(&:name).join ', '
+
+      say "Done installing documentation for #{names} after #{duration} seconds"
+    end
+
+    ##
+    # Loads the YARD generator
+
+    def self.load_yard
+      return if @yard_version
+
+      require 'yard'
+
+      @yard_version = Gem::Version.new ::YARD::VERSION
+    end
+
+    def initialize(spec, generate_yard = false, generate_yri = true)
+      @doc_dir = spec.doc_dir
+      @force = false
+      @spec = spec
+
+      @generate_yard = generate_yard
+      @generate_yri = generate_yri
+
+      @yard_dir = spec.doc_dir('yard')
+      @yri_dir = spec.doc_dir('yri')
+    end
+
+    def run_yardoc(*args)
+      args << '--quiet' unless Gem.configuration.really_verbose
+      args << '--backtrace' if Gem.configuration.backtrace
+      unless File.file?(File.join(@spec.full_gem_path, '.yardopts'))
+        args << @spec.require_paths
+        if @spec.extra_rdoc_files.size > 0
+          args << '-'
+          args += @spec.extra_rdoc_files
+        end
+      end
+      args = args.flatten.map {|arg| arg.to_s }
+
+      Dir.chdir(@spec.full_gem_path) do
+        YARD::CLI::Yardoc.run(*args)
+      end
+    rescue Errno::EACCES => e
+      dirname = File.dirname e.message.split("-")[1].strip
+      raise Gem::FilePermissionError.new(dirname)
+    rescue => ex
+      alert_error "While generating documentation for #{@spec.full_name}"
+      ui.errs.puts "... MESSAGE:   #{ex}"
+      ui.errs.puts "... YARDOC args: #{args.join(' ')}"
+      ui.errs.puts "\t#{ex.backtrace.join("\n\t")}" if Gem.configuration.backtrace
+      ui.errs.puts "(continuing with the rest of the installation)"
+    end
+
+    def install_yard
+      FileUtils.rm_rf @yard_dir
+
+      say "Installing YARD documentation for #{@spec.full_name}..."
+      run_yardoc '-o', @yard_dir
+    end
+
+    def install_yri
+      say "Building YARD (yri) index for #{@spec.full_name}..."
+      run_yardoc '-c', '-n', '--db', @yri_dir
+    end
+
+    ##
+    # Generates YARD and yri data
+
+    def generate
+      return if @spec.default_gem?
+      return unless @generate_yri || @generate_yard
+
+      setup
+
+      if @generate_yri && (@force || !File.exist?(@yri_dir))
+        install_yri
+      end
+
+      if @generate_yard && (@force || !File.exist?(@yard_dir))
+        install_yard
+      end
+    end
+
+    ##
+    # Prepares the spec for documentation generation
+
+    def setup
+      self.class.load_yard
+
+      if File.exist?(@doc_dir)
+        unless File.writable?(@doc_dir)
+          raise Gem::FilePermissionError, @doc_dir
+        end
+      else
+        FileUtils.mkdir_p @doc_dir
+      end
+    end
+  end
+end
+
+Gem.done_installing(&YARD::RubygemsHook.method(:generation_hook))


### PR DESCRIPTION
Rubygems 2.0 got rid of DocManager and instead relies on pos-tinstall hook. 

This is a port of the old integration (with RDoc integration code as a basis).

There are a few caveats to this code.

Both YARD and yri data is generated into docs directories supplied by the rubygems. Currently, yri can not find generated docs there. I intend to fix it too.