### PR TITLE
Do not crash on unnamed double splat argument

### DIFF
--- a/lib/yard/parser/ruby/ast_node.rb
+++ b/lib/yard/parser/ruby/ast_node.rb
@@ -410,7 +410,8 @@ module YARD
         end
 
         def double_splat_param
-          YARD.ruby2? ? self[-2] : nil
+          return nil unless YARD.ruby2?
+          self[-2] if self[-2].is_a?(AstNode) && self[-2].type == :ident
         end
 
         def block_param

--- a/spec/handlers/examples/method_handler_001.rb.txt
+++ b/spec/handlers/examples/method_handler_001.rb.txt
@@ -40,6 +40,8 @@ end
   def /(x = File.new('x', 'w'), y = 2) end
   def |; end; def =~ ()
   def -@; end;
+  def d_splat(reg, **opts); end
+  def d_unnamed_splat(**); end
 end
   def *(o) def +@; end
     def ~@

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -51,6 +51,11 @@ describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHandler"
     expect(P('Foo#blockmeth').parameters).to eq [['x', nil], ['&block', nil]]
   end
 
+  it "handles double splats" do
+    expect(P('Foo#d_splat').parameters).to eq [["reg", nil], ["**opts", nil]]
+    expect(P('Foo#d_unnamed_splat').parameters).to eq []
+  end
+
   it "handles overloads" do
     meth = P('Foo#foo')
 

--- a/spec/templates/examples/method006.html
+++ b/spec/templates/examples/method006.html
@@ -1,0 +1,108 @@
+<h1>Method: #m</h1>
+<div class="box_info">
+  <dl>
+    <dt class="">Defined in:</dt>
+    <dd class="">
+    (stdin)
+    </dd>
+  </dl>
+</div>
+
+<div class="method_details_list">
+  <div id="method_details">
+    <div class="method_details first">
+  <h3 class="signature first" id="m-instance_method">
+  
+    #<strong>m</strong>(x, y, *args, kword1: 123, kword2:)  
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+
+  </div>
+</div>
+<div class="tags">
+  <p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>x</span>
+      
+      
+        <span class='type'>(<tt>String</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>the x argument</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>y</span>
+      
+      
+        <span class='type'>(<tt>Boolean</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>the y argument</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>keyword</span>
+      
+      
+        <span class='type'>(<tt>kword1</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>1</div>
+      
+    </li>
+  
+    <li>
+      
+        <span class='name'>keyword</span>
+      
+      
+        <span class='type'>(<tt>kword2</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>2</div>
+      
+    </li>
+  
+</ul>
+
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+5</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File '(stdin)', line 5</span>
+
+def m(x, y, *args, kword1: 123, kword2:, **) end</pre>
+    </td>
+  </tr>
+</table>
+</div>
+  </div>
+</div>

--- a/spec/templates/examples/method006.txt
+++ b/spec/templates/examples/method006.txt
@@ -1,0 +1,20 @@
+------------------------------------------------------------- Method: #m
+                                                   (Defined in: (stdin))
+
+    root.m(x, y, *args, kword1: 123, kword2:) 
+------------------------------------------------------------------------
+
+    
+Parameters:
+-----------
+
+    (String) x - the x argument
+
+    (Boolean) y - the y argument
+
+    (kword1) keyword - 1
+
+    (kword2) keyword - 2
+
+
+

--- a/spec/templates/method_spec.rb
+++ b/spec/templates/method_spec.rb
@@ -100,4 +100,19 @@ describe YARD::Templates::Engine.template(:default, :method) do
 
     it_should_behave_like "all formats"
   end
+
+  describe "method with keyword arguments spalt" do
+    before do
+      @template = :method006
+      YARD.parse_string <<-'eof'
+        # @param [String] x the x argument
+        # @param [Boolean] y the y argument
+        # @param [kword1] keyword 1
+        # @param [kword2] keyword 2
+        def m(x, y, *args, kword1: 123, kword2:, **) end
+      eof
+    end
+
+    it_should_behave_like "all formats"
+  end
 end


### PR DESCRIPTION
# Description

Handle double splats in more safe manner, and do not crash on unnamed double splat arguments like this:

```
def example(**)
end
```

Describe your pull request and problem statement here.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md