### PR TITLE
CSS Updates for UI - style.css and full_list.css

### DIFF
--- a/templates/default/fulldoc/html/css/full_list.css
+++ b/templates/default/fulldoc/html/css/full_list.css
@@ -1,26 +1,92 @@
-body {
+html {
   margin: 0;
-  font-family: "Lucida Sans", "Lucida Grande", Verdana, Arial, sans-serif;
-  font-size: 13px;
-  height: 101%;
-  overflow-x: hidden;
-  background: #fafafa;
+  padding: 0;
+  width: 100%;
+  height: 100%;
+  top: 0;
 }
 
-h1 { padding: 12px 10px; padding-bottom: 0; margin: 0; font-size: 1.4em; }
+body {
+  margin: 0; padding: 0;
+  font-family: "Lucida Sans", "Lucida Grande", Verdana, Arial, sans-serif;
+  font-size: 13px;
+  height: 100%;
+  overflow: hidden;
+  background: #fafafa;
+  position: relative;
+}
+
+#content {
+  height: 100%;
+   width: 100%;
+  overflow: hidden;
+}
+
+.fixed_header {
+  position: absolute;
+  background: #fff;
+  width: 100%;
+  margin-top: 0;
+  top: 0;
+  z-index: 9999;
+  box-sizing: border-box;
+  height: 75px; }
+
+#full_list {
+  padding: 0;
+  list-style: none;
+  margin: 0;
+  font-size: 1.1em;
+  position: absolute;
+  top: 75px;
+  width: 100%;
+  max-height: calc( 100% - 75px);
+  box-sizing: border-box;
+  overflow-y: auto;
+  overflow-x: hidden;
+  -webkit-overflow-scrolling: touch;
+}
+  
+#content h1 { padding: 4px 10px 12px; padding-bottom: 0; margin: 0; font-size: 1.4em; }
+
 .clear { clear: both; }
-.fixed_header { position: fixed; background: #fff; width: 100%; padding-bottom: 10px; margin-top: 0; top: 0; z-index: 9999; height: 70px; }
-#search { position: absolute; right: 5px; top: 9px; padding-left: 24px; }
+
+#search {
+  right: 5px;
+  top: 9px;
+  width: 180px;
+  position: static;
+  margin: 3px;
+  margin-left: 10px;
+  font-size: 0.9em;
+  color: #888;
+  padding-left: 0;
+  padding-right: 14px; }
+
 #content.insearch #search, #content.insearch #noresults { background: url(data:image/gif;base64,R0lGODlhEAAQAPYAAP///wAAAPr6+pKSkoiIiO7u7sjIyNjY2J6engAAAI6OjsbGxjIyMlJSUuzs7KamppSUlPLy8oKCghwcHLKysqSkpJqamvT09Pj4+KioqM7OzkRERAwMDGBgYN7e3ujo6Ly8vCoqKjY2NkZGRtTU1MTExDw8PE5OTj4+PkhISNDQ0MrKylpaWrS0tOrq6nBwcKysrLi4uLq6ul5eXlxcXGJiYoaGhuDg4H5+fvz8/KKiohgYGCwsLFZWVgQEBFBQUMzMzDg4OFhYWBoaGvDw8NbW1pycnOLi4ubm5kBAQKqqqiQkJCAgIK6urnJyckpKSjQ0NGpqatLS0sDAwCYmJnx8fEJCQlRUVAoKCggICLCwsOTk5ExMTPb29ra2tmZmZmhoaNzc3KCgoBISEiIiIgAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAACH/C05FVFNDQVBFMi4wAwEAAAAh/hpDcmVhdGVkIHdpdGggYWpheGxvYWQuaW5mbwAh+QQJCAAAACwAAAAAEAAQAAAHaIAAgoMgIiYlg4kACxIaACEJCSiKggYMCRselwkpghGJBJEcFgsjJyoAGBmfggcNEx0flBiKDhQFlIoCCA+5lAORFb4AJIihCRbDxQAFChAXw9HSqb60iREZ1omqrIPdJCTe0SWI09GBACH5BAkIAAAALAAAAAAQABAAAAdrgACCgwc0NTeDiYozCQkvOTo9GTmDKy8aFy+NOBA7CTswgywJDTIuEjYFIY0JNYMtKTEFiRU8Pjwygy4ws4owPyCKwsMAJSTEgiQlgsbIAMrO0dKDGMTViREZ14kYGRGK38nHguHEJcvTyIEAIfkECQgAAAAsAAAAABAAEAAAB2iAAIKDAggPg4iJAAMJCRUAJRIqiRGCBI0WQEEJJkWDERkYAAUKEBc4Po1GiKKJHkJDNEeKig4URLS0ICImJZAkuQAhjSi/wQyNKcGDCyMnk8u5rYrTgqDVghgZlYjcACTA1sslvtHRgQAh+QQJCAAAACwAAAAAEAAQAAAHZ4AAgoOEhYaCJSWHgxGDJCQARAtOUoQRGRiFD0kJUYWZhUhKT1OLhR8wBaaFBzQ1NwAlkIszCQkvsbOHL7Y4q4IuEjaqq0ZQD5+GEEsJTDCMmIUhtgk1lo6QFUwJVDKLiYJNUd6/hoEAIfkECQgAAAAsAAAAABAAEAAAB2iAAIKDhIWGgiUlh4MRgyQkjIURGRiGGBmNhJWHm4uen4ICCA+IkIsDCQkVACWmhwSpFqAABQoQF6ALTkWFnYMrVlhWvIKTlSAiJiVVPqlGhJkhqShHV1lCW4cMqSkAR1ofiwsjJyqGgQAh+QQJCAAAACwAAAAAEAAQAAAHZ4AAgoOEhYaCJSWHgxGDJCSMhREZGIYYGY2ElYebi56fhyWQniSKAKKfpaCLFlAPhl0gXYNGEwkhGYREUywag1wJwSkHNDU3D0kJYIMZQwk8MjPBLx9eXwuETVEyAC/BOKsuEjYFhoEAIfkECQgAAAAsAAAAABAAEAAAB2eAAIKDhIWGgiUlh4MRgyQkjIURGRiGGBmNhJWHm4ueICImip6CIQkJKJ4kigynKaqKCyMnKqSEK05StgAGQRxPYZaENqccFgIID4KXmQBhXFkzDgOnFYLNgltaSAAEpxa7BQoQF4aBACH5BAkIAAAALAAAAAAQABAAAAdogACCg4SFggJiPUqCJSWGgkZjCUwZACQkgxGEXAmdT4UYGZqCGWQ+IjKGGIUwPzGPhAc0NTewhDOdL7Ykji+dOLuOLhI2BbaFETICx4MlQitdqoUsCQ2vhKGjglNfU0SWmILaj43M5oEAOwAAAAAAAAAAAA==) no-repeat center left; }
-#full_list { padding: 0; list-style: none; margin-left: 0; margin-top: 80px; font-size: 1.1em; }
 #full_list ul { padding: 0; }
 #full_list li { padding: 0; margin: 0; list-style: none; }
 #full_list li .item { padding: 5px 5px 5px 12px; }
 #noresults { padding: 7px 12px; background: #fff; }
 #content.insearch #noresults { margin-left: 7px; }
 li.collapsed ul { display: none; }
-li a.toggle { cursor: default; position: relative; left: -5px; top: 4px; text-indent: -999px; width: 10px; height: 9px; margin-left: -10px; display: block; float: left; background: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAASCAYAAABb0P4QAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAK8AAACvABQqw0mAAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTM5jWRgMAAAAVdEVYdENyZWF0aW9uIFRpbWUAMy8xNC8wOeNZPpQAAAE2SURBVDiNrZTBccIwEEXfelIAHUA6CZ24BGaWO+FuzZAK4k6gg5QAdGAq+Bxs2Yqx7BzyL7Llp/VfzZeQhCTc/ezuGzKKnKSzpCxXJM8fwNXda3df5RZETlIt6YUzSQDs93sl8w3wBZxCCE10GM1OcWbWjB2mWgEH4Mfdyxm3PSepBHibgQE2wLe7r4HjEidpnXMYdQPKEMJcsZ4zs2POYQOcaPfwMVOo58zsAdMt18BuoVDPxUJRacELbXv3hUIX2vYmOUvi8C8ydz/ThjXrqKqqLbDIAdsCKBd+Wo7GWa7o9qzOQHVVVXeAbs+yHHCH4aTsaCOQqunmUy1yBUAXkdMIfMlgF5EXLo2OpV/c/Up7jG4hhHcYLgWzAZXUc2b2ixsfvc/RmNNfOXD3Q/oeL9axJE1yT9IOoUu6MGUkAAAAAElFTkSuQmCC) no-repeat bottom left; }
-li.collapsed a.toggle { opacity: 0.5; cursor: default; background-position: top left; }
+
+li a.toggle { cursor: default;
+  text-indent: -999px;
+  width: 10px;
+  height: 9px;
+  padding: 3px 6px 5px 13px;
+  margin-left: -29px;
+  display: block; float: left;
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABQAAAASCAYAAABb0P4QAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAK8AAACvABQqw0mAAAABx0RVh0U29mdHdhcmUAQWRvYmUgRmlyZXdvcmtzIENTM5jWRgMAAAAVdEVYdENyZWF0aW9uIFRpbWUAMy8xNC8wOeNZPpQAAAE2SURBVDiNrZTBccIwEEXfelIAHUA6CZ24BGaWO+FuzZAK4k6gg5QAdGAq+Bxs2Yqx7BzyL7Llp/VfzZeQhCTc/ezuGzKKnKSzpCxXJM8fwNXda3df5RZETlIt6YUzSQDs93sl8w3wBZxCCE10GM1OcWbWjB2mWgEH4Mfdyxm3PSepBHibgQE2wLe7r4HjEidpnXMYdQPKEMJcsZ4zs2POYQOcaPfwMVOo58zsAdMt18BuoVDPxUJRacELbXv3hUIX2vYmOUvi8C8ydz/ThjXrqKqqLbDIAdsCKBd+Wo7GWa7o9qzOQHVVVXeAbs+yHHCH4aTsaCOQqunmUy1yBUAXkdMIfMlgF5EXLo2OpV/c/Up7jG4hhHcYLgWzAZXUc2b2ixsfvc/RmNNfOXD3Q/oeL9axJE1yT9IOoUu6MGUkAAAAAElFTkSuQmCC);
+  background-repeat: no-repeat;
+  background-position: bottom left;
+  background-origin: content-box;
+    background-clip: content-box;
+  cursor: pointer; 
+}
+li.collapsed a.toggle { opacity: 0.5; cursor: default; background-position: top left; cursor: pointer; }
+
 li { color: #888; cursor: pointer; }
 li.deprecated { text-decoration: line-through; font-style: italic; }
 li.odd { background: #f0f0f0; }
@@ -41,13 +107,12 @@ li.collapsed.clicked a.toggle { background-position: top right; }
 #full_list_nav span:after { content: ' | '; }
 #full_list_nav span:last-child:after { content: ''; }
 
-#content h1 { margin-top: 0; }
-li { white-space: nowrap; cursor: normal; }
+li { white-space: nowrap; }
 li small { display: block; font-size: 0.8em; }
 li small:before { content: ""; }
 li small:after { content: ""; }
 li small.search_info { display: none; }
-#search { width: 170px; position: static; margin: 3px; margin-left: 10px; font-size: 0.9em; color: #888; padding-left: 0; padding-right: 24px; }
+
 #content.insearch #search { background-position: center right; }
 #search input { width: 110px; }
 

--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -1,4 +1,4 @@
-html {
+html { margin: 0; padding: 0;
   width: 100%;
   height: 100%;
 }
@@ -6,11 +6,13 @@ body {
   font-family: "Lucida Sans", "Lucida Grande", Verdana, Arial, sans-serif;
   font-size: 13px;
   width: 100%;
+  height: 100%;
   margin: 0;
   padding: 0;
-  display: flex;
   display: -webkit-flex;
   display: -ms-flexbox;
+  display: flex;
+  overflow: hidden;
 }
 
 #nav {
@@ -27,12 +29,12 @@ body {
   width: 20%;
   height: 100%;
   position: relative;
-  display: flex;
   display: -webkit-flex;
   display: -ms-flexbox;
-  flex-shrink: 0;
+  display: flex;
   -webkit-flex-shrink: 0;
   -ms-flex: 1 0;
+  flex-shrink: 0;
 }
 #resizer {
   position: absolute;
@@ -44,14 +46,17 @@ body {
   z-index: 9999;
 }
 #main {
-  flex: 5 1;
   -webkit-flex: 5 1;
   -ms-flex: 5 1;
+  flex: 5 1;
   outline: none;
   position: relative;
   background: #fff;
   padding: 1.2em;
   padding-top: 0.2em;
+  box-sizing: border-box;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;  
 }
 
 @media (max-width: 920px) {
@@ -59,8 +64,6 @@ body {
 }
 
 @media (min-width: 920px) {
-  body { height: 100%; overflow: hidden; }
-  #main { height: 100%; overflow: auto; }
   #search { display: none; }
   #search_frame { display: none; }
 }
@@ -181,14 +184,14 @@ p.inherited {
   border: 0;
   width: 100%;
   font-size: 1em;
-  display: flex;
   display: -webkit-flex;
   display: -ms-flexbox;
+  display: flex;
 }
 .box_info dl dt {
-  flex-shrink: 0;
   -webkit-flex-shrink: 1;
   -ms-flex-shrink: 1;
+  flex-shrink: 0;
   width: 100px;
   text-align: right;
   font-weight: bold;
@@ -198,9 +201,9 @@ p.inherited {
   padding-right: 10px;
 }
 .box_info dl dd {
-  flex-grow: 1;
   -webkit-flex-grow: 1;
   -ms-flex: 1;
+  flex-grow: 1;
   max-width: 420px;
   padding: 6px 0;
   padding-right: 20px;
@@ -229,7 +232,15 @@ ul.toplevel { list-style: none; padding-left: 0; font-size: 1.1em; }
 
 dl.constants { margin-left: 10px; }
 dl.constants dt { font-weight: bold; font-size: 1.1em; margin-bottom: 5px; }
-dl.constants dd { width: 75%; white-space: pre; font-family: monospace; margin-bottom: 18px; }
+
+dl.constants dd { width: 100%; font-family: monospace; margin-bottom: 18px;
+  margin-left: 0;
+  padding-left: 32px;
+  box-sizing: border-box;
+}
+
+dl.constants dd pre.code { word-wrap: normal; white-space: normal; }
+
 dl.constants .docstring .note:first-child { margin-top: 5px; }
 
 .summary_desc {
@@ -395,9 +406,9 @@ li.r2 { background: #fafafa; }
   position: absolute;
   top: 40px;
   right: 12px;
-  width: 500px;
+  min-width: 15em;
   max-width: 80%;
-  height: 80%;
+  height: calc(100% - 50px);
   overflow-y: scroll;
   border: 1px solid #999;
   border-collapse: collapse;


### PR DESCRIPTION
### Description

Changes to the two css files, style.css and full_list.css.
#### Changes regardless of browser window width:
- List pane scrollbar does not extend into header.
- Momentum scrolling added for both main doc & list pane.
- List pane header adjusted to avoid incorrect search text input box placement in iOS.
- Enlarged the target area for 'Class List' tree open/close.  On a tablet, one has a fighting chance of opening a 'Class List' node without also loading the node.
#### Changes for browser window width less that 920 pixels in width:
- List pane show/hide control (a#full_list_link) is locked to the right window side, not the right document side.  Previously, for 'over-width' docs, it would require horizontal scrolling to make the control visible.
- List pane is limited in height to the window height.
- Changes the layout of constant code block, it will now wrap text.  Previously, many constants that were long lists of items would cause the doc page to   overflow the window width.  This corrects that, but may cause issues when a  constant is defined by lines of code wider than the screen. View the following in a narrow browser window:
  http://www.rubydoc.info/github/lsegal/yard/YARD/CodeObjects
#### General changes:
- Correctly ordered vendor prefixed css properties, of course, per convention.
#### Tested with:
- Current desktop versions of Chrome and Firefox
- iOS Safari and Chrome
### Completed Tasks
- [X] I have read the [Contributing Guide](https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md).
- [X] The pull request is complete (implemented / written).
- [X] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] NOT APPLICABLE - I wrote tests and they pass (if code is attached to PR).
