### PR TITLE
i18n: Fill "POT-Creation-Date" header value

### DIFF
--- a/lib/yard/i18n/pot_generator.rb
+++ b/lib/yard/i18n/pot_generator.rb
@@ -134,7 +134,7 @@ module YARD
 
       private
       def header
-        <<-'EOH'
+        <<-EOH
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
@@ -143,18 +143,26 @@ module YARD
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-11-20 22:17+0900\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: PACKAGE VERSION\\n"
+"Report-Msgid-Bugs-To: \\n"
+"POT-Creation-Date: #{generate_pot_creation_date_value}\\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+"Language-Team: LANGUAGE <LL@li.org>\\n"
+"Language: \\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
 
 EOH
+      end
+
+      def current_time
+        @current_time ||= Time.now
+      end
+
+      def generate_pot_creation_date_value
+        current_time.strftime("%Y-%m-%d %H:%M%z")
       end
 
       def generate_message(pot, message)

--- a/spec/i18n/pot_generator_spec.rb
+++ b/spec/i18n/pot_generator_spec.rb
@@ -25,7 +25,10 @@ describe YARD::I18n::PotGenerator do
 
   describe "Generate" do
     it "should generate the default header" do
-      @generator.generate.should == <<-'eoh'
+      current_time = Time.parse("2011-11-20 22:17+0900")
+      @generator.stub!(:current_time).and_return(current_time)
+      pot_creation_date = current_time.strftime("%Y-%m-%d %H:%M%z")
+      @generator.generate.should == <<-eoh
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
@@ -34,16 +37,16 @@ describe YARD::I18n::PotGenerator do
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2011-11-20 22:17+0900\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
-"MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: 8bit\n"
+"Project-Id-Version: PACKAGE VERSION\\n"
+"Report-Msgid-Bugs-To: \\n"
+"POT-Creation-Date: #{pot_creation_date}\\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\\n"
+"Language-Team: LANGUAGE <LL@li.org>\\n"
+"Language: \\n"
+"MIME-Version: 1.0\\n"
+"Content-Type: text/plain; charset=UTF-8\\n"
+"Content-Transfer-Encoding: 8bit\\n"
 
 eoh
     end


### PR DESCRIPTION
It should be the time of the .pot is created. The current
implementation uses the static value. (It was my mistake. Sorry.)
