### PR TITLE
Exclude frozen string comment from file docstring

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -5,6 +5,7 @@ module YARD
     module Ruby
       # Ruby 1.9 parser
       # @!attribute [r] encoding_line
+      # @!attribute [r] frozen_string_line
       # @!attribute [r] shebang_line
       # @!attribute [r] enumerator
       class RubyParser < Parser::Base
@@ -17,13 +18,14 @@ module YARD
         def enumerator; @parser.enumerator end
         def shebang_line; @parser.shebang_line end
         def encoding_line; @parser.encoding_line end
+        def frozen_string_line; @parser.frozen_string_line end
       end
 
       # Internal parser class
       # @since 0.5.6
       class RipperParser < Ripper
         attr_reader :ast, :charno, :comments, :file, :tokens
-        attr_reader :shebang_line, :encoding_line
+        attr_reader :shebang_line, :encoding_line, :frozen_string_line
         alias root ast
 
         def initialize(source, filename, *args)
@@ -43,6 +45,7 @@ module YARD
           @charno = 0
           @shebang_line = nil
           @encoding_line = nil
+          @frozen_string_line = nil
           @file_encoding = nil
         end
 
@@ -496,6 +499,9 @@ module YARD
               not_comment = true
             elsif comment =~ SourceParser::ENCODING_LINE
               @encoding_line = comment
+              not_comment = true
+            elsif comment =~ SourceParser::FROZEN_STRING_LINE
+              @frozen_string_line = comment
               not_comment = true
             end
           end

--- a/lib/yard/parser/source_parser.rb
+++ b/lib/yard/parser/source_parser.rb
@@ -62,6 +62,7 @@ module YARD
     class SourceParser
       SHEBANG_LINE  = /\A\s*#!\S+/
       ENCODING_LINE = /\A(?:\s*#*!.*\r?\n)?\s*(?:#+|\/\*+|\/\/+).*coding\s*[:=]{1,2}\s*([a-z\d_\-]+)/i
+      FROZEN_STRING_LINE = /frozen(-|_)string(-|_)literal: true/i
 
       # The default glob of files to be parsed.
       # @since 0.9.0

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -415,5 +415,13 @@ eof
         expect(Registry.at("Foo#bar").docstring).to eq "Docstring"
       end
     end
+
+    it "removes frozen string line from initial file comments" do
+      YARD.parse_string "# frozen_string_literal: true\n# this is a comment\nclass Foo; end"
+      YARD.parse_string "# Frozen-string-literal: true\n# this is a comment\nclass Bar; end"
+
+      expect(Registry.at(:Foo).docstring).to eq "this is a comment"
+      expect(Registry.at(:Bar).docstring).to eq "this is a comment"
+    end
   end
 end if HAVE_RIPPER


### PR DESCRIPTION
Ruby 2.3 added the `# frozen_string_literal: true` magic comment which enables immutable strings for a particular file.

This PR excludes those comments from file documentation in the same way that shebangs and encoding comments are currently excluded.

Edit: I'm confused why CI is failing as all specs pass for me locally. Any advice?