### PR TITLE
revise strange file path.

### DIFF
--- a/lib/yard/templates/engine.rb
+++ b/lib/yard/templates/engine.rb
@@ -35,7 +35,7 @@ module YARD
         def template(*path)
           from_template = nil
           from_template = path.shift if path.first.is_a?(Template)
-          path = path.join('/')
+          path = path.join('/').gsub(' ','')
           full_paths = find_template_paths(from_template, path)
 
           path = File.cleanpath(path).gsub('../', '')


### PR DESCRIPTION
# Description

When I want use my template from Rakefile,

``` 
 YARD::Rake::YardocTask.new{|t|
    t.files=['lib/**/*.rb']
    t.options=[]
  }
  YARD::Rake::YardocTask.new {|t|
    t.files=['**/*.md']
    t.options=['-t mathjax']
  }
```

above half works well, but below half dosn't.

The error tells 

```
ArgumentError: No such template for  mathjax/fulldoc/html
/usr/local/lib/ruby/gems/2.2.0/gems/yard-0.9.5/lib/yard/templates/engine.rb:41:in `template'
```

The path in engine.rb puts a character ' ' at the front.  When I write the template in .yardopts, '-t mathjax' works well.  If the template description is '-tmathjax' not '-t mathjax', it should be ok but not a usual sense.

# Completed Tasks

* [o] I have read the [Contributing Guide][contrib].
* [o] The pull request is complete (implemented / written).
* [o] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and they pass (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
