### PR TITLE
Report 100% coverage when there is no code at all

### DIFF
--- a/lib/yard/cli/stats.rb
+++ b/lib/yard/cli/stats.rb
@@ -59,7 +59,9 @@ module YARD
           end
         end
         meths.each {|m| send(m) }
-        if @total == 0
+        if number_of_files == 0
+          total = 100
+        elsif @total == 0
           total = 0
         else
           total = (@total - @undocumented).to_f / @total.to_f * 100
@@ -100,11 +102,16 @@ module YARD
         @all_objects ||= run_verifier Registry.all
       end
 
-      # Statistics for files
-      def stats_for_files
+      # Number of files
+      def number_of_files
         files = []
         all_objects.each {|o| files |= [o.file] }
-        output "Files", files.size
+        files.size
+      end
+
+      # Statistics for files
+      def stats_for_files
+        output "Files", number_of_files
       end
 
       # Statistics for modules

--- a/spec/cli/stats_spec.rb
+++ b/spec/cli/stats_spec.rb
@@ -85,6 +85,6 @@ eof
       "Classes:         0 (    0 undocumented)\n" +
       "Constants:       0 (    0 undocumented)\n" +
       "Methods:         0 (    0 undocumented)\n" +
-      " 0.00% documented\n"
+      " 100.00% documented\n"
   end
 end


### PR DESCRIPTION
For a new project, turning on Yard at the start immediately complains that there is insufficient documentation.  Making this change means that as part of your test suite, Yard will be 'green' from the beginning.

Addresses https://github.com/lsegal/yard/issues/754
