### PR TITLE
Issue #1002 - 'stack level too deep' - freeze_tree

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -656,10 +656,13 @@ module YARD
         end
 
         def freeze_tree(node = nil)
-          node ||= root
-          node.children.each do |child|
-            child.parent = node
-            freeze_tree(child)
+          nodes = [node || root]
+          while !nodes.empty?
+            p_node = nodes.shift
+            p_node.children.each do |child|
+              child.parent = p_node
+              nodes << child
+            end
           end
         end
       end if defined?(::Ripper)


### PR DESCRIPTION
Per discussion in issue #1002 - 'stack level too deep', change removes re-entrant code.

# Completed Tasks

* [X] I have read the [Contributing Guide][contrib].
* [X] The pull request is complete (implemented / written).
* [X] Git commits have been cleaned up (squash WIP / revert commits).
* [X] Tested locally with Ruby 2.2.4 & 2.3.2.

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md