### PR TITLE
[Breaking Change] Add validation to YARD::Verifier

### DIFF
--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -583,7 +583,7 @@ module YARD
 
         opts.on('--no-private', "Hide objects with @private tag") do
           options.verifier.add_expressions '!object.tag(:private) &&
-            (object.namespace.is_a?(CodeObjects::Proxy) || !object.namespace.tag(:private))'
+            (object.namespace.type == :proxy || !object.namespace.tag(:private))'
         end
 
         opts.on('--[no-]api API', 'Generates documentation for a given API',

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -454,8 +454,7 @@ describe YARD::CLI::Yardoc do
     end
 
     it "does not call #tag on namespace if namespace is proxy with --no-private" do
-      ns = double(:namespace)
-      expect(ns).to receive(:is_a?).with(CodeObjects::Proxy).and_return(true)
+      ns = double(:namespace, :type => :proxy)
       expect(ns).not_to receive(:tag)
       obj = double(:object, :type => :class, :namespace => ns, :visibility => :public)
       expect(obj).to receive(:tag).ordered.with(:private).and_return(false)
@@ -468,7 +467,6 @@ describe YARD::CLI::Yardoc do
       Registry.clear
       YARD.parse_string "module Qux; class Foo::Bar; end; end"
       foobar = Registry.at('Foo::Bar')
-      foobar.namespace.type = :module
       @yardoc.parse_arguments *%w( --no-private )
       expect(@yardoc.options.verifier.call(foobar)).to be true
     end


### PR DESCRIPTION
# Description
1. Evaluation has been placed inside of BasicObject sandbox to avoid Kernel method calls
2. Constants are no longer allowed in Verifier expressions
3. require() and send() calls are no longer allowed in expressions

This change may affect existing verifier filters using complex logic.
# Completed Tasks
- [x] I have read the [Contributing Guide](https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md).
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and they pass (if code is attached to PR).
