### PR TITLE
Seems to fix Chrome method signature height issue

### DIFF
--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -245,6 +245,7 @@ p.signature, h3.signature {
   font-size: 1.1em; font-weight: normal; font-family: Monaco, Consolas, Courier, monospace;
   padding: 6px 10px; margin-top: 1em;
   background: #E8F4FF; border: 1px solid #d8d8e5; border-radius: 5px;
+  line-height:2.2em;
 }
 p.signature tt,
 h3.signature tt { font-family: Monaco, Consolas, Courier, monospace; }


### PR DESCRIPTION
Or, the extra tall 'blueish' method signatures.

Not sure about where p.signature elements are used.  Used 2.2 simply based on twice
font-size...