### PR TITLE
Add some ruby-lang builtin conventions

### DIFF
--- a/spec/handlers/examples/method_handler_001.rb.txt
+++ b/spec/handlers/examples/method_handler_001.rb.txt
@@ -73,6 +73,29 @@ end
   #   @return whether today is the rainy day.
   def rainy?; end
 
+  # @group Some well known methods without @return tag
+
+  def to_s; end
+  def inspect; end
+  def to_sym; end
+  def to_int; end
+  def to_i; end
+  def to_f; end
+  def to_r; end
+  def to_ary; end
+  def to_a; end
+  def to_hash; end
+  def to_h; end
+  def to_enum; end
+  def enum_for; end
+  def to_proc; end
+  def to_io; end
+  def hash; end
+  def marshal_dump; end
+  def _dump; end
+
+  # @endgroup
+
   attr_writer :attr_name
   def attr_name; end
 

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -114,6 +114,33 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHandler"
     expect(meth).not_to have_tag(:return)
   end
 
+  {
+    :to_s         => String,
+    :inspect      => String,
+    :to_sym       => Symbol,
+    :to_int       => Integer,
+    :to_i         => Integer,
+    :to_f         => Float,
+    :to_r         => Rational,
+    :to_ary       => Array,
+    :to_a         => Array,
+    :to_hash      => Hash,
+    :to_h         => Hash,
+    :to_enum      => Enumerator,
+    :enum_for     => Enumerator,
+    :to_proc      => Proc,
+    :to_io        => IO,
+    :hash         => Integer,
+    :marshal_dump => String,
+    :_dump        => String
+  }.each_pair do |name, klass|
+    it "sets @return tag on ##{name} if no docstring is set" do
+      meth = P("Foo##{name}")
+      expect(meth).to have_tag(:return)
+      expect(meth.tag(:return).types).to eq [klass.to_s]
+    end
+  end
+
   it "adds method writer to existing attribute" do
     expect(Registry.at('Foo#attr_name')).to be_reader
     expect(Registry.at('Foo#attr_name=')).to be_writer


### PR DESCRIPTION
# Description

Some ruby methods are expected to be overridden as `inspect`.
I'll be happy if I can reduce `@return [String]` from them as `def predicate?`.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and they pass (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md

---

But when this PR has any style difference, please tell me 🙇 
(I don't have confident around `/^$/` vs `/\A\z/` and `Hash syntax`...)