### PR TITLE
Allow wrapping extra file meta data in HTML comment

### DIFF
--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -575,6 +575,17 @@ might not be descriptive enough, so YARD allows you to specify a full title:
 Currently all other meta-data is hidden from view, though accessible
 programmatically using the {YARD::CodeObjects::ExtraFileObject} class.
 
+You can wrap the meta data section in an HTML comment to prevent it
+from being displayed in rendered markdown on GitHub:
+
+    <!--
+    # @markup markdown
+    # @title The Best Library in the World!
+    # @author The Author Name
+    -->
+
+    This is the best library you will ever meet. Lipsum ...
+
 <a name="config"></a>
 
 ## Configuring YARD

--- a/lib/yard/code_objects/extra_file_object.rb
+++ b/lib/yard/code_objects/extra_file_object.rb
@@ -93,6 +93,8 @@ module YARD::CodeObjects
           end
         when /^\s*#\s*@(\S+)\s*(.+?)\s*$/
           attributes[$1] = $2
+        when /^\s*<!--\s*$/, /^\s*-->\s*$/
+          # Ignore HTML comments
         else
           cut_index = index
           break

--- a/spec/code_objects/extra_file_object_spec.rb
+++ b/spec/code_objects/extra_file_object_spec.rb
@@ -34,6 +34,18 @@ describe YARD::CodeObjects::ExtraFileObject do
       expect(file.contents).to eq "FOO BAR"
     end
 
+    it "allows the attributes section to be wrapped in an HTML comment" do
+      file = ExtraFileObject.new('file.txt', "<!--\n# @title X\n-->\nFOO BAR")
+      expect(file.attributes[:title]).to eq "X"
+      expect(file.contents).to eq "FOO BAR"
+    end
+
+    it "allows whitespace around ignored HTML comment" do
+      file = ExtraFileObject.new('file.txt', " \t <!-- \n# @title X\n \t --> \nFOO BAR")
+      expect(file.attributes[:title]).to eq "X"
+      expect(file.contents).to eq "FOO BAR"
+    end
+
     it "parses out old-style #!markup shebang format" do
       file = ExtraFileObject.new('file.txt', "#!foobar\nHello")
       expect(file.attributes[:markup]).to eq "foobar"


### PR DESCRIPTION
Meta data for extra files has to be placed at the top of the
file. Since each line has to be prefixed with a `#` those lines are
displayed as headers when viewing markdown files on GitHub. This
commit allows hiding the meta data section in rendered markdown on
GitHub by wrapping it in an HTML comment:

    <!--
    # @title Some title
    -->

    Rest of document