### PR TITLE
Test for alternative class assignment

### DIFF
--- a/spec/handlers/class_handler_spec.rb
+++ b/spec/handlers/class_handler_spec.rb
@@ -243,4 +243,10 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassHandler" 
   it "should handle inheritance from 'self'" do
     Registry.at('Outer1::Inner1').superclass.should == Registry.at('Outer1')
   end
+
+  it "should handle assignment of new classes to constants" do
+    obj = Registry.at('ClassAssignment')
+    obj.should be_kind_of(CodeObjects::ClassObject)
+    obj.docstring.should == 'Docstring'
+  end
 end

--- a/spec/handlers/examples/class_handler_001.rb.txt
+++ b/spec/handlers/examples/class_handler_001.rb.txt
@@ -118,3 +118,6 @@ class NotAStruct; end
 class Outer1
   class Inner1 < self; end
 end
+
+# Docstring
+ClassAssignment = Class.new


### PR DESCRIPTION
`Foo = Class.new`
is equivalent to:
`class Foo; end`

We should treat it as such, not as just any other constant.

WIP, implementation to come. Early comments welcome.