### PR TITLE
More robust Docstring summary

### DIFF
--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -172,15 +172,20 @@ module YARD
       resolve_reference
       return @summary if @summary
       stripped = self.gsub(/<.+?>/m, '').gsub(/[\r\n](?![\r\n])/, ' ').strip
-      open_parens = ['{', '(', '[']
-      close_parens = ['}', ')', ']']
       num_parens = 0
       idx = length.times do |index|
         case stripped[index, 1]
-        when ".", "\r", "\n"
+        when "."
           next_char = stripped[index + 1, 1].to_s
-          if num_parens == 0 && next_char =~ /^\s*$/
-            break index - 1
+          break index - 1 if num_parens <= 0 && next_char =~ /^\s*$/
+        when "\r", "\n"
+          next_char = stripped[index + 1, 1].to_s
+          if next_char =~ /^\s*$/
+            if stripped[index - 1, 1] == '.'
+              break index - 2
+            else
+              break index - 1
+            end
           end
         when "{", "(", "["
           num_parens += 1

--- a/spec/docstring_spec.rb
+++ b/spec/docstring_spec.rb
@@ -113,6 +113,13 @@ describe YARD::Docstring do
       Docstring.new("hello... me").summary.should == "hello..."
       Docstring.new("hello.").summary.should == "hello."
     end
+
+    it "should return summary if there is a newline and parentheses count doesn't match" do
+      Docstring.new("Happy method call :-)\n\nCall any time.").summary.should == "Happy method call :-)."
+      Docstring.new("Sad method call :-(\n\nCall any time.").summary.should == "Sad method call :-(."
+      Docstring.new("Hello (World. Forget to close.\n\nNew text").summary.should == "Hello (World. Forget to close."
+      Docstring.new("Hello (World. Forget to close\n\nNew text").summary.should == "Hello (World. Forget to close."
+    end
   end
 
   describe '#ref_tags' do


### PR DESCRIPTION
Prevents unclosed parentheses to break the summary.
Please, see `Process.detach` at http://www.rubydoc.info/stdlib/core/Process and `IO.select` at http://www.rubydoc.info/stdlib/core/IO.