### PR TITLE
Update to CodeObjects 'BUILTIN' constants

### DIFF
--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -63,20 +63,29 @@ module YARD
     METHODMATCH = /(?:(?:#{NAMESPACEMATCH}|[a-z]\w*)\s*(?:#{CSEPQ}|#{NSEPQ})\s*)?#{METHODNAMEMATCH}/
 
     # All builtin Ruby exception classes for inheritance tree.
-    BUILTIN_EXCEPTIONS = ["SecurityError", "Exception", "NoMethodError", "FloatDomainError",
-      "IOError", "TypeError", "NotImplementedError", "SystemExit", "Interrupt", "SyntaxError",
-      "RangeError", "NoMemoryError", "ArgumentError", "ThreadError", "EOFError", "RuntimeError",
-      "ZeroDivisionError", "StandardError", "LoadError", "NameError", "LocalJumpError", "SystemCallError",
-      "SignalException", "ScriptError", "SystemStackError", "RegexpError", "IndexError"]
+    BUILTIN_EXCEPTIONS = ["ArgumentError", "ClosedQueueError", "EncodingError",
+      "EOFError", "Exception", "FiberError", "FloatDomainError", "IndexError",
+      "Interrupt", "IOError", "KeyError", "LoadError", "LocalJumpError",
+      "NameError", "NoMemoryError", "NoMethodError", "NotImplementedError",
+      "RangeError", "RegexpError", "RuntimeError", "ScriptError", "SecurityError",
+      "SignalException", "StandardError", "StopIteration", "SyntaxError",
+      "SystemCallError", "SystemExit", "SystemStackError", "ThreadError",
+      "TypeError", "UncaughtThrowError", "ZeroDivisionError"]
+
     # All builtin Ruby classes for inheritance tree.
     # @note MatchingData is a 1.8.x legacy class
-    BUILTIN_CLASSES = ["TrueClass", "Array", "Dir", "Struct", "UnboundMethod", "Object", "Fixnum", "Float",
-      "ThreadGroup", "MatchingData", "MatchData", "Proc", "Binding", "Class", "Time", "Bignum", "NilClass", "Symbol",
-      "Numeric", "String", "Data", "MatchData", "Regexp", "Integer", "File", "IO", "Range", "FalseClass",
-      "Method", "Continuation", "Thread", "Hash", "Module"] + BUILTIN_EXCEPTIONS
+    BUILTIN_CLASSES = ["Array", "Bignum", "Binding", "Class", "Complex",
+      "ConditionVariable", "Data", "Dir", "Encoding", "Enumerator", "FalseClass",
+      "Fiber", "File", "Fixnum", "Float", "Hash", "IO", "Integer", "MatchData",
+      "Method", "Module", "NilClass", "Numeric", "Object", "Proc", "Queue",
+      "Random", "Range", "Rational", "Regexp", "RubyVM", "SizedQueue", "String",
+      "Struct", "Symbol", "Thread", "ThreadGroup", "Time", "TracePoint",
+      "TrueClass", "UnboundMethod"] + BUILTIN_EXCEPTIONS
+
     # All builtin Ruby modules for mixin handling.
-    BUILTIN_MODULES = ["ObjectSpace", "Signal", "Marshal", "Kernel", "Process", "GC", "FileTest", "Enumerable",
-      "Comparable", "Errno", "Precision", "Math"]
+    BUILTIN_MODULES = ["Comparable", "Enumerable", "Errno", "FileTest", "GC",
+      "Kernel", "Marshal", "Math", "ObjectSpace", "Precision", "Process", "Signal"]
+
     # All builtin Ruby classes and modules.
     BUILTIN_ALL = BUILTIN_CLASSES + BUILTIN_MODULES
 

--- a/spec/code_objects/constants_spec.rb
+++ b/spec/code_objects/constants_spec.rb
@@ -50,19 +50,27 @@ describe YARD::CodeObjects do
 
   describe :BUILTIN_EXCEPTIONS do
     it "includes all base exceptions" do
+      bad_names = []
       YARD::CodeObjects::BUILTIN_EXCEPTIONS.each do |name|
-        expect(eval(name)).to be <= Exception
+        begin
+          bad_names << name unless eval(name) <= Exception
+        rescue NameError
+        end
       end
+      expect(bad_names).to be_empty
     end
   end
 
   describe :BUILTIN_CLASSES do
     it "includes all base classes" do
+      bad_names = []
       YARD::CodeObjects::BUILTIN_CLASSES.each do |name|
-        next if name == "MatchingData" && !defined?(::MatchingData)
-        next if name == "Continuation"
-        expect(eval(name)).to be_instance_of(Class)
+        begin
+          bad_names << name unless eval(name).is_a?(Class)
+        rescue NameError
+        end
       end
+      expect(bad_names).to be_empty
     end
 
     it "includes all exceptions" do


### PR DESCRIPTION
# Description

Per #1003. Additionally, I decided to update all three,  `BUILTIN_EXCEPTIONS`, `BUILTIN_CLASSES`, and `BUILTIN_MODULES`.

* Ordered items
* Switched to %w
* Ruby 2.3.2
* Left `MatchingData` in `BUILTIN_CLASSES`
* `BUILTIN_CLASSES` still doesn't contain `ARGF` & `ENV` , both fail RSpec
* Kept approx 80+ char margin
* Blank space between ok?

# Completed Tasks

* [X] I have read the [Contributing Guide][contrib].
* [X] The pull request is complete (implemented / written).
* [ ] Git commits have been cleaned up (squash WIP / revert commits).
* [X] I wrote tests and they pass (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
