### PR TITLE
Fixes #984 - Index page, items in 'File Listing' wrapping - style.css file

### DIFF
--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -215,7 +215,14 @@ p.inherited {
 
 ul.toplevel { list-style: none; padding-left: 0; font-size: 1.1em; }
 .index_inline_list { padding-left: 0; font-size: 1.1em; }
-.index_inline_list li { list-style: none; display: inline-block; padding: 7px 12px; line-height: 35px; }
+
+.index_inline_list li {
+  list-style: none;
+  display: inline-block;
+  padding: 0 12px;
+  line-height: 30px;
+  margin-bottom: 5px;
+}
 
 dl.constants { margin-left: 10px; }
 dl.constants dt { font-weight: bold; font-size: 1.1em; margin-bottom: 5px; }


### PR DESCRIPTION
I apologize for #984.  It was an old commit that I had some merge commits mixed in with.  #984 had css units switched to em, which I prefer.  I removed them, incorrectly, as padding, margins, etc need to be set differently for inline and inline-block elements.  I checked this commit with Chrome and Firefox.

FYI, the GitHub 'App' for Windows is what creates all the merge commits.  If I use command line/shell, no issues.

