### PR TITLE
[config_dir] use one constant and fallback to /tmp

### DIFF
--- a/lib/yard.rb
+++ b/lib/yard.rb
@@ -7,9 +7,6 @@ module YARD
   # The root path for YARD builtin templates
   TEMPLATE_ROOT = File.join(ROOT, '..', 'templates')
 
-  # @deprecated Use {Config::CONFIG_DIR}
-  CONFIG_DIR = File.expand_path('~/.yard')
-
   # An alias to {Parser::SourceParser}'s parsing method
   #
   # @example Parse a glob of files

--- a/lib/yard.rb
+++ b/lib/yard.rb
@@ -1,4 +1,5 @@
 require File.expand_path('../yard/version.rb', __FILE__)
+require File.expand_path('../yard/config.rb', __FILE__)
 
 module YARD
   # The root path for YARD source libraries
@@ -6,6 +7,9 @@ module YARD
 
   # The root path for YARD builtin templates
   TEMPLATE_ROOT = File.join(ROOT, '..', 'templates')
+
+  # @deprecated Use {Config::CONFIG_DIR}
+  CONFIG_DIR = ::YARD::Config::CONFIG_DIR
 
   # An alias to {Parser::SourceParser}'s parsing method
   #

--- a/lib/yard/cli/yri.rb
+++ b/lib/yard/cli/yri.rb
@@ -6,12 +6,12 @@ module YARD
     class YRI < Command
       # The location in {YARD::CONFIG_DIR} where the YRI cache file is loaded
       # from.
-      CACHE_FILE = File.expand_path('~/.yard/yri_cache')
+      CACHE_FILE = File.join(::YARD::Config::CONFIG_DIR, 'yri_cache')
 
       # A file containing all paths, delimited by newlines, to search for
       # yardoc databases.
       # @since 0.5.1
-      SEARCH_PATHS_FILE = File.expand_path('~/.yard/yri_search_paths')
+      SEARCH_PATHS_FILE = File.join(::YARD::Config::CONFIG_DIR, 'yri_search_paths')
 
       # Default search paths that should be loaded dynamically into YRI. These paths
       # take precedence over all other paths ({SEARCH_PATHS_FILE} and RubyGems

--- a/lib/yard/config.rb
+++ b/lib/yard/config.rb
@@ -90,10 +90,9 @@ module YARD
       attr_accessor :options
     end
 
-    # The location where YARD stores user-specific settings
 
     HOME_DIR = begin
-                 Dir.home
+                 File.expand_path('~')
                rescue ArgumentError => e
                  require 'tmpdir'
                  dir = Dir.tmpdir
@@ -103,6 +102,7 @@ module YARD
                  STDERR.puts("Falling back to temp directory '#{dir}' for HOME.")
                  dir
                end
+    # The location where YARD stores user-specific settings
     CONFIG_DIR = File.join(HOME_DIR, '.yard')
 
     # The main configuration YAML file.

--- a/lib/yard/config.rb
+++ b/lib/yard/config.rb
@@ -1,3 +1,4 @@
+require 'etc'
 module YARD
   # This class maintains all system-wide configuration for YARD and handles
   # the loading of plugins. To access options call {options}, and to load
@@ -91,7 +92,7 @@ module YARD
     end
 
     # The location where YARD stores user-specific settings
-    CONFIG_DIR = File.expand_path('~/.yard') rescue '/tmp/.yard'
+    CONFIG_DIR = File.expand_path('~/.yard') rescue Etc.getpwuid.dir
 
     # The main configuration YAML file.
     CONFIG_FILE = File.join(CONFIG_DIR, 'config')

--- a/lib/yard/config.rb
+++ b/lib/yard/config.rb
@@ -91,7 +91,7 @@ module YARD
     end
 
     # The location where YARD stores user-specific settings
-    CONFIG_DIR = File.expand_path('~/.yard')
+    CONFIG_DIR = File.expand_path('~/.yard') rescue '/tmp/.yard'
 
     # The main configuration YAML file.
     CONFIG_FILE = File.join(CONFIG_DIR, 'config')

--- a/lib/yard/config.rb
+++ b/lib/yard/config.rb
@@ -1,4 +1,3 @@
-require 'etc'
 module YARD
   # This class maintains all system-wide configuration for YARD and handles
   # the loading of plugins. To access options call {options}, and to load
@@ -92,7 +91,19 @@ module YARD
     end
 
     # The location where YARD stores user-specific settings
-    CONFIG_DIR = File.expand_path('~/.yard') rescue Etc.getpwuid.dir
+
+    HOME_DIR = begin
+                 Dir.home
+               rescue ArgumentError => e
+                 require 'tmpdir'
+                 dir = Dir.tmpdir
+                 STDERR.puts(e)
+                 STDERR.puts("Warning! It appears something is unusual with your HOME environmental variable.")
+                 STDERR.puts("Please consider setting HOME to an absolute path.")
+                 STDERR.puts("Falling back to temp directory '#{dir}' for HOME.")
+                 dir
+               end
+    CONFIG_DIR = File.join(HOME_DIR, '.yard')
 
     # The main configuration YAML file.
     CONFIG_FILE = File.join(CONFIG_DIR, 'config')

--- a/lib/yard/registry.rb
+++ b/lib/yard/registry.rb
@@ -30,7 +30,8 @@ module YARD
   #   Registry.resolve(P('YARD::CodeObjects::Base'), '#docstring', true)
   module Registry
     DEFAULT_YARDOC_FILE = ".yardoc"
-    LOCAL_YARDOC_INDEX = File.expand_path('~/.yard/gem_index')
+    LOCAL_YARDOC_INDEX = File.join(::YARD::Config::CONFIG_DIR, 'gem_index')
+
     DEFAULT_PO_DIR = "po"
 
     extend Enumerable


### PR DESCRIPTION
This lets applications launch when ENV["HOME"] is unset, blank, or
relative.

For a variety of reasons, when launching my app, HOME is empty
and gems I need depend on YARD. I believe we shouldn't prevent
apps from starting in this case.

This cleans up our usage of "~/.yard" in a few places to reference the
same constant, which falls back to "/tmp.yard" when HOME is unset.

This also removes the deprecated ::YARD::CONFIG_DIR.
It was deprecated [Sep 16, 2010
598b051202549122dc12411ce6e7b26b4c98d66b](https://github.com/lsegal/yard/commit/598b051202549122dc12411ce6e7b26b4c98d66b)