### PR TITLE
Auto-link constants and identifiers in Ruby syntax highlighting

### DIFF
--- a/lib/yard/autoload.rb
+++ b/lib/yard/autoload.rb
@@ -174,6 +174,7 @@ module YARD
 
       autoload :AstNode,           __p('parser/ruby/ast_node')
       autoload :RubyParser,        __p('parser/ruby/ruby_parser')
+      autoload :TokenResolver,     __p('parser/ruby/token_resolver')
     end
 
     autoload :Base,                __p('parser/base')

--- a/lib/yard/parser/ruby/token_resolver.rb
+++ b/lib/yard/parser/ruby/token_resolver.rb
@@ -1,0 +1,154 @@
+module YARD
+  module Parser
+    module Ruby
+      # Supports {#each} enumeration over a source's tokens, yielding
+      # the token and a possible {CodeObjects::Base} associated with the
+      # constant or identifier token.
+      class TokenResolver
+        include Enumerable
+
+        # Creates a token resolver for given source.
+        #
+        # @param source [String] the source code to tokenize
+        # @param namespace [CodeObjects::Base] the object/namespace to resolve from
+        def initialize(source, namespace = Registry.root)
+          @tokens = RubyParser.parse(source, '(tokenize)').tokens
+          raise ParserSyntaxError if @tokens.empty? && !source.empty?
+          @default_namespace = namespace
+        end
+
+        # Iterates over each token, yielding the token and a possible code
+        # object that is associated with the token.
+        #
+        # @yieldparam token [Array(Symbol,String,Array(Integer,Integer))] the
+        #   current token object being iterated
+        # @yieldparam object [CodeObjects::Base, nil] the fully qualified code
+        #   object associated with the current token, or nil if there is no object
+        #   for the yielded token.
+        # @example Yielding code objects
+        #   r = TokenResolver.new("A::B::C")
+        #   r.each do |tok, obj|
+        #     if obj
+        #       puts "#{tok[0]} -> #{obj.path.inspect}"
+        #     else
+        #       puts "No object: #{tok.inspect}"
+        #     end
+        #   end
+        #
+        #   # Prints:
+        #   # :const -> "A"
+        #   # No object: [:op, "::"]
+        #   # :const -> "A::B"
+        #   # No object: [:op, "::"]
+        #   # :const -> "A::B::C"
+        def each(&block)
+          @states = []
+          push_state
+          @tokens.each do |token|
+            yield_obj = false
+
+            if skip_group && [:const, :ident, :op, :period].include?(token[0])
+              yield token, nil
+              next
+            else
+              self.skip_group = false
+            end
+
+            case token[0]
+            when :const
+              lookup(token[0], token[1])
+              yield_obj = true
+              self.last_sep = nil
+            when :ident
+              lookup(token[0], token[1])
+              yield_obj = true
+              self.last_sep = nil
+            when :op, :period
+              self.last_sep = token[1]
+              if !CodeObjects.types_for_separator(token[1])
+                self.object = nil
+                self.last_sep = nil
+              end
+            when :lparen
+              push_state
+            when :rparen
+              pop_state
+            else
+              self.object = nil
+            end
+
+            yield token, (yield_obj ? object : nil)
+
+            if next_object
+              self.object = next_object
+              self.next_object = nil
+            end
+            self.skip_group = true if yield_obj && object.nil?
+          end
+        end
+
+        private
+
+        def push_state
+          @states.push :object => nil, :skip_group => false, :last_sep => nil
+        end
+
+        def pop_state
+          @states.pop
+        end
+
+        def self.state_attr(*attrs)
+          attrs.each do |attr|
+            define_method(attr) { @states.last[attr.to_sym] }
+            define_method("#{attr}=") {|v| @states.last[attr.to_sym] = v }
+            protected attr, :"#{attr}="
+          end
+        end
+
+        state_attr :object, :next_object, :skip_group, :last_sep
+
+        def lookup(toktype, name)
+          types = object_resolved_types
+          return self.object = nil if types.empty?
+
+          if toktype == :const
+            types.any? do |type|
+              prefix = (type ? type.path : "") + last_sep.to_s
+              self.object = Registry.resolve(@default_namespace, "#{prefix}#{name}", true)
+            end
+          else # ident
+            types.any? do |type|
+              obj = Registry.resolve(type, name, true)
+              if obj.nil? && name == "new"
+                obj = Registry.resolve(object, "#initialize", true)
+                self.next_object = object if obj.nil?
+              end
+              self.object = obj
+            end
+          end
+        end
+
+        def object_resolved_types(obj = object)
+          return [obj] unless obj.is_a?(CodeObjects::MethodObject)
+
+          resolved_types = []
+          tags = obj.tags(:return)
+          tags += obj.tags(:overload).map {|o| o.tags(:return) }.flatten
+          tags.each do |tag|
+            next if tag.types.nil?
+            tag.types.each do |type|
+              type = type.sub(/<.+>/, '')
+              if type == "self"
+                resolved_types << obj.parent
+              elsif type_obj = Registry.resolve(obj, type, true)
+                resolved_types << type_obj
+              end
+            end
+          end
+
+          resolved_types
+        end
+      end
+    end
+  end
+end

--- a/spec/parser/ruby/token_resolver_spec.rb
+++ b/spec/parser/ruby/token_resolver_spec.rb
@@ -1,0 +1,165 @@
+require File.join(File.dirname(__FILE__), '..', '..', 'spec_helper')
+
+describe YARD::Parser::Ruby::TokenResolver do
+  before(:all) do
+    YARD.parse_string <<-eof
+      module A
+        def nomatch; end
+
+        module B
+          class C
+            def initialize; end
+
+            # @return [A::B::C]
+            def self.foo; end
+
+            # @return [self]
+            def self.foo2; end
+
+            def bar; end
+
+            # @return [nil, D<String>]
+            def baz; end
+
+            # @return [nil]
+            # @return [D<String>]
+            def baz2; end
+
+            # @overload qux(a)
+            #   @return [nil]
+            # @overload qux(b)
+            #   @return [D<String>]
+            def qux; end
+          end
+
+          class SubC < C
+          end
+        end
+      end
+
+      module D
+        def baz; end
+      end
+
+      class Q
+        def method; end
+
+        # @return [Q]
+        def self.q; end
+      end
+    eof
+  end
+
+  def tokens_match
+    expect(@resolved.map {|t| t.first.last }.join).to eq @src
+  end
+
+  def objs_match(*objects)
+    other_objs = @resolved.reject {|_, o| !o }.map {|_, o| o.path }
+    expect(other_objs).to eq objects.flatten
+    tokens_match
+  end
+
+  def tokenize(src, object = nil)
+    @src = src
+    @resolver = YARD::Parser::Ruby::TokenResolver.new(src, object)
+    @resolved = @resolver.map {|t, o| [t[0, 2], o] }
+  end
+
+  it "returns regular tokens" do
+    str = "def foo; Z::X::Y end"
+    tokenize(str)
+    tokens_match
+  end
+
+  it "resolves objects in compound constant paths" do
+    tokenize "A::B::C"
+    objs_match "A", "A::B", "A::B::C"
+  end
+
+  it "ignores full constant path if it breaks at beginning" do
+    tokenize "E::A::B::C"
+    objs_match []
+  end
+
+  it "ignores rest of constant path if sub-objects don't match" do
+    tokenize "D::A::B::C"
+    objs_match "D"
+  end
+
+  it "resets parsing at non-op tokens" do
+    tokenize "A::B::C < Q"
+    objs_match "A", "A::B", "A::B::C", "Q"
+  end
+
+  it "does not restart constant path" do
+    tokenize "A::B::D::A"
+    objs_match "A", "A::B"
+  end
+
+  it "resolves objects from base namespace" do
+    tokenize "A::B::C C", Registry.at("A::B")
+    objs_match "A", "A::B", "A::B::C", "A::B::C"
+  end
+
+  it "resolves methods" do
+    tokenize "A::B::C.foo"
+    objs_match "A", "A::B", "A::B::C", "A::B::C.foo"
+  end
+
+  it "supports 'new' constructor method" do
+    tokenize "A::B::C.new"
+    objs_match "A", "A::B", "A::B::C", "A::B::C#initialize"
+  end
+
+  it "skips constructor method if not found but continues resolving" do
+    tokenize "Q.new.method"
+    objs_match "Q", "Q#method"
+  end
+
+  it "resolves methods in inheritance tree" do
+    tokenize "A::B::SubC.new"
+    objs_match "A", "A::B", "A::B::SubC", "A::B::C#initialize"
+  end
+
+  it "parses compound method call chains based on return type" do
+    tokenize "A::B::C.foo.baz"
+    objs_match "A", "A::B", "A::B::C", "A::B::C.foo", "A::B::C#baz"
+  end
+
+  it "stops resolving if return types not found" do
+    tokenize "A::B::C.foo.bar.baz.baz"
+    objs_match "A", "A::B", "A::B::C", "A::B::C.foo", "A::B::C#bar"
+  end
+
+  it "handles multiple return types (returns first valid type match)" do
+    tokenize "A::B::C.foo.baz.baz"
+    objs_match "A", "A::B", "A::B::C", "A::B::C.foo", "A::B::C#baz", "D#baz"
+  end
+
+  it "doesn't perform lexical matching on methods" do
+    tokenize "A::B::C.nomatch"
+    objs_match "A", "A::B", "A::B::C"
+  end
+
+  it "handles multiple return tags (returns first valid type match)" do
+    tokenize "A::B::C.foo.baz2.baz"
+    objs_match "A", "A::B", "A::B::C", "A::B::C.foo", "A::B::C#baz2", "D#baz"
+  end
+
+  it "handles self as return type" do
+    tokenize "A::B::C.foo2.baz"
+    objs_match "A", "A::B", "A::B::C", "A::B::C.foo2", "A::B::C#baz"
+  end
+
+  it "handles multiple return tags inside overload tags" do
+    tokenize "A::B::C.foo.qux.baz"
+    objs_match "A", "A::B", "A::B::C", "A::B::C.foo", "A::B::C#qux", "D#baz"
+  end
+
+  it "resolves method calls with arguments" do
+    tokenize "Q.q(A::B, A::B::C.foo().bar).q.q"
+    objs_match "Q", "Q.q", "A", "A::B", "A", "A::B", "A::B::C",
+               "A::B::C.foo", "A::B::C#bar", "Q.q", "Q.q"
+  end
+end if HAVE_RIPPER

--- a/spec/templates/helpers/html_syntax_highlight_helper_spec.rb
+++ b/spec/templates/helpers/html_syntax_highlight_helper_spec.rb
@@ -5,7 +5,7 @@ describe YARD::Templates::Helpers::HtmlSyntaxHighlightHelper do
   include YARD::Templates::Helpers::HtmlSyntaxHighlightHelper
 
   describe "#html_syntax_highlight" do
-    let(:object) { Registry.root }
+    let(:object) { CodeObjects::NamespaceObject.new(:root, :YARD) }
 
     before do
       Registry.root.source_type = :ruby
@@ -42,13 +42,24 @@ describe YARD::Templates::Helpers::HtmlSyntaxHighlightHelper do
     end if HAVE_RIPPER
 
     it "returns escaped unhighlighted source if a syntax error is found (ripper)" do
-      expect(self).to receive(:options).and_return(Options.new.update(:highlight => true))
+      allow(self).to receive(:options).and_return(Options.new.update(:highlight => true))
       expect(html_syntax_highlight("def &x; ... end")).to eq "def &amp;x; ... end"
     end if HAVE_RIPPER
 
     it "returns escaped unhighlighted source if a syntax error is found (ripper)" do
-      expect(self).to receive(:options).and_return(Options.new.update(:highlight => true))
+      allow(self).to receive(:options).and_return(Options.new.update(:highlight => true))
       expect(html_syntax_highlight("$ git clone http://url")).to eq "$ git clone http://url"
+    end if HAVE_RIPPER
+
+    it "links constants/methods" do
+      other = CodeObjects::NamespaceObject.new(:root, :Other)
+      allow(self).to receive(:options).and_return(Options.new.update(:highlight => true))
+      allow(self).to receive(:run_verifier).with([other]).and_return([other])
+      allow(self).to receive(:link_object).with(other, "Other").and_return("LINK!")
+      result = html_syntax_highlight("def x; Other end")
+      html_equals_string(result, "<span class='kw'>def</span>
+        <span class='id identifier rubyid_x'>x</span><span class='semicolon'>;</span>
+        <span class='const'>LINK!</span> <span class='kw'>end</span>")
     end if HAVE_RIPPER
   end
 end

--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -108,6 +108,9 @@ h2 small a {
 }
 .rdoc-term { padding-right: 25px; font-weight: bold; }
 .rdoc-list p { margin: 0; padding: 0; margin-bottom: 4px; }
+.summary_desc pre.code .object_link a, .docstring pre.code .object_link a {
+  padding: 0px; background: inherit; color: inherit; border-radius: inherit;
+}
 
 /* style for <table> */
 #filecontents table, .docstring table { border-collapse: collapse; }
@@ -479,3 +482,9 @@ pre.code .rubyid_backref,
 pre.code .rubyid_nth_ref { color: #6D79DE; }
 pre.code .regexp, .dregexp { color: #036A07; }
 pre.code a { border-bottom: 1px dotted #bbf; }
+
+/* Color fix for links */
+#content .summary_desc pre.code .id > .object_link a, /* identifier */
+#content .docstring pre.code .id > .object_link a { color: #0085FF; }
+#content .summary_desc pre.code .const > .object_link a, /* constant */
+#content .docstring pre.code .const > .object_link a { color: #585CF6; }


### PR DESCRIPTION
# Description

This change allows constants and identifiers (simple constants, compound constants, and method names) rendered inside of code blocks to be automatically linked to their respective objects. 

Supports the following features: 

* Resolving from the current object's namespace (code in Foo::Bar will link methods inside that namespace)
* Compound paths and method calls (`A::B.foo`)
* Initialize / .new calls
* Method call chaining by reading return tags from resolved methods to continue lookup (`A.new.foo.bar.baz` where foo/bar/baz have `@return` tags).
* `self` return type
* Methods with arguments (parentheses only)

## Screenshots

![Screenshot](https://cloud.githubusercontent.com/assets/686/17088027/6a1c69c0-51ca-11e6-81ff-f5d87db5a257.PNG)

![Screenshot](https://cloud.githubusercontent.com/assets/686/17088017/31648d6a-51ca-11e6-9df4-94f6cab3fe88.PNG)

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and they pass (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md

