### PR TITLE
Lax spacing in Redcarpet to comply with the Markdown standard

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ group :asciidoc do
 end
 
 group :markdown do
-  gem 'redcarpet', '= 1.17.2', :platforms => :mri
+  gem 'redcarpet', '= 2.3.0', :platforms => :mri
   gem 'kramdown', :platforms => :jruby
 end
 

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -61,7 +61,8 @@ module YARD
           provider.new(text, :autolink).to_html
         elsif provider.to_s == 'RedcarpetCompat'
           provider.new(text, :no_intraemphasis, :gh_blockcode,
-                             :fenced_code, :autolink, :tables).to_html
+                             :fenced_code, :autolink, :tables,
+                             :lax_spacing).to_html
         else
           provider.new(text).to_html
         end

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -183,8 +183,20 @@ describe YARD::Templates::Helpers::HtmlHelper do
 
       html = htmlify(markdown, :markdown)
       html.should =~ %r{<table>}
-      html.should =~ %r{<td>City</td>}
+      html.should =~ %r{<th>City</th>}
       html.should =~ %r{<td>NC</td>}
+    end
+
+    it 'should handle fenced code blocks (Redcarpet specific)' do
+      log.enter_level(Logger::FATAL) do
+        unless markup_class(:markdown).to_s == 'RedcarpetCompat'
+          pending 'This test is Redcarpet specific'
+        end
+      end
+
+      markdown = "Introduction:\n```ruby\nputs\n\nputs\n```"
+      html = htmlify(markdown, :markdown)
+      html.should =~ %r{^<p>Introduction:</p>.*<code class="ruby">}m
     end
   end
 


### PR DESCRIPTION
The pull request turns on the `:lax_spacing` option of Redcarpet such that GitHub-flavored code blocks do not need to be preceded by empty lines as in the Markdown standard. More details can be found [here](https://github.com/vmg/redcarpet/issues/390).
