### PR TITLE
Add a spec for escaped colons in a C constant comment

### DIFF
--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -89,6 +89,23 @@ describe YARD::Parser::C::CParser do
         constant.value.should == '0xdeadbeef'
         constant.docstring.should == "This constant is frequently used to indicate a\nsoftware crash or deadlock in embedded systems."
       end
+
+      it 'should allow escaped colons in value of docstring' do
+        parse <<-eof
+          #define MSK_DEADBEEF 0xdeadbeef
+          void
+          Init_Mask(void)
+          {
+              rb_cMask  = rb_define_class("Mask", rb_cObject);
+              /* DEAD\\:\\:BEEF: This constant is frequently used to indicate a
+               * software crash or deadlock in embedded systems. */
+              rb_define_const(rb_cMask, "DEADBEEF", INT2FIX(MSK_DEADBEEF));
+          }
+        eof
+        constant = Registry.at('Mask::DEADBEEF')
+        constant.value.should == 'DEAD::BEEF'
+        constant.docstring.should == "This constant is frequently used to indicate a\nsoftware crash or deadlock in embedded systems."
+      end
     end
 
     describe 'Macros' do


### PR DESCRIPTION
`YARD::Handlers::C::HandlerMethods#find_constant_docstring` has a beefy regex that allows a comment to consist of a value and a description, separated by a colon. The regex also allows the user to escape colons as well, in case the value has a colon in it, as described in a comment:

``` ruby
# In the case of rb_define_const, the definition and comment are in
# "/* definition: comment */" form.  The literal ':' and '\' characters
# can be escaped with a backslash.
```

This tests said behavior.
