### PR TITLE
Use last_description instead of last_comment for Rake 11

### DIFF
--- a/lib/yard/rake/yardoc_task.rb
+++ b/lib/yard/rake/yardoc_task.rb
@@ -66,7 +66,7 @@ module YARD
       # Defines the rake task
       # @return [void]
       def define
-        desc "Generate YARD Documentation" unless ::Rake.application.last_comment
+        desc "Generate YARD Documentation" unless ::Rake.application.last_description
         task(name) do
           before.call if before.is_a?(Proc)
           yardoc = YARD::CLI::Yardoc.new


### PR DESCRIPTION
Rake 11 removed `last_comment`. It should be replace `last_description`

see. https://github.com/ruby/rake/blob/master/History.rdoc