### PR TITLE
Improved initial rendering of class list.

### DIFF
--- a/templates/default/fulldoc/html/css/full_list.css
+++ b/templates/default/fulldoc/html/css/full_list.css
@@ -12,28 +12,27 @@ h1 { padding: 12px 10px; padding-bottom: 0; margin: 0; font-size: 1.4em; }
 .fixed_header { position: fixed; background: #fff; width: 100%; padding-bottom: 10px; margin-top: 0; top: 0; z-index: 9999; height: 70px; }
 #search { position: absolute; right: 5px; top: 9px; padding-left: 24px; }
 #content.insearch #search, #content.insearch #noresults { background: url(data:image/gif;base64,R0lGODlhEAAQAPYAAP///wAAAPr6+pKSkoiIiO7u7sjIyNjY2J6engAAAI6OjsbGxjIyMlJSUuzs7KamppSUlPLy8oKCghwcHLKysqSkpJqamvT09Pj4+KioqM7OzkRERAwMDGBgYN7e3ujo6Ly8vCoqKjY2NkZGRtTU1MTExDw8PE5OTj4+PkhISNDQ0MrKylpaWrS0tOrq6nBwcKysrLi4uLq6ul5eXlxcXGJiYoaGhuDg4H5+fvz8/KKiohgYGCwsLFZWVgQEBFBQUMzMzDg4OFhYWBoaGvDw8NbW1pycnOLi4ubm5kBAQKqqqiQkJCAgIK6urnJyckpKSjQ0NGpqatLS0sDAwCYmJnx8fEJCQlRUVAoKCggICLCwsOTk5ExMTPb29ra2tmZmZmhoaNzc3KCgoBISEiIiIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCAAAACwAAAAAEAAQAAAHaIAAgoMgIiYlg4kACxIaACEJCSiKggYMCRselwkpghGJBJEcFgsjJyoAGBmfggcNEx0flBiKDhQFlIoCCA+5lAORFb4AJIihCRbDxQAFChAXw9HSqb60iREZ1omqrIPdJCTe0SWI09GBACH5BAkIAAAALAAAAAAQABAAAAdrgACCgwc0NTeDiYozCQkvOTo9GTmDKy8aFy+NOBA7CTswgywJDTIuEjYFIY0JNYMtKTEFiRU8Pjwygy4ws4owPyCKwsMAJSTEgiQlgsbIAMrO0dKDGMTViREZ14kYGRGK38nHguHEJcvTyIEAIfkECQgAAAAsAAAAABAAEAAAB2iAAIKDAggPg4iJAAMJCRUAJRIqiRGCBI0WQEEJJkWDERkYAAUKEBc4Po1GiKKJHkJDNEeKig4URLS0ICImJZAkuQAhjSi/wQyNKcGDCyMnk8u5rYrTgqDVghgZlYjcACTA1sslvtHRgQAh+QQJCAAAACwAAAAAEAAQAAAHZ4AAgoOEhYaCJSWHgxGDJCQARAtOUoQRGRiFD0kJUYWZhUhKT1OLhR8wBaaFBzQ1NwAlkIszCQkvsbOHL7Y4q4IuEjaqq0ZQD5+GEEsJTDCMmIUhtgk1lo6QFUwJVDKLiYJNUd6/hoEAIfkECQgAAAAsAAAAABAAEAAAB2iAAIKDhIWGgiUlh4MRgyQkjIURGRiGGBmNhJWHm4uen4ICCA+IkIsDCQkVACWmhwSpFqAABQoQF6ALTkWFnYMrVlhWvIKTlSAiJiVVPqlGhJkhqShHV1lCW4cMqSkAR1ofiwsjJyqGgQAh+QQJCAAAACwAAAAAEAAQAAAHZ4AAgoOEhYaCJSWHgxGDJCSMhREZGIYYGY2ElYebi56fhyWQniSKAKKfpaCLFlAPhl0gXYNGEwkhGYREUywag1wJwSkHNDU3D0kJYIMZQwk8MjPBLx9eXwuETVEyAC/BOKsuEjYFhoEAIfkECQgAAAAsAAAAABAAEAAAB2eAAIKDhIWGgiUlh4MRgyQkjIURGRiGGBmNhJWHm4ueICImip6CIQkJKJ4kigynKaqKCyMnKqSEK05StgAGQRxPYZaENqccFgIID4KXmQBhXFkzDgOnFYLNgltaSAAEpxa7BQoQF4aBACH5BAkIAAAALAAAAAAQABAAAAdogACCg4SFggJiPUqCJSWGgkZjCUwZACQkgxGEXAmdT4UYGZqCGWQ+IjKGGIUwPzGPhAc0NTewhDOdL7Ykji+dOLuOLhI2BbaFETICx4MlQitdqoUsCQ2vhKGjglNfU0SWmILaj43M5oEAOwAAAAAAAAAAAA==) no-repeat center left; }
-#full_list { padding: 0; list-style: none; margin-left: 0; margin-top: 80px; }
+#full_list { padding: 0; list-style: none; margin-left: 0; margin-top: 80px; font-size: 1.1em; }
 #full_list ul { padding: 0; }
-#full_list li { padding: 5px; padding-left: 12px; margin: 0; font-size: 1.1em; list-style: none; }
+#full_list li { padding: 0; margin: 0; list-style: none; }
+#full_list li .item { padding: 5px 5px 5px 12px; }
 #noresults { padding: 7px 12px; background: #fff; }
 #content.insearch #noresults { margin-left: 7px; }
-ul.collapsed ul, ul.collapsed li { display: none; }
-ul.collapsed.search_uncollapsed { display: block; }
-ul.collapsed.search_uncollapsed li { display: list-item; }
+li.collapsed ul { display: none; }
 li a.toggle { cursor: default; position: relative; left: -5px; top: 4px; text-indent: -999px; width: 10px; height: 9px; margin-left: -10px; display: block; float: left; background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAASCAYAAABb0P4QAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAK8AAACvABQqw0mAAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTM5jWRgMAAAAVdEVYdENyZWF0aW9uIFRpbWUAMy8xNC8wOeNZPpQAAAE2SURBVDiNrZTBccIwEEXfelIAHUA6CZ24BGaWO+FuzZAK4k6gg5QAdGAq+Bxs2Yqx7BzyL7Llp/VfzZeQhCTc/ezuGzKKnKSzpCxXJM8fwNXda3df5RZETlIt6YUzSQDs93sl8w3wBZxCCE10GM1OcWbWjB2mWgEH4Mfdyxm3PSepBHibgQE2wLe7r4HjEidpnXMYdQPKEMJcsZ4zs2POYQOcaPfwMVOo58zsAdMt18BuoVDPxUJRacELbXv3hUIX2vYmOUvi8C8ydz/ThjXrqKqqLbDIAdsCKBd+Wo7GWa7o9qzOQHVVVXeAbs+yHHCH4aTsaCOQqunmUy1yBUAXkdMIfMlgF5EXLo2OpV/c/Up7jG4hhHcYLgWzAZXUc2b2ixsfvc/RmNNfOXD3Q/oeL9axJE1yT9IOoUu6MGUkAAAAAElFTkSuQmCC) no-repeat bottom left; }
 li.collapsed a.toggle { opacity: 0.5; cursor: default; background-position: top left; }
 li { color: #888; cursor: pointer; }
 li.deprecated { text-decoration: line-through; font-style: italic; }
-li.r1 { background: #f0f0f0; }
-li.r2 { background: #fafafa; }
-li:hover { background: #ddd; }
+li.odd { background: #f0f0f0; }
+li.even { background: #fafafa; }
+.item:hover { background: #ddd; }
 li small:before { content: "("; }
 li small:after { content: ")"; }
 li small.search_info { display: none; }
 a, a:visited { text-decoration: none; color: #05a; }
-li.clicked { background: #05a; color: #ccc; }
-li.clicked a, li.clicked a:visited { color: #eee; }
-li.clicked a.toggle { opacity: 0.5; background-position: bottom right; }
+li.clicked > .item { background: #05a; color: #ccc; }
+li.clicked > .item a, li.clicked > .item a:visited { color: #eee; }
+li.clicked > .item a.toggle { opacity: 0.5; background-position: bottom right; }
 li.collapsed.clicked a.toggle { background-position: top right; }
 #search input { border: 1px solid #bbb; border-radius: 3px; }
 #full_list_nav { margin-left: 10px; font-size: 0.9em; display: block; color: #aaa; }
@@ -52,7 +51,8 @@ li small.search_info { display: none; }
 #content.insearch #search { background-position: center right; }
 #search input { width: 110px; }
 
-#full_list.insearch li { display: none; }
-#full_list.insearch li.found { display: list-item; padding-left: 10px; }
+#full_list.insearch ul { display: block; }
+#full_list.insearch .item { display: none; }
+#full_list.insearch .found { display: block; padding-left: 11px !important; }
 #full_list.insearch li a.toggle { display: none; }
 #full_list.insearch li small.search_info { display: block; }

--- a/templates/default/fulldoc/html/full_list_class.erb
+++ b/templates/default/fulldoc/html/full_list_class.erb
@@ -1,2 +1,2 @@
-<li id="object_"><%= link_object(Registry.root, Registry.root.title, nil, false) %></li>
+<li id="object_" class="odd"><div class="item"><%= link_object(Registry.root, Registry.root.title, nil, false) %></div></li>
 <%= class_list %>

--- a/templates/default/fulldoc/html/full_list_file.erb
+++ b/templates/default/fulldoc/html/full_list_file.erb
@@ -1,5 +1,7 @@
-<% n = 1 %>
+<% even_odd = 'odd'  %>
 <% @items.each do |item| %>
-  <li id="object_<%= item.path %>" class="r<%= n %>"><span class="object_link"><%= link_file item %></a></li>
-  <% n = n == 2 ? 1 : 2 %>
+  <li id="object_<%= item.path %>" class="<%= even_odd %>">
+    <div class="item"><span class="object_link"><%= link_file item %></a></div>
+  </li>
+  <% even_odd = (even_odd == 'even' ? 'odd' : 'even') %>
 <% end %>

--- a/templates/default/fulldoc/html/full_list_method.erb
+++ b/templates/default/fulldoc/html/full_list_method.erb
@@ -1,8 +1,10 @@
-<% n = 1 %>
+<% even_odd = 'odd'  %>
 <% @items.each do |item| %>
-  <li class="r<%= n %> <%= item.has_tag?(:deprecated) ? 'deprecated' : '' %>">
-    <%= linkify item, h(item.name(true)) %>
-    <small><%= item.namespace.title %></small>
+  <li class="<%= even_odd %> <%= item.has_tag?(:deprecated) ? 'deprecated' : '' %>">
+    <div class="item">
+      <%= linkify item, h(item.name(true)) %>
+      <small><%= item.namespace.title %></small>
+    </div>
   </li>
-  <% n = n == 2 ? 1 : 2 %>
+  <% even_odd = (even_odd == 'even' ? 'odd' : 'even') %>
 <% end %>

--- a/templates/default/fulldoc/html/setup.rb
+++ b/templates/default/fulldoc/html/setup.rb
@@ -172,27 +172,70 @@ def generate_frameset
   asset(url_for_frameset, erb(:frames))
 end
 
+# @api private
+class TreeContext
+
+  def initialize
+    @depth = 0
+    @even_odd = Alternator.new(:even, :odd)
+  end
+
+  def nest
+    @depth += 1
+    yield
+    @depth -= 1
+  end
+
+  # @return [String] Returns a css pixel offset, e.g. "30px"
+  def indent
+    "#{(@depth + 2) * 15}px"
+  end
+
+  def classes
+    classes = []
+    classes << 'collapsed' if @depth > 0
+    classes << @even_odd.next if @depth < 2
+    classes
+  end
+
+  class Alternator
+    def initialize(first, second)
+      @next = first
+      @after = second
+    end
+    def next
+      @next, @after = @after, @next
+      @after
+    end
+  end
+
+end
+
 # @return [String] HTML output of the classes to be displayed in the
 #    full_list_class template.
-def class_list(root = Registry.root)
+def class_list(root = Registry.root, tree = TreeContext.new)
   out = ""
   children = run_verifier(root.children)
   if root == Registry.root
     children += @items.select {|o| o.namespace.is_a?(CodeObjects::Proxy) }
   end
-  children.reject {|c| c.nil? }.sort_by {|child| child.path }.map do |child|
+  children.compact.sort_by(&:path).each do |child|
     if child.is_a?(CodeObjects::NamespaceObject)
       name = child.namespace.is_a?(CodeObjects::Proxy) ? child.path : child.name
       has_children = run_verifier(child.children).any? {|o| o.is_a?(CodeObjects::NamespaceObject) }
-      out << "<li id='object_#{child.path}'>"
+      out << "<li id='object_#{child.path}' class='#{tree.classes.join(' ')}'>"
+      out << "<div class='item' style='padding-left:#{tree.indent}'>"
       out << "<a class='toggle'></a> " if has_children
       out << linkify(child, name)
       out << " &lt; #{child.superclass.name}" if child.is_a?(CodeObjects::ClassObject) && child.superclass
       out << "<small class='search_info'>"
       out << child.namespace.title
       out << "</small>"
+      out << "</div>"
+      tree.nest do
+        out << "<ul>#{class_list(child, tree)}</ul>" if has_children
+      end
       out << "</li>"
-      out << "<ul>#{class_list(child)}</ul>" if has_children
     end
   end
   out


### PR DESCRIPTION
The sidebar `#full_list` tree of classes renders slowly and jumps after page load because much of its formatting is provided by JavaScript. Large trees suffer in render and it can be jarring when
navigating the tree. This pull request makes the following changes:

* Updates the `class_list` method in the default template to apply the initial css classes necessary to expand the tree 1 level, alternate row colors, and to indent nested items. This requires adding an additional parameter that can maintain a context of depth as this method is called recursively.

* The previous `class_list` method generated ul elements as siblings of li elements and relied on JavaScript to apply padding to simulate nesting. The ul elements for nested classes are now children of the li elements. JavaScript is no longer needed to apply nesting.

* Improves search speed on large trees by removing the use of setTimeout and instead the tree is detached from the dom and re-attached after modifications. This prevents the browser from locking up during dom updates and eliminates a large number of redraws.

Some other thoughts for improvements, not implemented by this pull-request:

* There is still a notable delay in highlighting the current "clicked" section of the tree and expanding to it upon page load. The expand logic is a result of a message sent from the frames' parent. If this message were sent upon dom load, but before the entire page load, speed would be improved here as well. Alternatively, if the frame could detect the clicked element itself based on the parents url, the delay could be drastically reduced.