### PR TITLE
⚠️ `*' interpreted as argument prefix

### DIFF
--- a/lib/yard/rake/yardoc_task.rb
+++ b/lib/yard/rake/yardoc_task.rb
@@ -71,7 +71,7 @@ module YARD
           before.call if before.is_a?(Proc)
           yardoc = YARD::CLI::Yardoc.new
           yardoc.options[:verifier] = verifier if verifier
-          yardoc.run *(options + files)
+          yardoc.run(*(options + files))
           YARD::CLI::Stats.run(*(stats_options + ['--use-cache'])) unless stats_options.empty?
           after.call if after.is_a?(Proc)
         end


### PR DESCRIPTION
Here's a tiny patch that fixes a trivial Ruby warning.