### PR TITLE
Fix unexpected writers in --list-undoc.

### DIFF
--- a/lib/yard/tags/directives.rb
+++ b/lib/yard/tags/directives.rb
@@ -479,6 +479,7 @@ module YARD
             writer.source = object.source
             writer.group = object.group
             writer.parameters = [['value', nil]]
+            writer.docstring = object.base_docstring
             handler.register_file_info(writer)
           end
           attrs[clean_name][:write] = writer


### PR DESCRIPTION
When we run:

    yard stats --list-undoc sample.rb

with sample.rb (https://gist.github.com/ohai/82d5d409d4fcbb859e0e#file-sample-rb), we get the message  that A#baz= undocumented (https://gist.github.com/ohai/82d5d409d4fcbb859e0e#file-result).
However, I expect that this message should not appear.

This is because the MethodObject object of the writer always
has an empty docstring.

With this fix, the MethodObject objects of the reader and the
writer created by the @!attribute attribute share a docstring.