### PR TITLE
YARD module - fixes docstring when doc'd

### DIFF
--- a/lib/yard/handlers/ruby/private_constant_handler.rb
+++ b/lib/yard/handlers/ruby/private_constant_handler.rb
@@ -1,7 +1,8 @@
-# Sets visibility of a constant (class, module, const)
 module YARD
   module Handlers
     module Ruby
+
+      # Sets visibility of a constant (class, module, const)
       class PrivateConstantHandler < YARD::Handlers::Ruby::Base
         handles method_call(:private_constant)
         namespace_only


### PR DESCRIPTION
comment is for PrivateConstantHandler 

prev code
```ruby
#COMMENT
module YARD
  module Handlers
    module Ruby
      class PrivateConstantHandler
```

changed code code
```ruby
module YARD
  module Handlers
    module Ruby
      #COMMENT
      class PrivateConstantHandler
```