### PR TITLE
Allow C initialization functions to have VALUE return type. Ref #909

### DIFF
--- a/lib/yard/handlers/c/init_handler.rb
+++ b/lib/yard/handlers/c/init_handler.rb
@@ -1,6 +1,6 @@
 # Handles the Init_Libname() method
 class YARD::Handlers::C::InitHandler < YARD::Handlers::C::Base
-  MATCH = %r{\A\s*(?:static\s+)?void\s+(?:[Ii]nit_)?(\w+)\s*}
+  MATCH = %r{\A\s*(?:static\s+)?(?:void|VALUE)\s+(?:[Ii]nit_)?(\w+)\s*}
   handles MATCH
   statement_class ToplevelStatement
 


### PR DESCRIPTION
This change allow functions that define classes/modules to have a signature that return either `void` or `VALUE`. More details in #909.