### PR TITLE
Recognize core Ruby classes (declared in ruby.h) in C extension Init function

### DIFF
--- a/lib/yard/handlers/c/handler_methods.rb
+++ b/lib/yard/handlers/c/handler_methods.rb
@@ -51,6 +51,16 @@ module YARD
           end
 
           namespace = namespace_for_variable(var_name)
+
+          # Is this method being defined on a core Ruby class or module?
+          if namespace.is_a?(Proxy)
+            if var_name =~ /^rb_c(\w+)/ && YARD::CodeObjects::BUILTIN_CLASSES.include?($1)
+              namespace = namespaces[var_name] = YARD::CodeObjects::ClassObject.new(:root, $1)
+            elsif var_name =~ /^rb_m(\w+)/ && YARD::CodeObjects::BUILTIN_MODULES.include?($1)
+              namespace = namespaces[var_name] = YARD::CodeObjects::ModuleObject.new(:root, $1)
+            end
+          end
+
           return if namespace.nil? # XXX: raise UndocumentableError might be too noisy.
           register MethodObject.new(namespace, name, scope) do |obj|
             register_visibility(obj, visibility)

--- a/spec/handlers/c/method_handler_spec.rb
+++ b/spec/handlers/c/method_handler_spec.rb
@@ -236,4 +236,19 @@ describe YARD::Handlers::C::MethodHandler do
     Registry.at('Foo#bar').should_not be_nil
     Registry.at('Kernel#baz').should_not be_nil
   end
+
+  it "should recognize core Ruby classes and modules provided by ruby.h" do
+    parse_init <<-eof
+      rb_define_method(rb_cFixnum, "popcount", fix_popcount, 0);
+      rb_define_private_method(rb_mKernel, "pp", obj_pp, 0);
+      rb_define_method(rb_mEnumerable, "to_hash", enum_to_hash, 0);
+    eof
+    Registry.at('Fixnum').type.should == :class
+    Registry.at('Fixnum#popcount').type.should == :method
+    Registry.at('Object').type.should == :class
+    # Methods defined on Kernel are treated as if they were defined on Object
+    Registry.at('Object#pp').type.should == :method
+    Registry.at('Enumerable').type.should == :module
+    Registry.at('Enumerable#to_hash').type.should == :method
+  end
 end


### PR DESCRIPTION
In a C extension's Init method, code like this:

    rb_define_method(rb_cFixnum, "popcount", fix_popcount, 0);

...doesn't cause Fixnum#popcount to appear in the generated Yardocs, because YARD
can't find a definition of Fixnum anywhere in the C extension code.

Fix that, so that when a C extension adds a method to a core Ruby class or module,
the method documentation will appear in the generated Yardocs.