### PR TITLE
Move global `log` method into YARD namespace

### DIFF
--- a/lib/yard.rb
+++ b/lib/yard.rb
@@ -49,6 +49,14 @@ module YARD
 
   # @return [Boolean] whether YARD is being run in Ruby 2.0
   def self.ruby2?; @ruby2 ||= (RUBY_VERSION >= '2.0.0') end
+
+  # The global {YARD::Logger} instance
+  #
+  # @return [YARD::Logger] the global {YARD::Logger} instance
+  # @see YARD::Logger
+  def self.log
+    YARD::Logger.instance
+  end
 end
 
 # Keep track of Ruby version for compatibility code

--- a/lib/yard/cli/command.rb
+++ b/lib/yard/cli/command.rb
@@ -37,12 +37,12 @@ module YARD
         opts.on('--safe', 'Enable safe mode for this instance') do
           # Parsed in YARD::Config.load
         end
-        opts.on_tail('-q', '--quiet', 'Show no warnings.') { log.level = Logger::ERROR }
-        opts.on_tail('--verbose', 'Show more information.') { log.level = Logger::INFO }
-        opts.on_tail('--debug', 'Show debugging information.') { log.level = Logger::DEBUG }
-        opts.on_tail('--backtrace', 'Show stack traces') { log.show_backtraces = true }
-        opts.on_tail('-v', '--version', 'Show version.') { log.puts "yard #{YARD::VERSION}"; exit }
-        opts.on_tail('-h', '--help', 'Show this help.')  { log.puts opts; exit }
+        opts.on_tail('-q', '--quiet', 'Show no warnings.') { YARD.log.level = Logger::ERROR }
+        opts.on_tail('--verbose', 'Show more information.') { YARD.log.level = Logger::INFO }
+        opts.on_tail('--debug', 'Show debugging information.') { YARD.log.level = Logger::DEBUG }
+        opts.on_tail('--backtrace', 'Show stack traces') { YARD.log.show_backtraces = true }
+        opts.on_tail('-v', '--version', 'Show version.') { YARD.log.puts "yard #{YARD::VERSION}"; exit }
+        opts.on_tail('-h', '--help', 'Show this help.')  { YARD.log.puts opts; exit }
       end
 
       # Parses the option and gracefully handles invalid switches
@@ -68,7 +68,7 @@ module YARD
         return if YARD::Config.options[:safe_mode]
         load(file)
       rescue LoadError => load_exception
-        log.error "The file `#{file}' could not be loaded:\n#{load_exception}"
+        YARD.log.error "The file `#{file}' could not be loaded:\n#{load_exception}"
         exit
       end
 
@@ -77,7 +77,7 @@ module YARD
       # @param [OptionParser::ParseError] err the exception raised by the
       #   option parser
       def unrecognized_option(err)
-        log.warn "Unrecognized/#{err.message}"
+        YARD.log.warn "Unrecognized/#{err.message}"
       end
     end
   end

--- a/lib/yard/cli/command_parser.rb
+++ b/lib/yard/cli/command_parser.rb
@@ -53,7 +53,7 @@ module YARD
       def self.run(*args) new.run(*args) end
 
       def initialize
-        log.show_backtraces = false
+        YARD.log.show_backtraces = false
       end
 
       # Runs the {Command} object matching the command name of the first
@@ -79,12 +79,12 @@ module YARD
       def commands; self.class.commands end
 
       def list_commands
-        log.puts "Usage: yard <command> [options]"
-        log.puts
-        log.puts "Commands:"
+        YARD.log.puts "Usage: yard <command> [options]"
+        YARD.log.puts
+        YARD.log.puts "Commands:"
         commands.keys.sort_by {|k| k.to_s }.each do |command_name|
           command = commands[command_name].new
-          log.puts "%-8s %s" % [command_name, command.description]
+          YARD.log.puts "%-8s %s" % [command_name, command.description]
         end
       end
     end

--- a/lib/yard/cli/config.rb
+++ b/lib/yard/cli/config.rb
@@ -48,10 +48,10 @@ module YARD
 
       def modify_item
         if reset
-          log.debug "Resetting #{key}"
+          YARD.log.debug "Resetting #{key}"
           YARD::Config.options[key] = YARD::Config::DEFAULT_CONFIG_OPTIONS[key]
         else
-          log.debug "Setting #{key} to #{values.inspect}"
+          YARD.log.debug "Setting #{key} to #{values.inspect}"
           items, current_items = encode_values, YARD::Config.options[key]
           items = [current_items].flatten + [items].flatten if append
           YARD::Config.options[key] = items
@@ -60,14 +60,14 @@ module YARD
       end
 
       def view_item
-        log.debug "Viewing #{key}"
-        log.puts YARD::Config.options[key].inspect
+        YARD.log.debug "Viewing #{key}"
+        YARD.log.puts YARD::Config.options[key].inspect
       end
 
       def list_configuration
-        log.debug "Listing configuration"
+        YARD.log.debug "Listing configuration"
         require 'yaml'
-        log.puts YAML.dump(YARD::Config.options).sub(/\A--.*\n/, '').gsub(/\n\n/, "\n")
+        YARD.log.puts YAML.dump(YARD::Config.options).sub(/\A--.*\n/, '').gsub(/\n\n/, "\n")
       end
 
       def encode_values

--- a/lib/yard/cli/display.rb
+++ b/lib/yard/cli/display.rb
@@ -19,7 +19,7 @@ module YARD
       # @return [void]
       def run(*args)
         return unless parse_arguments(*args)
-        log.puts wrap_layout(format_objects)
+        YARD.log.puts wrap_layout(format_objects)
       end
 
       # @return [String] the output data for all formatted objects

--- a/lib/yard/cli/gems.rb
+++ b/lib/yard/cli/gems.rb
@@ -30,14 +30,14 @@ module YARD
           ver = "= #{spec.version}"
           dir = Registry.yardoc_file_for_gem(spec.name, ver)
           if dir && File.directory?(dir) && !@rebuild
-            log.debug "#{spec.name} index already exists at '#{dir}'"
+            YARD.log.debug "#{spec.name} index already exists at '#{dir}'"
           else
             yfile = Registry.yardoc_file_for_gem(spec.name, ver, true)
             next unless yfile
             next unless File.directory?(spec.full_gem_path)
             Registry.clear
             Dir.chdir(spec.full_gem_path)
-            log.info "Building yardoc index for gem: #{spec.full_name}"
+            YARD.log.info "Building yardoc index for gem: #{spec.full_name}"
             Yardoc.run('--no-stats', '-n', '-b', yfile)
           end
         end
@@ -48,7 +48,7 @@ module YARD
           gem, ver_require = gems[index], gems[index + 1] || ">= 0"
           specs = Gem.source_index.find_name(gem, ver_require)
           if specs.empty?
-            log.warn "#{gem} #{ver_require} could not be found in RubyGems index"
+            YARD.log.warn "#{gem} #{ver_require} could not be found in RubyGems index"
           else
             @gems += specs
           end
@@ -73,7 +73,7 @@ module YARD
 
 
         if !args.empty? && @gems.empty?
-          log.error "No specified gems could be found for command"
+          YARD.log.error "No specified gems could be found for command"
         elsif @gems.empty?
           @gems += Gem.source_index.find_name('') if @gems.empty?
         end

--- a/lib/yard/cli/help.rb
+++ b/lib/yard/cli/help.rb
@@ -9,7 +9,7 @@ module YARD
         if args.first && cmd = CommandParser.commands[args.first.to_sym]
           cmd.run('--help')
         else
-          log.puts "Command #{args.first} not found." if args.first
+          YARD.log.puts "Command #{args.first} not found." if args.first
           CommandParser.run('--help')
         end
       end

--- a/lib/yard/cli/list.rb
+++ b/lib/yard/cli/list.rb
@@ -11,8 +11,8 @@ module YARD
       # @return [void]
       def run(*args)
         if args.include?('--help')
-          log.puts "Usage: yard list [yardoc_options]"
-          log.puts "Takes the same arguments as yardoc. See yardoc --help"
+          YARD.log.puts "Usage: yard list [yardoc_options]"
+          YARD.log.puts "Takes the same arguments as yardoc. See yardoc --help"
         else
           Yardoc.run('-c', '--list', *args)
         end

--- a/lib/yard/cli/markup_types.rb
+++ b/lib/yard/cli/markup_types.rb
@@ -11,21 +11,21 @@ module YARD
       # @param [Array<String>] args the list of arguments.
       # @return [void]
       def run(*args)
-        log.puts "Available markup types for `doc' command:"
-        log.puts
+        YARD.log.puts "Available markup types for `doc' command:"
+        YARD.log.puts
         types = Templates::Helpers::MarkupHelper::MARKUP_PROVIDERS
         exts = Templates::Helpers::MarkupHelper::MARKUP_EXTENSIONS
         types.sort_by {|name, _| name.to_s }.each do |name, providers|
-          log.puts "[#{name}]"
+          YARD.log.puts "[#{name}]"
           libs = providers.map {|p| p[:lib] }.compact
           if libs.size > 0
-            log.puts "  Providers: #{libs.join(" ")}"
+            YARD.log.puts "  Providers: #{libs.join(" ")}"
           end
           if exts[name]
-            log.puts "  Extensions: #{exts[name].map {|e| ".#{e}"}.join(" ")}"
+            YARD.log.puts "  Extensions: #{exts[name].map {|e| ".#{e}"}.join(" ")}"
           end
 
-          log.puts
+          YARD.log.puts
         end
       end
     end

--- a/lib/yard/cli/server.rb
+++ b/lib/yard/cli/server.rb
@@ -97,7 +97,7 @@ module YARD
             libraries[library] ||= []
             libraries[library] |= [libver]
           else
-            log.warn "Cannot find yardoc db for #{library}: #{dir.inspect}"
+            YARD.log.warn "Cannot find yardoc db for #{library}: #{dir.inspect}"
           end
         end
       end
@@ -140,10 +140,10 @@ module YARD
             libraries[spec.name] |= [YARD::Server::LibraryVersion.new(spec.name, spec.version.to_s, nil, :gem)]
           end
         else
-          log.warn "Cannot find #{gemfile}.lock, ignoring --gemfile option"
+          YARD.log.warn "Cannot find #{gemfile}.lock, ignoring --gemfile option"
         end
       rescue LoadError
-        log.error "Bundler not available, ignoring --gemfile option"
+        YARD.log.error "Bundler not available, ignoring --gemfile option"
       end
 
       def optparse(*args)
@@ -224,9 +224,9 @@ module YARD
       end
 
       def generate_doc_for_first_time(libver)
-        log.enter_level(Logger::INFO) do
+        YARD.log.enter_level(Logger::INFO) do
           yardoc_file = libver.yardoc_file.sub /^#{Regexp.quote Dir.pwd}[\\\/]+/, ''
-          log.info "No yardoc db found in #{yardoc_file}, parsing source before starting server..."
+          YARD.log.info "No yardoc db found in #{yardoc_file}, parsing source before starting server..."
         end
         Dir.chdir(libver.source_path) do
           Yardoc.run('-n')

--- a/lib/yard/cli/stats.rb
+++ b/lib/yard/cli/stats.rb
@@ -67,30 +67,30 @@ module YARD
         else
           total = (@total - @undocumented).to_f / @total.to_f * 100
         end
-        log.puts("% 3.2f%% documented" % total)
+        YARD.log.puts("% 3.2f%% documented" % total)
       end
 
       # Prints list of undocumented objects
       def print_undocumented_objects
         return if !@undoc_list || @undoc_list.empty?
-        log.puts
-        log.puts "Undocumented Objects:"
+        YARD.log.puts
+        YARD.log.puts "Undocumented Objects:"
 
         objects = @undoc_list.sort_by {|o| o.file }
         max = objects.sort_by {|o| o.path.length }.last.path.length
         if @compact
           objects.each do |object|
-            log.puts("%-#{max}s     (%s)" % [object.path,
+            YARD.log.puts("%-#{max}s     (%s)" % [object.path,
               [object.file, object.line].compact.join(":")])
           end
         else
           last_file = nil
           objects.each do |object|
             if object.file != last_file
-              log.puts
-              log.puts "(in file: #{object.file})"
+              YARD.log.puts
+              YARD.log.puts "(in file: #{object.file})"
             end
-            log.puts object.path
+            YARD.log.puts object.path
             last_file = object.file
           end
         end
@@ -151,7 +151,7 @@ module YARD
         else
           data = "%5s" % data
         end
-        log.puts("%-12s %s" % [name + ":", data])
+        YARD.log.puts("%-12s %s" % [name + ":", data])
       end
 
       private

--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -231,7 +231,7 @@ module YARD
       #   contains a single nil value, skip calling of {#parse_arguments}
       # @return [void]
       def run(*args)
-        log.show_progress = true
+        YARD.log.show_progress = true
         if args.size == 0 || !args.first.nil?
           # fail early if arguments are not valid
           return unless parse_arguments(*args)
@@ -252,16 +252,16 @@ module YARD
           print_list
         end
 
-        if !list && statistics && log.level < Logger::ERROR
+        if !list && statistics && YARD.log.level < Logger::ERROR
           Registry.load_all
-          log.enter_level(Logger::ERROR) do
+          YARD.log.enter_level(Logger::ERROR) do
             Stats.new(false).run(*args)
           end
         end
 
         true
       ensure
-        log.show_progress = false
+        YARD.log.show_progress = false
       end
 
       # Parses commandline arguments
@@ -288,7 +288,7 @@ module YARD
         # US-ASCII is invalid encoding for onefile
         if defined?(::Encoding) && options.onefile
           if ::Encoding.default_internal == ::Encoding::US_ASCII
-            log.warn "--one-file is not compatible with US-ASCII encoding, using ASCII-8BIT"
+            YARD.log.warn "--one-file is not compatible with US-ASCII encoding, using ASCII-8BIT"
             ::Encoding.default_external, ::Encoding.default_internal = ['ascii-8bit'] * 2
           end
         end
@@ -328,7 +328,7 @@ module YARD
           if checksums && serialized && !object.files.any? {|f, line| changed_files.include?(f) }
             true
           else
-            log.debug "Re-generating object #{object.path}..."
+            YARD.log.debug "Re-generating object #{object.path}..."
             false
           end
         end
@@ -340,7 +340,7 @@ module YARD
       #
       # @return (see YARD::Templates::Helpers::MarkupHelper#load_markup_provider)
       def verify_markup_options
-        result, lvl = false, has_markup ? log.level : Logger::FATAL
+        result, lvl = false, has_markup ? YARD.log.level : Logger::FATAL
         obj = Struct.new(:options).new(options)
         obj.extend(Templates::Helpers::MarkupHelper)
         options.files.each do |file|
@@ -349,9 +349,9 @@ module YARD
           return false if !result && markup != :rdoc
         end
         options.markup = :rdoc unless has_markup
-        log.enter_level(lvl) { result = obj.load_markup_provider }
+        YARD.log.enter_level(lvl) { result = obj.load_markup_provider }
         if !result && !has_markup
-          log.warn "Could not load default RDoc formatter, " +
+          YARD.log.warn "Could not load default RDoc formatter, " +
             "ignoring any markup (install RDoc to get default formatting)."
           options.markup = :none
           true
@@ -368,7 +368,7 @@ module YARD
         outpath = options.serializer.basepath
         assets.each do |from, to|
           to = File.join(outpath, to)
-          log.debug "Copying asset '#{from}' to '#{to}'"
+          YARD.log.debug "Copying asset '#{from}' to '#{to}'"
           from += '/.' if File.directory?(from)
           FileUtils.cp_r(from, to)
         end
@@ -381,7 +381,7 @@ module YARD
         Registry.load_all
         run_verifier(Registry.all).
           sort_by {|item| [item.file || '', item.line || 0] }.each do |item|
-          log.puts "#{item.file}:#{item.line}: #{item.path}"
+          YARD.log.puts "#{item.file}:#{item.line}: #{item.path}"
         end
       end
 
@@ -393,7 +393,7 @@ module YARD
           if File.file?(file)
             options.files << CodeObjects::ExtraFileObject.new(file)
           else
-            log.warn "Could not find extra file: #{file}"
+            YARD.log.warn "Could not find extra file: #{file}"
           end
         end
       end
@@ -624,7 +624,7 @@ module YARD
           if File.file?(readme)
             options.readme = CodeObjects::ExtraFileObject.new(readme)
           else
-            log.warn "Could not find readme file: #{readme}"
+            YARD.log.warn "Could not find readme file: #{readme}"
           end
         end
 
@@ -639,7 +639,7 @@ module YARD
           from, to = *asset.split(':').map {|f| File.cleanpath(f) }
           to ||= from
           if from =~ re || to =~ re
-            log.warn "Invalid file '#{asset}'"
+            YARD.log.warn "Invalid file '#{asset}'"
           else
             assets[from] = to
           end

--- a/lib/yard/cli/yri.rb
+++ b/lib/yard/cli/yri.rb
@@ -72,8 +72,8 @@ module YARD
       # @return [void]
       # @since 0.5.6
       def print_usage
-        log.puts "Usage: yri [options] <Path to object>"
-        log.puts "See yri --help for more options."
+        YARD.log.puts "Usage: yri [options] <Path to object>"
+        YARD.log.puts "See yri --help for more options."
       end
 
       # Caches the .yardoc file where an object can be found in the {CACHE_FILE}
@@ -111,15 +111,15 @@ module YARD
         @search_paths.unshift(Registry.yardoc_file)
 
         # Try to load it from in memory cache
-        log.debug "Searching for #{name} in memory"
+        YARD.log.debug "Searching for #{name} in memory"
         if obj = try_load_object(name, nil)
           return obj
         end
 
-        log.debug "Searching for #{name} in search paths"
+        YARD.log.debug "Searching for #{name} in search paths"
         @search_paths.each do |path|
           next unless File.exist?(path)
-          log.debug "Searching for #{name} in #{path}..."
+          YARD.log.debug "Searching for #{name} in #{path}..."
           Registry.load(path)
           if obj = try_load_object(name, path)
             return obj

--- a/lib/yard/code_objects/extra_file_object.rb
+++ b/lib/yard/code_objects/extra_file_object.rb
@@ -105,14 +105,14 @@ module YARD::CodeObjects
         begin
           contents.force_encoding(attributes[:encoding])
         rescue ArgumentError
-          log.warn "Invalid encoding `#{attributes[:encoding]}' in #{filename}"
+          YARD.log.warn "Invalid encoding `#{attributes[:encoding]}' in #{filename}"
         end
       end
       contents
     rescue ArgumentError => e
       if retried && e.message =~ /invalid byte sequence/
         # This should never happen.
-        log.warn "Could not read #{filename}, #{e.message}. You probably want to set `--charset`."
+        YARD.log.warn "Could not read #{filename}, #{e.message}. You probably want to set `--charset`."
         return ''
       end
       data.force_encoding('binary') if data.respond_to?(:force_encoding)

--- a/lib/yard/code_objects/proxy.rb
+++ b/lib/yard/code_objects/proxy.rb
@@ -193,15 +193,15 @@ module YARD
         if obj = to_obj
           obj.__send__(meth, *args, &block)
         else
-          log.warn "Load Order / Name Resolution Problem on #{path}:"
-          log.warn "-"
-          log.warn "Something is trying to call #{meth} on object #{path} before it has been recognized."
-          log.warn "This error usually means that you need to modify the order in which you parse files"
-          log.warn "so that #{path} is parsed before methods or other objects attempt to access it."
-          log.warn "-"
-          log.warn "YARD will recover from this error and continue to parse but you *may* have problems"
-          log.warn "with your generated documentation. You should probably fix this."
-          log.warn "-"
+          YARD.log.warn "Load Order / Name Resolution Problem on #{path}:"
+          YARD.log.warn "-"
+          YARD.log.warn "Something is trying to call #{meth} on object #{path} before it has been recognized."
+          YARD.log.warn "This error usually means that you need to modify the order in which you parse files"
+          YARD.log.warn "so that #{path} is parsed before methods or other objects attempt to access it."
+          YARD.log.warn "-"
+          YARD.log.warn "YARD will recover from this error and continue to parse but you *may* have problems"
+          YARD.log.warn "with your generated documentation. You should probably fix this."
+          YARD.log.warn "-"
           begin
             super
           rescue NoMethodError

--- a/lib/yard/config.rb
+++ b/lib/yard/config.rb
@@ -124,8 +124,8 @@ module YARD
       translate_plugin_names
       load_plugins
     rescue => e
-      log.error "Invalid configuration file, using default options."
-      log.backtrace(e)
+      YARD.log.error "Invalid configuration file, using default options."
+      YARD.log.backtrace(e)
       options.update(DEFAULT_CONFIG_OPTIONS)
     end
 
@@ -157,7 +157,7 @@ module YARD
       name = translate_plugin_name(name)
       return false if options[:ignored_plugins].include?(name)
       return false if name =~ /^yard-doc-/
-      log.debug "Loading plugin '#{name}'..."
+      YARD.log.debug "Loading plugin '#{name}'..."
       require name
       true
     rescue LoadError => e
@@ -182,7 +182,7 @@ module YARD
       end
       result
     rescue LoadError
-      log.debug "RubyGems is not present, skipping plugin loading"
+      YARD.log.debug "RubyGems is not present, skipping plugin loading"
       false
     end
 
@@ -213,8 +213,8 @@ module YARD
     # Print a warning if the plugin failed to load
     # @return [false]
     def self.load_plugin_failed(name, exception)
-      log.warn "Error loading plugin '#{name}'"
-      log.backtrace(exception) if $DEBUG
+      YARD.log.warn "Error loading plugin '#{name}'"
+      YARD.log.backtrace(exception) if $DEBUG
       false
     end
 

--- a/lib/yard/docstring_parser.rb
+++ b/lib/yard/docstring_parser.rb
@@ -196,11 +196,11 @@ module YARD
       if library.has_tag?(tag_name)
         @tags += [library.tag_create(tag_name, tag_buf)].flatten
       else
-        log.warn "Unknown tag @#{tag_name}" +
+        YARD.log.warn "Unknown tag @#{tag_name}" +
           (object ? " in file `#{object.file}` near line #{object.line}" : "")
       end
     rescue Tags::TagFormatError
-      log.warn "Invalid tag format for @#{tag_name}" +
+      YARD.log.warn "Invalid tag format for @#{tag_name}" +
         (object ? " in file `#{object.file}` near line #{object.line}" : "")
     end
 
@@ -219,12 +219,12 @@ module YARD
           dir
         end
       else
-        log.warn "Unknown directive @!#{tag_name}" +
+        YARD.log.warn "Unknown directive @!#{tag_name}" +
           (object ? " in file `#{object.file}` near line #{object.line}" : "")
         nil
       end
     rescue Tags::TagFormatError
-      log.warn "Invalid directive format for @!#{tag_name}" +
+      YARD.log.warn "Invalid directive format for @!#{tag_name}" +
         (object ? " in file `#{object.file}` near line #{object.line}" : "")
       nil
     end
@@ -307,12 +307,12 @@ module YARD
         next if tag.is_a?(Tags::RefTagList) # we don't handle this yet
         next unless tag.tag_name == "param"
         if seen_names.include?(tag.name)
-          log.warn "@param tag has duplicate parameter name: " +
+          YARD.log.warn "@param tag has duplicate parameter name: " +
             "#{tag.name} #{infile_info}"
         elsif names.include?(tag.name)
           seen_names << tag.name
         else
-          log.warn "@param tag has unknown parameter name: " +
+          YARD.log.warn "@param tag has unknown parameter name: " +
             "#{tag.name} #{infile_info}"
         end
       end

--- a/lib/yard/globals.rb
+++ b/lib/yard/globals.rb
@@ -8,11 +8,3 @@ def P(namespace, name = nil, type = nil)
   namespace, name = nil, namespace if name.nil?
   YARD::Registry.resolve(namespace, name, false, true, type)
 end
-
-# The global {YARD::Logger} instance
-#
-# @return [YARD::Logger] the global {YARD::Logger} instance
-# @see YARD::Logger
-def log
-  YARD::Logger.instance
-end

--- a/lib/yard/handlers/base.rb
+++ b/lib/yard/handlers/base.rb
@@ -564,7 +564,7 @@ module YARD
         retries = 0
         while object.is_a?(Proxy)
           if retries <= max_retries
-            log.debug "Missing object #{object} in file `#{parser.file}', moving it to the back of the line."
+            YARD.log.debug "Missing object #{object} in file `#{parser.file}', moving it to the back of the line."
             parser.parse_remaining_files
           else
             raise NamespaceMissingError, object

--- a/lib/yard/handlers/c/base.rb
+++ b/lib/yard/handlers/c/base.rb
@@ -89,11 +89,11 @@ module YARD
           return if processed_files[file]
           processed_files[file] = file
           begin
-            log.debug "Processing embedded call to C source #{file}..."
+            YARD.log.debug "Processing embedded call to C source #{file}..."
             globals.ordered_parser.files.delete(file) if globals.ordered_parser
             parser.process(Parser::C::CParser.new(File.read(file), file).parse)
           rescue Errno::ENOENT
-            log.warn "Missing source file `#{file}' when parsing #{object}"
+            YARD.log.warn "Missing source file `#{file}' when parsing #{object}"
           end
         end
 

--- a/lib/yard/handlers/processor.rb
+++ b/lib/yard/handlers/processor.rb
@@ -113,20 +113,20 @@ module YARD
             begin
               handler.new(self, stmt).process
             rescue HandlerAborted => abort
-              log.debug "#{handler.to_s} cancelled from #{caller.last}"
-              log.debug "\tin file '#{file}':#{stmt.line}:\n\n" + stmt.show + "\n"
+              YARD.log.debug "#{handler.to_s} cancelled from #{caller.last}"
+              YARD.log.debug "\tin file '#{file}':#{stmt.line}:\n\n" + stmt.show + "\n"
             rescue NamespaceMissingError => missingerr
-              log.warn "The #{missingerr.object.type} #{missingerr.object.path} has not yet been recognized."
-              log.warn "If this class/method is part of your source tree, this will affect your documentation results."
-              log.warn "You can correct this issue by loading the source file for this object before `#{file}'"
-              log.warn
+              YARD.log.warn "The #{missingerr.object.type} #{missingerr.object.path} has not yet been recognized."
+              YARD.log.warn "If this class/method is part of your source tree, this will affect your documentation results."
+              YARD.log.warn "You can correct this issue by loading the source file for this object before `#{file}'"
+              YARD.log.warn
             rescue Parser::UndocumentableError => undocerr
-              log.warn "in #{handler.to_s}: Undocumentable #{undocerr.message}"
-              log.warn "\tin file '#{file}':#{stmt.line}:\n\n" + stmt.show + "\n"
+              YARD.log.warn "in #{handler.to_s}: Undocumentable #{undocerr.message}"
+              YARD.log.warn "\tin file '#{file}':#{stmt.line}:\n\n" + stmt.show + "\n"
             rescue => e
-              log.error "Unhandled exception in #{handler.to_s}:"
-              log.error "  in `#{file}`:#{stmt.line}:\n\n#{stmt.show}\n"
-              log.backtrace(e)
+              YARD.log.error "Unhandled exception in #{handler.to_s}:"
+              YARD.log.error "  in `#{file}`:#{stmt.line}:\n\n#{stmt.show}\n"
+              YARD.log.backtrace(e)
             end
           end
         end
@@ -141,7 +141,7 @@ module YARD
       def parse_remaining_files
         if globals.ordered_parser
           globals.ordered_parser.parse
-          log.debug("Re-processing #{@file}...")
+          YARD.log.debug("Re-processing #{@file}...")
         end
       end
 

--- a/lib/yard/i18n/po_parser.rb
+++ b/lib/yard/i18n/po_parser.rb
@@ -11,8 +11,8 @@ module YARD
           require "gettext/runtime/mofile"
           @@gettext_version = 2
         rescue LoadError
-          log.warn "Need gettext gem 2.x for i18n feature:"
-          log.warn "  gem install gettext -v 2.3.9"
+          YARD.log.warn "Need gettext gem 2.x for i18n feature:"
+          YARD.log.warn "  gem install gettext -v 2.3.9"
         end
       else
         begin
@@ -25,8 +25,8 @@ module YARD
             require "gettext/runtime/mofile"
             @@gettext_version = 2
           rescue LoadError
-            log.warn "Need gettext gem for i18n feature:"
-            log.warn "  gem install gettext"
+            YARD.log.warn "Need gettext gem for i18n feature:"
+            YARD.log.warn "  gem install gettext"
           end
         end
       end

--- a/lib/yard/options.rb
+++ b/lib/yard/options.rb
@@ -168,10 +168,10 @@ module YARD
     #   an Options object. Instead, register the attribute before using it.
     def method_missing(meth, *args, &block)
       if meth.to_s =~ /^(.+)=$/
-        log.debug "Attempting to set unregistered key #{$1} on #{self.class}"
+        YARD.log.debug "Attempting to set unregistered key #{$1} on #{self.class}"
         instance_variable_set("@#{$1}", args.first)
       elsif args.size == 0
-        log.debug "Attempting to access unregistered key #{meth} on #{self.class}"
+        YARD.log.debug "Attempting to access unregistered key #{meth} on #{self.class}"
         instance_variable_get("@#{meth}")
       else
         super

--- a/lib/yard/parser/source_parser.rb
+++ b/lib/yard/parser/source_parser.rb
@@ -40,7 +40,7 @@ module YARD
       # @see Processor#parse_remaining_files
       def parse
         while file = files.shift
-          log.capture("Parsing #{file}") do
+          YARD.log.capture("Parsing #{file}") do
             SourceParser.new(SourceParser.parser_type, @global_state).parse(file)
           end
         end
@@ -90,8 +90,8 @@ module YARD
         # @param [Fixnum] level the logger level to use during parsing. See
         #   {YARD::Logger}
         # @return [void]
-        def parse(paths = ["{lib,app}/**/*.rb", "ext/**/*.c"], excluded = [], level = log.level)
-          log.debug("Parsing #{paths.inspect} with `#{parser_type}` parser")
+        def parse(paths = ["{lib,app}/**/*.rb", "ext/**/*.c"], excluded = [], level = YARD.log.level)
+          YARD.log.debug("Parsing #{paths.inspect} with `#{parser_type}` parser")
           excluded = excluded.map do |path|
             case path
             when Regexp; path
@@ -103,7 +103,7 @@ module YARD
             map {|p| p.include?("*") ? Dir[p].sort_by {|f| f.length } : p }.flatten.
             reject {|p| !File.file?(p) || excluded.any? {|re| p =~ re } }
 
-          log.enter_level(level) do
+          YARD.log.enter_level(level) do
             parse_in_order(*files.uniq)
           end
         end
@@ -421,7 +421,7 @@ module YARD
           return if Registry.checksums[file] == checksum
 
           if Registry.checksums.has_key?(file)
-            log.info "File '#{file}' was modified, re-processing..."
+            YARD.log.info "File '#{file}' was modified, re-processing..."
           end
           Registry.checksums[@file] = checksum
           self.parser_type = parser_type_for_filename(file)
@@ -445,11 +445,11 @@ module YARD
 
         @parser
       rescue ArgumentError, NotImplementedError => e
-        log.warn("Cannot parse `#{file}': #{e.message}")
-        log.backtrace(e, :warn)
+        YARD.log.warn("Cannot parse `#{file}': #{e.message}")
+        YARD.log.backtrace(e, :warn)
       rescue ParserSyntaxError => e
-        log.warn(e.message.capitalize)
-        log.backtrace(e, :warn)
+        YARD.log.warn(e.message.capitalize)
+        YARD.log.backtrace(e, :warn)
       end
 
       # Tokenizes but does not parse the block of code using the current {#parser_type}

--- a/lib/yard/registry_store.rb
+++ b/lib/yard/registry_store.rb
@@ -149,7 +149,7 @@ module YARD
     def load_all
       return unless @file
       return if @loaded_objects >= @available_objects
-      log.debug "Loading entire database: #{@file} ..."
+      YARD.log.debug "Loading entire database: #{@file} ..."
       objects = []
 
       all_disk_objects.sort_by {|x| x.size }.each do |path|
@@ -161,7 +161,7 @@ module YARD
         put(obj.path, obj)
       end
       @loaded_objects += objects.size
-      log.debug "Loaded database (file='#{@file}' count=#{objects.size} total=#{@available_objects})"
+      YARD.log.debug "Loaded database (file='#{@file}' count=#{objects.size} total=#{@available_objects})"
     end
 
     # Saves the database to disk
@@ -282,7 +282,7 @@ module YARD
       if root = @serializer.deserialize('root')
         @loaded_objects += 1
         if root.is_a?(Hash) # single object db
-          log.debug "Loading single object DB from .yardoc"
+          YARD.log.debug "Loading single object DB from .yardoc"
           @loaded_objects += (root.keys.size - 1)
           @store = root
         else # just the root object

--- a/lib/yard/serializers/file_system_serializer.rb
+++ b/lib/yard/serializers/file_system_serializer.rb
@@ -35,7 +35,7 @@ module YARD
       # @return [String] the written data (for chaining)
       def serialize(object, data)
         path = File.join(basepath, serialized_path(object))
-        log.debug "Serializing to #{path}"
+        YARD.log.debug "Serializing to #{path}"
         File.open!(path, "wb") {|f| f.write data }
       end
 

--- a/lib/yard/serializers/yardoc_serializer.rb
+++ b/lib/yard/serializers/yardoc_serializer.rb
@@ -73,10 +73,10 @@ module YARD
       def deserialize(path, is_path = false)
         path = File.join(basepath, serialized_path(path)) unless is_path
         if File.file?(path)
-          log.debug "Deserializing #{path}..."
+          YARD.log.debug "Deserializing #{path}..."
           Marshal.load(File.read_binary(path))
         else
-          log.debug "Could not find #{path}"
+          YARD.log.debug "Could not find #{path}"
           nil
         end
       end

--- a/lib/yard/server/adapter.rb
+++ b/lib/yard/server/adapter.rb
@@ -76,9 +76,9 @@ module YARD
         self.document_root = server_options[:DocumentRoot]
         self.router = (options[:router] || Router).new(self)
         options[:adapter] = self
-        log.debug "Serving libraries using #{self.class}: #{libraries.keys.join(', ')}"
-        log.debug "Caching on" if options[:caching]
-        log.debug "Document root: #{document_root}" if document_root
+        YARD.log.debug "Serving libraries using #{self.class}: #{libraries.keys.join(', ')}"
+        YARD.log.debug "Caching on" if options[:caching]
+        YARD.log.debug "Document root: #{document_root}" if document_root
       end
 
       # Adds a library to the {#libraries} mapping for a given library object.

--- a/lib/yard/server/commands/base.rb
+++ b/lib/yard/server/commands/base.rb
@@ -161,7 +161,7 @@ module YARD
             path = File.join(adapter.document_root, request.path.sub(/\.html$/, '') + '.html')
             path = path.sub(%r{/\.html$}, '.html')
             FileUtils.mkdir_p(File.dirname(path))
-            log.debug "Caching data to #{path}"
+            YARD.log.debug "Caching data to #{path}"
             File.open(path, 'wb') {|f| f.write(data) }
           end
           self.body = data

--- a/lib/yard/server/commands/library_command.rb
+++ b/lib/yard/server/commands/library_command.rb
@@ -108,7 +108,7 @@ module YARD
         def load_yardoc
           raise LibraryNotPreparedError unless library.yardoc_file
           if Thread.current[:__yard_last_yardoc__] == library.yardoc_file
-            log.debug "Reusing yardoc file: #{library.yardoc_file}"
+            YARD.log.debug "Reusing yardoc file: #{library.yardoc_file}"
             return
           end
           Registry.clear

--- a/lib/yard/server/library_version.rb
+++ b/lib/yard/server/library_version.rb
@@ -195,7 +195,7 @@ module YARD
         unless yardoc_file && File.directory?(yardoc_file)
           Thread.new do
             # Build gem docs on demand
-            log.debug "Building gem docs for #{to_s(false)}"
+            YARD.log.debug "Building gem docs for #{to_s(false)}"
             CLI::Gems.run(name, ver)
             self.yardoc_file = Registry.yardoc_file_for_gem(name, ver)
             FileUtils.touch(File.join(yardoc_file, 'complete'))

--- a/lib/yard/server/rack_adapter.rb
+++ b/lib/yard/server/rack_adapter.rb
@@ -50,7 +50,7 @@ module YARD
         request.path_info = unescape(request.path_info) # unescape things like %3F
         router.call(request)
       rescue StandardError => ex
-        log.backtrace(ex)
+        YARD.log.backtrace(ex)
         [500, {'Content-Type' => 'text/plain'},
           [ex.message + "\n" + ex.backtrace.join("\n")]]
       end
@@ -69,12 +69,12 @@ module YARD
 
       def print_start_message(server)
         opts = server.default_options.merge(server.options)
-        log.puts ">> YARD #{YARD::VERSION} documentation server at http://#{opts[:Host]}:#{opts[:Port]}"
+        YARD.log.puts ">> YARD #{YARD::VERSION} documentation server at http://#{opts[:Host]}:#{opts[:Port]}"
 
         # Only happens for Mongrel
         return unless server.server.to_s == "Rack::Handler::Mongrel"
-        log.puts ">> #{server.server.class_name} web server (running on Rack)"
-        log.puts ">> Listening on #{opts[:Host]}:#{opts[:Port]}, CTRL+C to stop"
+        YARD.log.puts ">> #{server.server.class_name} web server (running on Rack)"
+        YARD.log.puts ">> Listening on #{opts[:Host]}:#{opts[:Port]}, CTRL+C to stop"
       end
     end
   end

--- a/lib/yard/server/static_caching.rb
+++ b/lib/yard/server/static_caching.rb
@@ -35,7 +35,7 @@ module YARD
         cache_path = File.join(adapter.document_root, request.path.sub(/\.html$/, '') + '.html')
         cache_path = cache_path.sub(%r{/\.html$}, '.html')
         if File.file?(cache_path)
-          log.debug "Loading cache from disk: #{cache_path}"
+          YARD.log.debug "Loading cache from disk: #{cache_path}"
           return [200, {'Content-Type' => 'text/html'}, [File.read_binary(cache_path)]]
         end
         nil

--- a/lib/yard/tags/directives.rb
+++ b/lib/yard/tags/directives.rb
@@ -318,7 +318,7 @@ module YARD
 
       def warn
         if object && handler
-          log.warn "Invalid/missing macro name for " +
+          YARD.log.warn "Invalid/missing macro name for " +
             "#{object.path} (#{handler.parser.file}:#{handler.statement.line})"
         end
       end

--- a/lib/yard/templates/engine.rb
+++ b/lib/yard/templates/engine.rb
@@ -117,7 +117,7 @@ module YARD
           if serializer.respond_to?(:basepath)
             filename = File.join(serializer.basepath, filename)
           end
-          log.capture("Generating #{filename}", nil) do
+          YARD.log.capture("Generating #{filename}", nil) do
             serializer.before_serialize if serializer
             output = yield
             if serializer

--- a/lib/yard/templates/helpers/base_helper.rb
+++ b/lib/yard/templates/helpers/base_helper.rb
@@ -60,12 +60,12 @@ module YARD::Templates::Helpers
           file = $1
           relpath = File.relative_path(Dir.pwd, File.expand_path(file))
           if relpath =~ /^\.\./
-            log.warn "Cannot include file from path `#{file}'"
+            YARD.log.warn "Cannot include file from path `#{file}'"
             ""
           elsif File.file?(file)
             link_include_file(file)
           else
-            log.warn "Cannot find file at `#{file}' for inclusion"
+            YARD.log.warn "Cannot find file at `#{file}' for inclusion"
             ""
           end
         when /^include:(\S+)/
@@ -73,7 +73,7 @@ module YARD::Templates::Helpers
           if obj = YARD::Registry.resolve(object.namespace, path)
             link_include_object(obj)
           else
-            log.warn "Cannot find object at `#{path}' for inclusion"
+            YARD.log.warn "Cannot find object at `#{path}' for inclusion"
             ""
           end
         when /^render:(\S+)/

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -214,8 +214,8 @@ module YARD
               match = /(.+)?(\{#{Regexp.quote name}(?:\s.*?)?\})(.+)?/.match(text)
               file = (@file ? @file.filename : object.file) || '(unknown)'
               line = (@file ? 1 : (object.docstring.line_range ? object.docstring.line_range.first : 1)) + (match ? $`.count("\n") : 0)
-              log.warn "In file `#{file}':#{line}: Cannot resolve link to #{name} from text" + (match ? ":" : ".")
-              log.warn((match[1] ? '...' : '') + match[2].gsub("\n","") + (match[3] ? '...' : '')) if match
+              YARD.log.warn "In file `#{file}':#{line}: Cannot resolve link to #{name} from text" + (match ? ":" : ".")
+              YARD.log.warn((match[1] ? '...' : '') + match[2].gsub("\n","") + (match[3] ? '...' : '')) if match
             end
 
             link

--- a/lib/yard/templates/helpers/markup_helper.rb
+++ b/lib/yard/templates/helpers/markup_helper.rb
@@ -89,7 +89,7 @@ module YARD
         end
 
         if providers == nil || providers.empty?
-          log.error "Invalid markup type '#{type}' or markup provider " +
+          YARD.log.error "Invalid markup type '#{type}' or markup provider " +
             "(#{options.markup_provider}) is not registered."
           return false
         end
@@ -105,7 +105,7 @@ module YARD
 
         # Show error message telling user to install first potential provider
         name, lib = *[providers.first[:const], providers.first[:lib] || type]
-        log.error "Missing '#{lib}' gem for #{type.to_s.capitalize} formatting. Install it with `gem install #{lib}`"
+        YARD.log.error "Missing '#{lib}' gem for #{type.to_s.capitalize} formatting. Install it with `gem install #{lib}`"
         false
       end
 

--- a/spec/cli/command_spec.rb
+++ b/spec/cli/command_spec.rb
@@ -15,20 +15,20 @@ describe YARD::CLI::Command do
     end
 
     it "should skip unrecognized options but continue to next option" do
-      log.should_receive(:warn).with(/Unrecognized.*--list/)
-      log.should_receive(:warn).with(/Unrecognized.*--list2/)
+      YARD.log.should_receive(:warn).with(/Unrecognized.*--list/)
+      YARD.log.should_receive(:warn).with(/Unrecognized.*--list2/)
       parse('--list', '--list2', '--foo')
       @saw_foo.should be_true
     end
 
     it "should skip unrecognized options and any extra non-option arg that follows" do
-      log.should_receive(:warn).with(/Unrecognized.*--list/)
+      YARD.log.should_receive(:warn).with(/Unrecognized.*--list/)
       parse('--list', 'foo', '--foo')
       @saw_foo.should be_true
     end
 
     it "should stop retrying to parse at non-switch argument" do
-      log.should_receive(:warn).with(/Unrecognized.*--list/)
+      YARD.log.should_receive(:warn).with(/Unrecognized.*--list/)
       args = parse('--list', 'foo', 'foo', 'foo')
       args.should == %w(foo foo)
     end

--- a/spec/cli/config_spec.rb
+++ b/spec/cli/config_spec.rb
@@ -17,7 +17,7 @@ describe YARD::CLI::Config do
     it "should accept --list" do
       opts = YARD::Config.options
       YAML.should_receive(:dump).twice.and_return("--- foo\nbar\nbaz")
-      log.should_receive(:puts).twice.with("bar\nbaz")
+      YARD.log.should_receive(:puts).twice.with("bar\nbaz")
       run
       run('--list')
       YARD::Config.options.should == opts
@@ -27,7 +27,7 @@ describe YARD::CLI::Config do
   describe 'Viewing an item' do
     it "should view item if no value is given" do
       YARD::Config.options[:foo] = 'bar'
-      log.should_receive(:puts).with('"bar"')
+      YARD.log.should_receive(:puts).with('"bar"')
       run 'foo'
       YARD::Config.options[:foo].should == 'bar'
     end

--- a/spec/cli/diff_spec.rb
+++ b/spec/cli/diff_spec.rb
@@ -12,7 +12,7 @@ describe YARD::CLI::Diff do
   describe 'Argument handling' do
     it "should exit if there is only one gem name" do
       @diff.should_receive(:exit)
-      log.should_receive(:puts).with(/Usage/)
+      YARD.log.should_receive(:puts).with(/Usage/)
       @diff.run
     end
   end
@@ -58,8 +58,8 @@ describe YARD::CLI::Diff do
           end
         eof
       end
-      log.stub!(:print) {|data| @data << data }
-      log.stub!(:puts) {|*args| @data << args.join("\n"); @data << "\n" }
+      YARD.log.stub!(:print) {|data| @data << data }
+      YARD.log.stub!(:puts) {|*args| @data << args.join("\n"); @data << "\n" }
       @diff.run(*(args + ['gem1', 'gem2']))
     end
 
@@ -251,8 +251,8 @@ eof
     end
 
     it "should error if gem is not found" do
-      log.should_receive(:error).with("Cannot find gem gem1")
-      log.should_receive(:error).with("Cannot find gem gem2.gem")
+      YARD.log.should_receive(:error).with("Cannot find gem gem1")
+      YARD.log.should_receive(:error).with("Cannot find gem gem2.gem")
       @diff.stub!(:load_gem_data).and_return(false)
       @diff.run('gem1', 'gem2.gem')
     end

--- a/spec/cli/display_spec.rb
+++ b/spec/cli/display_spec.rb
@@ -9,13 +9,13 @@ describe YARD::CLI::Display do
 
   it "displays an object" do
     YARD::CLI::Display.run('-f', 'text', 'Foo')
-    log.io.string.strip.should eq(@object.format.strip)
+    YARD.log.io.string.strip.should eq(@object.format.strip)
   end
 
   it "wraps output with -l (defaulting to layout)" do
     YARD::CLI::Display.run('-l', '-f', 'html', 'Foo')
     formatted_output = @object.format(:format => :html).strip
-    actual_output = log.io.string.strip
+    actual_output = YARD.log.io.string.strip
     actual_output.should_not eq(formatted_output)
     actual_output.should include(formatted_output)
   end
@@ -23,7 +23,7 @@ describe YARD::CLI::Display do
   it "wraps output with --layout onefile" do
     YARD::CLI::Display.run('--layout', 'onefile', '-f', 'html', 'Foo')
     formatted_output = @object.format(:format => :html).strip
-    actual_output = log.io.string.strip
+    actual_output = YARD.log.io.string.strip
     actual_output.should_not eq(formatted_output)
     actual_output.should include(formatted_output)
   end

--- a/spec/cli/gems_spec.rb
+++ b/spec/cli/gems_spec.rb
@@ -59,15 +59,15 @@ describe YARD::CLI::Gems do
       build_specs(@gem2)
       Gem.source_index.should_receive(:find_name).with(@gem1.name, '>= 2.0').and_return([])
       Gem.source_index.should_receive(:find_name).with(@gem2.name, '>= 0').and_return([@gem2])
-      log.should_receive(:warn).with(/#{@gem1.name} >= 2.0 could not be found/)
+      YARD.log.should_receive(:warn).with(/#{@gem1.name} >= 2.0 could not be found/)
       CLI::Gems.run(@gem1.name, '>= 2.0', @gem2.name)
     end
 
     it "should fail if specified gem(s) is/are not found" do
       CLI::Yardoc.should_not_receive(:run)
       Gem.source_index.should_receive(:find_name).with(@gem1.name, '>= 2.0').and_return([])
-      log.should_receive(:warn).with(/#{@gem1.name} >= 2.0 could not be found/)
-      log.should_receive(:error).with(/No specified gems could be found/)
+      YARD.log.should_receive(:warn).with(/#{@gem1.name} >= 2.0 could not be found/)
+      YARD.log.should_receive(:error).with(/No specified gems could be found/)
       CLI::Gems.run(@gem1.name, '>= 2.0')
     end
 

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -15,7 +15,7 @@ describe YARD::CLI::Help do
     it "should show all commands if command isn't found" do
       CLI::CommandParser.should_receive(:run).with('--help')
       help = CLI::Help.new
-      log.should_receive(:puts).with(/not found/)
+      YARD.log.should_receive(:puts).with(/not found/)
       help.run('unknown')
     end
   end

--- a/spec/cli/markup_types_spec.rb
+++ b/spec/cli/markup_types_spec.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/../spec_helper'
 describe YARD::CLI::MarkupTypes do
   it "lists all available markup types" do
     YARD::CLI::MarkupTypes.run
-    data = log.io.string
+    data = YARD.log.io.string
     exts = YARD::Templates::Helpers::MarkupHelper::MARKUP_EXTENSIONS
     YARD::Templates::Helpers::MarkupHelper::MARKUP_PROVIDERS.each do |name, providers|
       data.should match(/\b#{name}\b/)

--- a/spec/cli/server_spec.rb
+++ b/spec/cli/server_spec.rb
@@ -137,7 +137,7 @@ describe YARD::CLI::Server do
     it "should fail if specified directory does not exist" do
       @set_libraries = false
       File.stub(:exist?).with('b').and_return(false)
-      log.should_receive(:warn).with(/Cannot find yardoc db for a: "b"/)
+      YARD.log.should_receive(:warn).with(/Cannot find yardoc db for a: "b"/)
       run %w(a b)
     end
   end
@@ -289,13 +289,13 @@ describe YARD::CLI::Server do
       bundler_required
       File.should_receive(:exist?).with(/\.yardopts$/).at_least(:once).and_return(false)
       File.should_receive(:exist?).with('somefile.lock').and_return(false)
-      log.should_receive(:warn).with(/Cannot find somefile.lock/)
+      YARD.log.should_receive(:warn).with(/Cannot find somefile.lock/)
       run '-G', 'somefile'
     end
 
     it "should error if Bundler not available (with -G)" do
       @cli.should_receive(:require).with('bundler').and_raise(LoadError)
-      log.should_receive(:error).with(/Bundler not available/)
+      YARD.log.should_receive(:error).with(/Bundler not available/)
       run '-G'
     end
 

--- a/spec/cli/stats_spec.rb
+++ b/spec/cli/stats_spec.rb
@@ -28,7 +28,7 @@ describe YARD::CLI::Stats do
     @stats = CLI::Stats.new(false)
     @stats.stub!(:support_rdoc_document_file!).and_return([])
     @stats.stub!(:yardopts).and_return([])
-    log.stub!(:puts) {|*args| @output << args.join("\n") << "\n" }
+    YARD.log.stub!(:puts) {|*args| @output << args.join("\n") << "\n" }
   end
 
   it "should list undocumented objects with --list-undoc" do

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -273,7 +273,7 @@ describe YARD::CLI::Yardoc do
       end
 
       it "should not allow from or to to refer to a path above current path" do
-        log.should_receive(:warn).exactly(4).times.with(/invalid/i)
+        YARD.log.should_receive(:warn).exactly(4).times.with(/invalid/i)
         @yardoc.run *%w( --asset ../../../etc/passwd )
         @yardoc.assets.should be_empty
         @yardoc.run *%w( --asset a/b/c/d/../../../../../../etc/passwd )
@@ -596,12 +596,12 @@ describe YARD::CLI::Yardoc do
     end
 
     it "should warn if extra file is not found" do
-      log.should_receive(:warn).with(/Could not find extra file: UNKNOWN/)
+      YARD.log.should_receive(:warn).with(/Could not find extra file: UNKNOWN/)
       @yardoc.parse_arguments *%w( - UNKNOWN )
     end
 
     it "should warn if readme file is not found" do
-      log.should_receive(:warn).with(/Could not find readme file: UNKNOWN/)
+      YARD.log.should_receive(:warn).with(/Could not find readme file: UNKNOWN/)
       @yardoc.parse_arguments *%w( -r UNKNOWN )
     end
 
@@ -623,7 +623,7 @@ describe YARD::CLI::Yardoc do
     it "should not allow US-ASCII charset when using --one-file" do
       ienc = Encoding.default_internal
       eenc = Encoding.default_external
-      log.should_receive(:warn).with(/not compatible with US-ASCII.*using ASCII-8BIT/)
+      YARD.log.should_receive(:warn).with(/not compatible with US-ASCII.*using ASCII-8BIT/)
       @yardoc.parse_arguments *%w( --one-file --charset us-ascii )
       Encoding.default_internal.name.should == 'ASCII-8BIT'
       Encoding.default_external.name.should == 'ASCII-8BIT'
@@ -755,7 +755,7 @@ describe YARD::CLI::Yardoc do
       mod = YARD::Templates::Helpers::MarkupHelper
       mod.clear_markup_cache
       mod.const_get(:MARKUP_PROVIDERS).should_receive(:[]).with(:rdoc).and_return([{:lib => 'INVALID'}])
-      log.should_receive(:warn).with(/Could not load default RDoc formatter/)
+      YARD.log.should_receive(:warn).with(/Could not load default RDoc formatter/)
       @yardoc.stub(:generate) { @yardoc.options.files = []; true }
       @yardoc.run
       @yardoc.options.markup.should == :none
@@ -766,7 +766,7 @@ describe YARD::CLI::Yardoc do
       mod = YARD::Templates::Helpers::MarkupHelper
       mod.clear_markup_cache
       mod.const_get(:MARKUP_PROVIDERS).should_receive(:[]).with(:markdown).and_return([{:lib => 'INVALID'}])
-      log.should_receive(:error).with(/Missing 'INVALID' gem for Markdown formatting/)
+      YARD.log.should_receive(:error).with(/Missing 'INVALID' gem for Markdown formatting/)
       files = [CodeObjects::ExtraFileObject.new('test.md', '')]
       @yardoc.stub(:generate) { @yardoc.options.files = files; true }
       @yardoc.run
@@ -777,7 +777,7 @@ describe YARD::CLI::Yardoc do
       mod = YARD::Templates::Helpers::MarkupHelper
       mod.clear_markup_cache
       mod.const_get(:MARKUP_PROVIDERS).should_receive(:[]).with(:markdown).and_return([{:lib => 'INVALID'}])
-      log.should_receive(:error).with(/Missing 'INVALID' gem for Markdown formatting/)
+      YARD.log.should_receive(:error).with(/Missing 'INVALID' gem for Markdown formatting/)
       files = [CodeObjects::ExtraFileObject.new('test', '# @markup markdown')]
       @yardoc.stub(:generate) { @yardoc.options.files = files; true }
       @yardoc.run

--- a/spec/code_objects/extra_file_object_spec.rb
+++ b/spec/code_objects/extra_file_object_spec.rb
@@ -66,7 +66,7 @@ describe YARD::CodeObjects::ExtraFileObject do
     end
 
     it "should force encoding to @encoding attribute if present" do
-      log.should_not_receive(:warn)
+      YARD.log.should_not_receive(:warn)
       data = "# @encoding sjis\nFOO"
       data.force_encoding('binary')
       file = ExtraFileObject.new('file.txt', data)
@@ -74,7 +74,7 @@ describe YARD::CodeObjects::ExtraFileObject do
     end if YARD.ruby19?
 
     it "should warn if @encoding is invalid" do
-      log.should_receive(:warn).with("Invalid encoding `INVALID' in file.txt")
+      YARD.log.should_receive(:warn).with("Invalid encoding `INVALID' in file.txt")
       data = "# @encoding INVALID\nFOO"
       encoding = data.encoding
       file = ExtraFileObject.new('file.txt', data)
@@ -82,12 +82,12 @@ describe YARD::CodeObjects::ExtraFileObject do
     end if YARD.ruby19?
 
     it "should ignore encoding in 1.8.x (or encoding-unaware platforms)" do
-      log.should_not_receive(:warn)
+      YARD.log.should_not_receive(:warn)
       file = ExtraFileObject.new('file.txt', "# @encoding INVALID\nFOO")
     end if YARD.ruby18?
 
     it "should attempt to re-parse data as 8bit ascii if parsing fails" do
-      log.should_not_receive(:warn)
+      YARD.log.should_not_receive(:warn)
       str, out = *(["\xB0"] * 2)
       if str.respond_to?(:force_encoding)
         str.force_encoding('utf-8')

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -56,7 +56,7 @@ describe YARD::Config do
   describe '.load_plugin' do
     it "should load a plugin by 'name' as 'yard-name'" do
       YARD::Config.should_receive(:require).with('yard-foo')
-      log.should_receive(:debug).with(/Loading plugin 'yard-foo'/).once
+      YARD.log.should_receive(:debug).with(/Loading plugin 'yard-foo'/).once
       YARD::Config.load_plugin('foo').should == true
     end
 
@@ -68,20 +68,20 @@ describe YARD::Config do
 
     it "should load plugin by 'yard-name' as 'yard-name'" do
       YARD::Config.should_receive(:require).with('yard-foo')
-      log.should_receive(:debug).with(/Loading plugin 'yard-foo'/).once
+      YARD.log.should_receive(:debug).with(/Loading plugin 'yard-foo'/).once
       YARD::Config.load_plugin('yard-foo').should == true
     end
 
     it "should load plugin by 'yard_name' as 'yard_name'" do
       YARD::Config.should_receive(:require).with('yard_foo')
-      log.should_receive(:debug).with(/Loading plugin 'yard_foo'/).once
-      log.show_backtraces = false
+      YARD.log.should_receive(:debug).with(/Loading plugin 'yard_foo'/).once
+      YARD.log.show_backtraces = false
       YARD::Config.load_plugin('yard_foo').should == true
     end
 
     it "should log error if plugin is not found" do
       YARD::Config.should_receive(:require).with('yard-foo').and_raise(LoadError)
-      log.should_receive(:warn).with(/Error loading plugin 'yard-foo'/).once
+      YARD.log.should_receive(:warn).with(/Error loading plugin 'yard-foo'/).once
       YARD::Config.load_plugin('yard-foo').should == false
     end
 
@@ -169,7 +169,7 @@ describe YARD::Config do
       source_mock.should_receive(:find_name).with('').and_return(plugins.values)
       Gem.should_receive(:source_index).and_return(source_mock)
       YARD::Config.should_receive(:load_plugin).with('yard-plugin').and_raise(Gem::LoadError)
-      log.should_receive(:warn).with(/Error loading plugin 'yard-plugin'/)
+      YARD.log.should_receive(:warn).with(/Error loading plugin 'yard-plugin'/)
       YARD::Config.load_plugins.should == false
     end
   end

--- a/spec/docstring_parser_spec.rb
+++ b/spec/docstring_parser_spec.rb
@@ -97,7 +97,7 @@ eof
     end
 
     it "should warn about unknown tag" do
-      log.should_receive(:warn).with(/Unknown tag @hello$/)
+      YARD.log.should_receive(:warn).with(/Unknown tag @hello$/)
       docstring("@hello world")
     end
 
@@ -136,7 +136,7 @@ eof
 
     it "should ignore new directives without @! prefix syntax" do
       TestLibrary.define_directive('dir1', Tags::ScopeDirective)
-      log.should_receive(:warn).with(/@dir1/)
+      YARD.log.should_receive(:warn).with(/@dir1/)
       docstring("@dir1")
     end
 
@@ -209,7 +209,7 @@ eof
     end
 
     it "should warn about invalid named parameters" do
-      log.should_receive(:warn).with(/@param tag has unknown parameter name: notaparam/)
+      YARD.log.should_receive(:warn).with(/@param tag has unknown parameter name: notaparam/)
       YARD.parse_string <<-eof
         # @param notaparam foo
         def foo(a) end
@@ -217,7 +217,7 @@ eof
     end
 
     it "should warn about duplicate named parameters" do
-      log.should_receive(:warn).with(/@param tag has duplicate parameter name: a/)
+      YARD.log.should_receive(:warn).with(/@param tag has duplicate parameter name: a/)
       YARD.parse_string <<-eof
         # @param a foo
         # @param a foo

--- a/spec/handlers/c/method_handler_spec.rb
+++ b/spec/handlers/c/method_handler_spec.rb
@@ -145,7 +145,7 @@ describe YARD::Handlers::C::MethodHandler do
   end
 
   it "should warn if other file can't be found" do
-    log.should_receive(:warn).with(/Missing source file `other.c' when parsing Foo#foo/)
+    YARD.log.should_receive(:warn).with(/Missing source file `other.c' when parsing Foo#foo/)
     parse <<-eof
       void Init_Foo() {
         mFoo = rb_define_module("Foo");

--- a/spec/handlers/class_condition_handler_spec.rb
+++ b/spec/handlers/class_condition_handler_spec.rb
@@ -54,8 +54,8 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassCondition
   end
 
   it "should not fail on complex conditions" do
-    log.should_not_receive(:warn)
-    log.should_not_receive(:error)
+    YARD.log.should_not_receive(:warn)
+    YARD.log.should_not_receive(:error)
     no_undoc_error "if defined?(A) && defined?(B); puts 'hi' end"
     no_undoc_error(<<-eof)
       (<<-TEST) unless defined?(ABCD_MODEL_TEST)

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -2,7 +2,7 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHandler" do
   before(:all) do
-    log.enter_level(Logger::ERROR) do
+    YARD.log.enter_level(Logger::ERROR) do
       parse_file :method_handler_001, __FILE__
     end
   end
@@ -170,7 +170,7 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHandler"
   end
 
   it "should warn if the macro name is invalid" do
-    log.should_receive(:warn).with(/Invalid directive.*@!macro/)
+    YARD.log.should_receive(:warn).with(/Invalid directive.*@!macro/)
     YARD.parse_string "class Foo\n# @!macro\ndef self.foo; end\nend"
   end
 

--- a/spec/handlers/processor_spec.rb
+++ b/spec/handlers/processor_spec.rb
@@ -27,8 +27,8 @@ describe YARD::Handlers::Processor do
     end
     stmt = OpenStruct.new(:line => 1, :show => 'SOURCE')
     @proc.stub!(:find_handlers).and_return([AbortHandlerProcessor])
-    log.should_receive(:debug).with(/AbortHandlerProcessor cancelled from/)
-    log.should_receive(:debug).with("\tin file '(stdin)':1:\n\nSOURCE\n")
+    YARD.log.should_receive(:debug).with(/AbortHandlerProcessor cancelled from/)
+    YARD.log.should_receive(:debug).with("\tin file '(stdin)':1:\n\nSOURCE\n")
     @proc.process([stmt])
   end
 end

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -3,33 +3,33 @@ require File.join(File.dirname(__FILE__), "spec_helper")
 describe YARD::Logger do
   describe '#show_backtraces' do
     it "should be true if debug level is on" do
-      log.show_backtraces = true
-      log.enter_level(Logger::DEBUG) do
-        log.show_backtraces = false
-        log.show_backtraces.should == true
+      YARD.log.show_backtraces = true
+      YARD.log.enter_level(Logger::DEBUG) do
+        YARD.log.show_backtraces = false
+        YARD.log.show_backtraces.should == true
       end
-      log.show_backtraces.should == false
+      YARD.log.show_backtraces.should == false
     end
   end
 
   describe '#backtrace' do
-    before { log.show_backtraces = true }
-    after { log.show_backtraces = false }
+    before { YARD.log.show_backtraces = true }
+    after { YARD.log.show_backtraces = false }
 
     it "should log backtrace in error by default" do
-      log.should_receive(:error).with("RuntimeError: foo")
-      log.should_receive(:error).with("Stack trace:\n\tline1\n\tline2\n")
+      YARD.log.should_receive(:error).with("RuntimeError: foo")
+      YARD.log.should_receive(:error).with("Stack trace:\n\tline1\n\tline2\n")
       exc = RuntimeError.new("foo")
       exc.set_backtrace(['line1', 'line2'])
-      log.enter_level(Logger::INFO) { log.backtrace(exc) }
+      YARD.log.enter_level(Logger::INFO) { YARD.log.backtrace(exc) }
     end
 
     it "should allow backtrace to be entered in other modes" do
-      log.should_receive(:warn).with("RuntimeError: foo")
-      log.should_receive(:warn).with("Stack trace:\n\tline1\n\tline2\n")
+      YARD.log.should_receive(:warn).with("RuntimeError: foo")
+      YARD.log.should_receive(:warn).with("Stack trace:\n\tline1\n\tline2\n")
       exc = RuntimeError.new("foo")
       exc.set_backtrace(['line1', 'line2'])
-      log.enter_level(Logger::INFO) { log.backtrace(exc, :warn) }
+      YARD.log.enter_level(Logger::INFO) { YARD.log.backtrace(exc, :warn) }
     end
   end
 end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -96,9 +96,9 @@ describe YARD::Options do
     end
 
     it "should print debugging messages about unregistered keys" do
-      log.should_receive(:debug).with("Attempting to access unregistered key bar on FooOptions")
+      YARD.log.should_receive(:debug).with("Attempting to access unregistered key bar on FooOptions")
       FooOptions.new.bar
-      log.should_receive(:debug).with("Attempting to set unregistered key bar on FooOptions")
+      YARD.log.should_receive(:debug).with("Attempting to set unregistered key bar on FooOptions")
       FooOptions.new.bar = 1
     end
   end

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -42,7 +42,7 @@ describe YARD::Parser::C::CParser do
 
       it "should stop searching for extra source file gracefully if file is not found" do
         File.should_receive(:read).with('extra.c').and_raise(Errno::ENOENT)
-        log.should_receive(:warn).with("Missing source file `extra.c' when parsing Multifile#extra")
+        YARD.log.should_receive(:warn).with("Missing source file `extra.c' when parsing Multifile#extra")
         parse(@contents)
         Registry.at('Multifile#extra').docstring.should == ''
       end

--- a/spec/parser/source_parser_spec.rb
+++ b/spec/parser/source_parser_spec.rb
@@ -599,10 +599,10 @@ describe YARD::Parser::SourceParser do
     end
 
     it "should attempt to parse files in order" do
-      log.enter_level(Logger::DEBUG) do
+      YARD.log.enter_level(Logger::DEBUG) do
         msgs = []
-        log.should_receive(:debug) {|m| msgs << m }.at_least(:once)
-        log.stub(:<<)
+        YARD.log.should_receive(:debug) {|m| msgs << m }.at_least(:once)
+        YARD.log.stub(:<<)
         in_order_parse 'parse_in_order_001', 'parse_in_order_002'
         msgs[1].should =~ /Parsing .+parse_in_order_001.+/
         msgs[2].should =~ /Missing object MyModule/
@@ -638,15 +638,15 @@ describe YARD::Parser::SourceParser do
     end
 
     it "should display a warning for invalid parser type" do
-      log.should_receive(:warn).with(/unrecognized file/)
-      log.should_receive(:backtrace)
+      YARD.log.should_receive(:warn).with(/unrecognized file/)
+      YARD.log.should_receive(:backtrace)
       YARD::Parser::SourceParser.parse_string("int main() { }", :d)
     end
 
     if HAVE_RIPPER
       it "should display a warning for a syntax error (with new parser)" do
-        log.should_receive(:warn).with(/Syntax error in/)
-        log.should_receive(:backtrace)
+        YARD.log.should_receive(:warn).with(/Syntax error in/)
+        YARD.log.should_receive(:backtrace)
         YARD::Parser::SourceParser.parse_string("%!!!", :ruby)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ unless defined?(HAVE_RIPPER)
   end if ENV['LEGACY']
 end
 
-def parse_file(file, thisfile = __FILE__, log_level = log.level, ext = '.rb.txt')
+def parse_file(file, thisfile = __FILE__, log_level = YARD.log.level, ext = '.rb.txt')
   Registry.clear
   path = File.join(File.dirname(thisfile), 'examples', file.to_s + ext)
   YARD::Parser::SourceParser.parse(path, [], log_level)
@@ -122,7 +122,7 @@ module Kernel
 end if ENV['TM_APP_PATH']
 
 RSpec.configure do |config|
-  config.before(:each) { log.io = StringIO.new }
+  config.before(:each) { YARD.log.io = StringIO.new }
 end
 
 include YARD

--- a/spec/templates/helpers/base_helper_spec.rb
+++ b/spec/templates/helpers/base_helper_spec.rb
@@ -90,7 +90,7 @@ describe YARD::Templates::Helpers::BaseHelper do
     end
 
     it "should return empty string and warn if object does not exist" do
-      log.should_receive(:warn).with(/Cannot find object .* for inclusion/)
+      YARD.log.should_receive(:warn).with(/Cannot find object .* for inclusion/)
       linkify('include:NotExist').should == ''
     end
 
@@ -113,12 +113,12 @@ describe YARD::Templates::Helpers::BaseHelper do
     end
 
     it "should not allow include:file for path above pwd" do
-      log.should_receive(:warn).with("Cannot include file from path `a/b/../../../../file'")
+      YARD.log.should_receive(:warn).with("Cannot include file from path `a/b/../../../../file'")
       linkify('include:file:a/b/../../../../file').should == ''
     end
 
     it "should warn if include:file:path does not exist" do
-      log.should_receive(:warn).with(/Cannot find file .+ for inclusion/)
+      YARD.log.should_receive(:warn).with(/Cannot find file .+ for inclusion/)
       linkify('include:file:notexist').should == ''
     end
   end

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -148,7 +148,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
     end
 
     it "should autolink URLs (markdown specific)" do
-      log.enter_level(Logger::FATAL) do
+      YARD.log.enter_level(Logger::FATAL) do
         unless markup_class(:markdown).to_s == "RedcarpetCompat"
           pending 'This test depends on a markdown engine that supports autolinking'
         end
@@ -158,7 +158,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
     end
 
     it "should not autolink URLs inside of {} (markdown specific)" do
-      log.enter_level(Logger::FATAL) do
+      YARD.log.enter_level(Logger::FATAL) do
         pending 'This test depends on markdown' unless markup_class(:markdown)
       end
       htmlify('{http://example.com Title}', :markdown).chomp.should =~
@@ -431,7 +431,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       logger = mock(:log)
       logger.should_receive(:warn).ordered.with("In file `(stdin)':2: Cannot resolve link to InvalidObject from text:")
       logger.should_receive(:warn).ordered.with("...{InvalidObject}")
-      stub!(:log).and_return(logger)
+      YARD.stub!(:log).and_return(logger)
       stub!(:object).and_return(Registry.at('MyObject'))
       resolve_links(object.docstring)
     end
@@ -453,7 +453,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       logger.should_receive(:warn).ordered.with("...{InvalidObject3}...")
       logger.should_receive(:warn).ordered.with("In file `(stdin)':4: Cannot resolve link to InvalidObject4 from text:")
       logger.should_receive(:warn).ordered.with("{InvalidObject4}")
-      stub!(:log).and_return(logger)
+      YARD.stub!(:log).and_return(logger)
       stub!(:object).and_return(Registry.at('MyObject'))
       resolve_links(object.docstring)
     end
@@ -463,7 +463,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
       logger = mock(:log)
       logger.should_receive(:warn).ordered.with("In file `myfile.txt':3: Cannot resolve link to InvalidObject from text:")
       logger.should_receive(:warn).ordered.with("...{InvalidObject Some Title}")
-      stub!(:log).and_return(logger)
+      YARD.stub!(:log).and_return(logger)
       stub!(:object).and_return(Registry.root)
       resolve_links(<<-eof)
         Hello world

--- a/spec/templates/helpers/markup_helper_spec.rb
+++ b/spec/templates/helpers/markup_helper_spec.rb
@@ -19,7 +19,7 @@ describe YARD::Templates::Helpers::MarkupHelper do
 
   describe '#load_markup_provider' do
     before do
-      log.stub!(:error)
+      YARD.log.stub!(:error)
       @gen = GeneratorMock.new
       @gen.options.reset_defaults
     end
@@ -101,7 +101,7 @@ describe YARD::Templates::Helpers::MarkupHelper do
     end
 
     it "should fail if the markup type is not found" do
-      log.should_receive(:error).with(/Invalid markup/)
+      YARD.log.should_receive(:error).with(/Invalid markup/)
       @gen.options.markup = :xxx
       @gen.load_markup_provider.should == false
       @gen.markup_provider.should == nil


### PR DESCRIPTION
## Background

I recently ran into [a bug](https://gist.github.com/iamvery/10763416) when using YARD with Savon 2.0's "block" syntax. Savon's block implementation (which is referred to as a ["little hack"](http://savonrb.com/version2/client.html)) presumably relies on some metaprogramming. When `yard` is loaded, Savon's `log` configuration invokes YARD's default logger rather than triggering the internals of Savon.

I came to the conclusion that YARD probably shouldn't pollute the top level namespace with a `log` method. I did see #641 which seemed to agree with my logic with a caveat directed at "discoverability". I'm not confident I understand the concern, but I'm offering an alternate implementation for your consideration.
## Implementation

I opted to implement this as a namespaced module which may be included/extended wherever logging is needed. Perhaps that's not the best longterm solution, but I like this as a first pass to reduce thrash on the existing code. All specs are green for me locally on Ruby 2.1.1

Please let me know what you think. I'm happy to maintain this PR until it's acceptable :+1: 
