### PR TITLE
Keep attribute documentation for structs.

### DIFF
--- a/lib/yard/handlers/ruby/struct_handler_methods.rb
+++ b/lib/yard/handlers/ruby/struct_handler_methods.rb
@@ -133,6 +133,7 @@ module YARD::Handlers::Ruby::StructHandlerMethods
   def create_attributes(klass, members)
     # For each parameter, add reader and writers
     members.each do |member|
+      next if klass.attributes[:instance][member]
       klass.attributes[:instance][member] = SymbolHash[:read => nil, :write => nil]
       create_writer klass, member if create_member_method?(klass, member, :write)
       create_reader klass, member if create_member_method?(klass, member, :read)

--- a/spec/handlers/constant_handler_spec.rb
+++ b/spec/handlers/constant_handler_spec.rb
@@ -56,6 +56,9 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ConstantHandle
     a1.tag(:return).types.should == ["String"]
     a2.docstring.should == "Another attr"
     a2.tag(:return).types.should == ["Number"]
+    a3 = Registry.at("DocstringStruct#new_syntax")
+    a3.docstring.should == "Attribute defined with the new syntax"
+    a3.tag(:return).types.should == ["Symbol"]
   end
 
   it "should raise undocumentable error in 1.9 parser for Struct.new assignment to non-const" do

--- a/spec/handlers/examples/constant_handler_001.rb.txt
+++ b/spec/handlers/examples/constant_handler_001.rb.txt
@@ -22,4 +22,7 @@ MyEmptyStruct = Struct.new
 #
 # @attr [String] bar An attr
 # @attr [Number] baz Another attr
-DocstringStruct = Struct.new(:bar, :baz)
+# @!attribute new_syntax
+#   Attribute defined with the new syntax
+#   @return [Symbol] something usefull
+DocstringStruct = Struct.new(:bar, :baz, :new_syntax)


### PR DESCRIPTION
Attribute documentation using directives was overwriten by the struct handler,
lets keep that documentation.

Related to #692.