### PR TITLE
Add CONSTANTSTART regular expression

### DIFF
--- a/lib/yard/autoload.rb
+++ b/lib/yard/autoload.rb
@@ -46,6 +46,7 @@ module YARD
     autoload :BUILTIN_MODULES,      __p('code_objects/base')
     autoload :BUILTIN_EXCEPTIONS,   __p('code_objects/base')
     autoload :CONSTANTMATCH,        __p('code_objects/base')
+    autoload :CONSTANTSTART,        __p('code_objects/base')
     autoload :METHODMATCH,          __p('code_objects/base')
     autoload :METHODNAMEMATCH,      __p('code_objects/base')
     autoload :NAMESPACEMATCH,       __p('code_objects/base')

--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -49,6 +49,9 @@ module YARD
     # Regular expression to match constant name
     CONSTANTMATCH = /[A-Z]\w*/
 
+    # Regular expression to match the beginning of a constant
+    CONSTANTSTART = /^[A-Z]/
+
     # Regular expression to match namespaces (const A or complex path A::B)
     NAMESPACEMATCH = /(?:(?:#{NSEPQ}\s*)?#{CONSTANTMATCH})+/
 

--- a/lib/yard/code_objects/proxy.rb
+++ b/lib/yard/code_objects/proxy.rb
@@ -242,12 +242,12 @@ module YARD
         if @namespace.root?
           (@imethod ? ISEP : "") + name.to_s
         elsif @origname
-          if @origname =~ /^[A-Z]/
+          if @origname =~ CONSTANTSTART
             @origname
           else
             [namespace.path, @origname].join
           end
-        elsif name.to_s =~ /^[A-Z]/ # const
+        elsif name.to_s =~ CONSTANTSTART
           name.to_s
         else # class meth?
           [namespace.path, name.to_s].join(CSEP)

--- a/spec/code_objects/constants_spec.rb
+++ b/spec/code_objects/constants_spec.rb
@@ -8,6 +8,14 @@ describe YARD::CodeObjects, "CONSTANTMATCH" do
   end
 end
 
+describe YARD::CodeObjects, "CONSTANTSTART" do
+  it "should match a constant" do
+    "Constant"[CodeObjects::CONSTANTSTART].should == "C"
+    "identifier"[CodeObjects::CONSTANTSTART].should be_nil
+    "File.new"[CodeObjects::CONSTANTSTART].should == "F"
+  end
+end
+
 describe YARD::CodeObjects, "NAMESPACEMATCH" do
   it "should match a namespace (multiple constants with ::)" do
     "Constant"[CodeObjects::NAMESPACEMATCH].should == "Constant"


### PR DESCRIPTION
Prior to this commit, the regular expression used in the proxy_path
method was hard coded. In addition to be inconsistent with the rest
of the regular expressions in CodeObjects::Proxy (which use the constants
defined in CodeObjects::Base), this also meant that it was not possible
to patch the regular expressions to accommodate namespaces in other
languages.

In order to fix these issues, add a CONSTANTSTART regex constant that
matches the first letter of constants that begin with an uppercase letter.

------

A bit of context on where this is coming from: I'm working on an extension for
YARD to document the Puppet DSL. However Puppet namespaces do not
require words to be capitalized. This means that our namespaces get all mangled.
I was able to trace this down to the proxy_path method.

I added another regular expression constant because patching this seemed like
a better solution that trying to patch a private method, and most of the other
regular expressions used for namespace matching have constants already. If
this is the wrong approach please let me know! Happy to try something else.