### PR TITLE
Stricter matching of override comments to methods defined in C extension

### DIFF
--- a/lib/yard/handlers/c/handler_methods.rb
+++ b/lib/yard/handlers/c/handler_methods.rb
@@ -158,10 +158,15 @@ module YARD
           # so look in overrides
           override_comments.each do |name, override_comment|
             next unless override_comment.file == file
-            name = name.gsub(/::([^:]+?)\Z/, '.\1')
-            just_method_name = name.gsub(/\A.+(#|::|\.)/, '')
-            just_method_name = 'initialize' if just_method_name == 'new'
-            if object.path == name || object.name.to_s == just_method_name
+            name = name.gsub(/::([^:\.#]+?)\Z/, '.\1')
+
+            path = if name =~ /\.|#/ # explicit namespace in override comment
+              object.path
+            else
+              object.name.to_s
+            end
+
+            if path == name || path == name.sub(/new$/, 'initialize') || path == name.sub('.', '#')
               register_docstring(object, override_comment.source, override_comment)
               return
             end


### PR DESCRIPTION
Previously, an override comment for `Foo#baz` would also be applied to `Bar#baz`.
This was especially problematic, because if an extension defined methods with the
same names on two different classes, the override comment which appeared *first*
in the source code would always be favored over a more specific comment which
appeared later.

One thing I'd like to clarify:

If there is an override comment for `Foo::foo`, should it be attached to *both* `Foo.foo` *and* `Foo#foo`?