### PR TITLE
fix matching of qualified Init_* function in the C parser

### DIFF
--- a/lib/yard/handlers/c/init_handler.rb
+++ b/lib/yard/handlers/c/init_handler.rb
@@ -1,6 +1,6 @@
 # Handles the Init_Libname() method
 class YARD::Handlers::C::InitHandler < YARD::Handlers::C::Base
-  MATCH = %r{\A\s*(?:static\s+)?void\s+(?:[Ii]nit_)?(\w+)\s*}
+  MATCH = %r{void\s+(?:[Ii]nit_)?(\w+)\s*}
   handles MATCH
   statement_class ToplevelStatement
 


### PR DESCRIPTION
Ruby extensions generated using SWIG have an Init function
looking like this:

#ifdef __cplusplus
extern "C"
#endif
SWIGEXPORT void Init_project(void) {
}

It is also easy to imagine many other kind of qualifiers in front
of the Init function declaration.
So yard should be rather flexible about the Init function prototype.