### PR TITLE
Remove ununsed local variables

### DIFF
--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -172,8 +172,6 @@ module YARD
       resolve_reference
       return @summary if @summary
       stripped = self.gsub(/<.+?>/m, '').gsub(/[\r\n](?![\r\n])/, ' ').strip
-      open_parens = ['{', '(', '[']
-      close_parens = ['}', ')', ']']
       num_parens = 0
       idx = length.times do |index|
         case stripped[index, 1]


### PR DESCRIPTION
Some variables where unused. Removing them allows for less clutter and
also prevents rubyist that have warnings enabled to have those warnings
printed out.