### PR TITLE
Use RuboCop::RakeTask in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -36,9 +36,8 @@ rescue LoadError
   nil # noop
 end
 
-task :rubocop do
-  sh "rubocop"
-end
+require 'rubocop/rake_task'
+RuboCop::RakeTask.new
 
 task :default => [:rubocop, :spec]
 


### PR DESCRIPTION
This PR uses the RakeTask class from RuboCop to define its Rake task.