### PR TITLE
Re-enable Ruby 2.2 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rvm:
   - 1.9.3
   - 2.0
   - 2.1
-# - 2.2 - re-enable after https://bugs.ruby-lang.org/issues/10693 is fixed
+  - 2.2
 #  - jruby      # see http://jira.codehaus.org/browse/JRUBY-7007
 #  - ruby-head  # RedCloth does not compile on head
 #  - 1.8.6      # Does not work on travis-ci


### PR DESCRIPTION
Now that the blocking bug in Ruby has been fixed, we can build on Ruby 2.2
again.

https://bugs.ruby-lang.org/issues/10693