### PR TITLE
add stats_options for YardocTask, simplifies rake task definitions for extra stats options

### DIFF
--- a/lib/yard/rake/yardoc_task.rb
+++ b/lib/yard/rake/yardoc_task.rb
@@ -14,6 +14,10 @@ module YARD
       # @return [Array<String>] the options passed to the commandline utility
       attr_accessor :options
 
+      # Options to pass to {CLI::Stats}
+      # @return [Array<String>] the options passed to the stats utility
+      attr_accessor :stats_options
+
       # The Ruby source files (and any extra documentation files separated by '-')
       # to process.
       # @example Task files assignment
@@ -46,11 +50,13 @@ module YARD
       def initialize(name = :yard)
         @name = name
         @options = []
+        @stats_options = []
         @files = []
 
         yield self if block_given?
         self.options +=  ENV['OPTS'].split(/[ ,]/) if ENV['OPTS']
         self.files   += ENV['FILES'].split(/[ ,]/) if ENV['FILES']
+        self.options << '--no-stats' unless self.stats_options.empty?
 
         define
       end
@@ -66,6 +72,7 @@ module YARD
           yardoc = YARD::CLI::Yardoc.new
           yardoc.options[:verifier] = verifier if verifier
           yardoc.run *(options + files)
+          YARD::CLI::Stats.run(*(stats_options + ['--use-cache'])) unless stats_options.empty?
           after.call if after.is_a?(Proc)
         end
       end

--- a/spec/rake/yardoc_task_spec.rb
+++ b/spec/rake/yardoc_task_spec.rb
@@ -56,6 +56,33 @@ describe YARD::Rake::YardocTask do
     end
   end
 
+  describe '#stats_options' do
+    before do
+      @yard_stats = Object.new
+      @yard_stats.stub!(:run)
+      YARD::CLI::Stats.stub!(:new).and_return(@yard_stats)
+    end
+
+    it "should not invoke stats" do
+      @yard_stats.should_not_receive(:run)
+      @yardoc.statistics = true
+      YARD::Rake::YardocTask.new do |t|
+      end
+      run
+      @yardoc.statistics.should == true
+    end
+
+    it "should invoke stats" do
+      @yard_stats.should_receive(:run).with('--list-undoc', '--use-cache')
+      @yardoc.statistics = true
+      YARD::Rake::YardocTask.new do |t|
+        t.stats_options = %w(--list-undoc)
+      end
+      run
+      @yardoc.statistics.should == false
+    end
+  end
+
   describe '#before' do
     it "should allow before callback" do
       proc = lambda { }


### PR DESCRIPTION
this simplifies:

``` ruby
YARD::Rake::YardocTask.new do |t|
  t.files   = ["lib/**/*.rb"]
  t.options = ["--no-stats"]
  t.after = Proc.new do
    YARD::CLI::Stats.new.run("--list-undoc", "--compact")
  end
end
```

to:

``` ruby
YARD::Rake::YardocTask.new do |t|
  t.files   = ["lib/**/*.rb"]
  t.stats_options = ["--list-undoc", "--compact"]
end
```
