### PR TITLE
Fixed issue #744 by making the 'frames' link have a relative URL

### DIFF
--- a/templates/default/layout/html/script_setup.erb
+++ b/templates/default/layout/html/script_setup.erb
@@ -1,5 +1,5 @@
 <script type="text/javascript" charset="utf-8">
   hasFrames = window.top.frames.main ? true : false;
   relpath = '<%= u = url_for(''); u + (u != '' ? '/' : '') %>';
-  framesUrl = "<%= url_for_frameset %>#!" + escape(window.location.href);
+  framesUrl = "<%= url_for_frameset %>#!<%= url_for(@file || @object, nil, false) %>";
 </script>


### PR DESCRIPTION
This pull request should fix issue #744.  I tested it on my project and all the "frames" links worked correctly.  I also printed the generated URLs on the console and skimmed through them to make sure each generated url looked reasonable.
