### PR TITLE
spec: Skip markdown-specific test with 'pending'.

### DIFF
--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -184,7 +184,7 @@ describe YARD::Templates::Helpers::HtmlHelper do
     it "creates tables (markdown specific)" do
       log.enter_level(Logger::FATAL) do
         unless markup_class(:markdown).to_s == "RedcarpetCompat"
-          skip "This test depends on a markdown engine that supports tables"
+          pending "This test depends on a markdown engine that supports tables"
         end
       end
 


### PR DESCRIPTION
In Guix, redcarpet isn't available during the tests because this creates a circular dependency, so I came across the following error, fixed by this pull request, I believe.
```
Failures:

  1) YARD::Templates::Helpers::HtmlHelper#htmlify creates tables (markdown specific)
     Failure/Error: skip "This test depends on a markdown engine that supports tables"
     NoMethodError:
       undefined method `skip' for #<RSpec::Core::ExampleGroup::Nested_122::Nested_4:0x0055555a184840>
     # ./spec/templates/helpers/html_helper_spec.rb:187:in `block (4 levels) in <top (required)>'
     # ./lib/yard/logging.rb:168:in `enter_level'
     # ./spec/templates/helpers/html_helper_spec.rb:185:in `block (3 levels) in <top (required)>'
```