### PR TITLE
rake gem: Support RubyGems 2.0.0 or later

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,14 @@ task :default => :specs
 
 desc "Builds the gem"
 task :gem do
-  Gem::Builder.new(eval(File.read('yard.gemspec'))).build
+  spec_path = 'yard.gemspec'
+  spec = eval(File.read(spec_path), TOPLEVEL_BINDING, spec_path)
+  if Gem.const_defined?(:Builder)
+    Gem::Builder.new(spec).build
+  else
+    require "rubygems/package"
+    Gem::Package.build(spec)
+  end
 end
 
 desc "Installs the gem"


### PR DESCRIPTION
RubyGems 2.0.0 changed API to create gem:

http://rubygems.rubyforge.org/rubygems-update/History_txt.html

> 2.0.0 / 2013-02-24
> - Merged Gem::Builder into Gem::Package.
>   Use Gem::Package.build instead of Gem::Builder.new(spec).build
