### PR TITLE
Remove an obsolete reference to RubyForge.

### DIFF
--- a/yard.gemspec
+++ b/yard.gemspec
@@ -20,6 +20,5 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
   s.executables   = ['yard', 'yardoc', 'yri']
   s.has_rdoc      = 'yard'
-  s.rubyforge_project = 'yard'
   s.license = 'MIT' if s.respond_to?(:license=)
 end


### PR DESCRIPTION
The reference to RubyForge is obsolete since RubyForge itself is down meanwhile.