### PR TITLE
Fix inverted conditional in Logger#show_progress

### DIFF
--- a/lib/yard/logging.rb
+++ b/lib/yard/logging.rb
@@ -26,7 +26,7 @@ module YARD
       return false if YARD.ruby18? # threading is too ineffective for progress support
       return false if YARD.windows? # windows has poor ANSI support
       return false unless io.tty? # no TTY support on IO
-      return false if level > WARN # no progress in verbose/debug modes
+      return false unless level > INFO # no progress in verbose/debug modes
       @show_progress
     end
     attr_writer :show_progress


### PR DESCRIPTION
Prior to this patch, YARD would show animated progress even when `--debug` was
specified. The progress animation renders any debugger REPL unusable, so having
a way to disable it from the command line is critical.
