### PR TITLE
Fix a broken link

### DIFF
--- a/docs/Tags.md
+++ b/docs/Tags.md
@@ -141,7 +141,7 @@ a set of conventions for how to list types is described below.
 
 <p class="note">
   A list of examples of common type listings and what they translate into is
-  available at <a href="http://yardoc.org/types">http://yardoc.org/types</a>.
+  available at <a href="http://yardoc.org/types.html">http://yardoc.org/types</a>.
 </p>
 
 Typically, a type list contains a list of classes or modules that are associated


### PR DESCRIPTION
# Description

The `Type List Conventions` section of `docs/Tags.md`  contains a broken link (http://yardoc.org/types) which displays the home page instead of http://yardoc.org/types.html.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] ~~I wrote tests and they pass~~ (not applicable).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md