### PR TITLE
Extract method parameter names from C function signatures

### DIFF
--- a/lib/yard/handlers/c/method_handler.rb
+++ b/lib/yard/handlers/c/method_handler.rb
@@ -6,9 +6,9 @@ class YARD::Handlers::C::MethodHandler < YARD::Handlers::C::Base
                     module_function  |
                     private_method
                  )
-                 \s*\(\s*([\w\.]+),
-                   \s*"([^"]+)",
-                   \s*(?:RUBY_METHOD_FUNC\(|VALUEFUNC\(|\(\w+\))?(\w+)\)?,
+                 \s*\(\s*([\w\.]+)\s*,
+                   \s*"([^"]+)"\s*,
+                   \s*(?:RUBY_METHOD_FUNC\(|VALUEFUNC\(|\(\w+\))?(\w+)\)?\s*,
                    \s*(-?\w+)\s*\)}xm
   MATCH2 = %r{rb_define_global_function\s*\(
                 \s*"([^"]+)",

--- a/spec/handlers/c/method_handler_spec.rb
+++ b/spec/handlers/c/method_handler_spec.rb
@@ -254,11 +254,18 @@ describe YARD::Handlers::C::MethodHandler do
   it "should extract varargs method parameters from C function signatures" do
     parse <<-eof
       static VALUE varargs_func(int argc, VALUE *argv, VALUE self) { return self; }
+      /* let's see if parser is robust in the face of strange spacing */
+      static VALUE varargs_func2(	int 	argc ,	VALUE
+	* 	 argv  ,VALUE  self	)
+
+      {return self;}
       void Init_Foo() {
         mFoo = rb_define_module("Foo");
         rb_define_method(mFoo, "varargs", varargs_func, -1);
+        rb_define_method(	mFoo	,"varargs2",varargs_func2		,-1);
       }
     eof
     Registry.at('Foo#varargs').parameters.should == [['*args', nil]]
+    Registry.at('Foo#varargs2').parameters.should == [['*args', nil]]
   end
 end


### PR DESCRIPTION
Use a couple of regexes on the source for a Ruby method defined in a C extension, to get the parameters. This is already done for methods defined in Ruby, but for those defined in C.

This is not foolproof -- for example, if the Ruby method implemented by a C function takes a block argument, we can't identify that from the C function signature. But at least we can identify regular method arguments.

This makes the generated documentation for C extension methods noticeably better.