### PR TITLE
Parser percent arrays fix

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -49,6 +49,7 @@ module YARD
           @frozen_string_line = nil
           @file_encoding = nil
           @newline = true
+          @percent_ary = nil
         end
 
         def parse
@@ -261,7 +262,21 @@ module YARD
         end
 
         def add_token(token, data)
-          if @tokens.last && @tokens.last[0] == :symbeg
+          if @percent_ary
+            if token == :words_sep && data !~ /\s\z/
+              rng = @percent_ary.source_range
+              rng = Range.new(rng.first, rng.last + data.length)
+              @percent_ary.source_range = rng
+              @tokens << [token, data, [lineno, charno]]
+              @percent_ary = nil
+            elsif token == :tstring_end && data =~ /\A\s/
+              rng = @percent_ary.source_range
+              rng = Range.new(rng.first, rng.last + data.length)
+              @percent_ary.source_range = rng
+              @tokens << [token, data, [lineno, charno]]
+              @percent_ary = nil
+            end
+          elsif @tokens.last && @tokens.last[0] == :symbeg
             @tokens[-1] = [:symbol, ":" + data, @tokens.last[2]]
           elsif @heredoc_state == :started
             @heredoc_tokens << [token, data, [lineno, charno]]
@@ -295,8 +310,6 @@ module YARD
         undef on_aref_field
         undef on_lbracket
         undef on_rbracket
-        undef on_qwords_new
-        undef on_qwords_add
         undef on_string_literal
         undef on_lambda
         undef on_unary
@@ -423,6 +436,7 @@ module YARD
             begin; undef on_#{kw}_new; rescue NameError; end
             def on_#{kw}_new(*args)
               node = LiteralNode.new(:#{kw}_literal, args)
+              @percent_ary = node
               if @map[:#{kw}_beg]
                 lstart, sstart = *@map[:#{kw}_beg].pop
                 node.source_range = Range.new(sstart, @ns_charno-1)


### PR DESCRIPTION
# Description

Fixes percent array parsing with `\n ]` for closing delimiter
# Completed Tasks
- [X] I have read the [Contributing Guide](https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md).
- [X] The pull request is complete (implemented / written).
- [X] Git commits have been cleaned up (squash WIP / revert commits).
- [X] I wrote tests and they pass (if code is attached to PR).
