### PR TITLE
Update ruby_parser.rb

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -219,7 +219,7 @@ module YARD
           node.line_range = Range.new(lstart, lineno)
           if node.respond_to?(:block)
             sr, lr = node.block.source_range, node.block.line_range
-            node.block.source_range = Range.new(sr.first, @tokens.last[2][1])
+            node.block.source_range = Range.new(sr.first, @tokens.last[2][1]-1)
             node.block.line_range = Range.new(lr.first, @tokens.last[2][0])
           end
           node


### PR DESCRIPTION
AstNode#block should return content of the ruby code block.
Example:
module A
some_method
end
old return "some_method\r\ne"
new return "some_method\r\n"