### PR TITLE
Server Process.fork error Windows

### DIFF
--- a/lib/yard/server/commands/library_command.rb
+++ b/lib/yard/server/commands/library_command.rb
@@ -29,11 +29,13 @@ module YARD
       #
       # @abstract
       class LibraryCommand < Base
-        begin
-          Process.fork { exit 0 }
-          CAN_FORK = true
-        rescue
-          CAN_FORK = false
+        CAN_FORK = false
+        if Process.respond_to?(:fork)
+          begin
+            Process.fork { exit 0 }
+            CAN_FORK = true
+          rescue
+          end
         end
 
         # @return [LibraryVersion] the object containing library information


### PR DESCRIPTION
After pulling changes tonite, tests failed on Windows.

Crash on `Process.fork`.  See the following, and note

'If fork is not usable, Process.respond_to?(:fork) returns false.'  Hence, added that test to the code.

https://msp-greg.github.io/Ruby-2.3/Core/Process.html#fork-class_method

# Completed Tasks

* [X] I have read the [Contributing Guide][contrib].
* [X] The pull request is complete (implemented / written).
* [X] Git commits have been cleaned up (squash WIP / revert commits).
* [X] Tested locally against Ruby 2.2.4 & 2.3.2.

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md

