### PR TITLE
Cleanup yard specs and fix lots of warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Gemfile.lock
 /coverage
 /.bundle
 /vendor
+spec/examples.txt

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --color
+--require spec_helper

--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -220,8 +220,10 @@ module YARD
         @has_markup = false
 
         if defined?(::Encoding) && ::Encoding.respond_to?(:default_external=)
-          ::Encoding.default_external = 'utf-8'
-          ::Encoding.default_internal = 'utf-8'
+          utf8 = ::Encoding.find('utf-8')
+
+          ::Encoding.default_external = utf8 unless ::Encoding.default_external == utf8
+          ::Encoding.default_internal = utf8 unless ::Encoding.default_internal == utf8
         end
       end
 

--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -272,7 +272,7 @@ module YARD
       # @return [String] if prefix is true, prefix + the name as a String.
       #   This must be implemented by the subclass.
       def name(prefix = false)
-        prefix ? @name.to_s : @name
+        prefix ? @name.to_s : (defined?(@name) && @name)
       end
 
       # Associates a file with a code object, optionally adding the line where it was defined.

--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -172,7 +172,7 @@ module YARD
     # @return [String] The first line or paragraph of the docstring; always ends with a period.
     def summary
       resolve_reference
-      return @summary if @summary
+      return @summary if defined?(@summary) && @summary
       stripped = gsub(/[\r\n](?![\r\n])/, ' ').strip
       num_parens = 0
       idx = length.times do |index|

--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -327,7 +327,7 @@ module YARD
     # @return [void]
     def resolve_reference
       loop do
-        return if @unresolved_reference.nil?
+        return if defined?(@unresolved_reference).nil? || @unresolved_reference.nil?
         return if CodeObjects::Proxy === @unresolved_reference
 
         reference = @unresolved_reference

--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -154,7 +154,7 @@ module YARD
       resolve_reference
       obj = super
       %w(all summary tags ref_tags).each do |name|
-        val = instance_variable_get("@#{name}")
+        val = instance_variable_defined?("@#{name}") && instance_variable_get("@#{name}")
         obj.instance_variable_set("@#{name}", val ? val.dup : nil)
       end
       obj

--- a/lib/yard/handlers/c/base.rb
+++ b/lib/yard/handlers/c/base.rb
@@ -26,7 +26,11 @@ module YARD
         end
 
         def self.statement_class(type = nil)
-          type ? @statement_class = type : (@statement_class || Statement)
+          if type
+            @statement_class = type
+          else
+            (defined?(@statement_class) && @statement_class) || Statement
+          end
         end
 
         # @group Registering objects

--- a/lib/yard/logging.rb
+++ b/lib/yard/logging.rb
@@ -48,6 +48,7 @@ module YARD
       self.formatter = method(:format_log)
       @progress_indicator = 0
       @mutex = Mutex.new
+      @progress_msg = nil
     end
 
     # Changes the debug level to DEBUG if $DEBUG is set

--- a/lib/yard/options.rb
+++ b/lib/yard/options.rb
@@ -173,7 +173,7 @@ module YARD
         instance_variable_set("@#{$1}", args.first)
       elsif args.empty?
         log.debug "Attempting to access unregistered key #{meth} on #{self.class}"
-        instance_variable_get("@#{meth}")
+        instance_variable_defined?("@#{meth}") ? instance_variable_get("@#{meth}") : nil
       else
         super
       end

--- a/lib/yard/options.rb
+++ b/lib/yard/options.rb
@@ -188,7 +188,9 @@ module YARD
     def reset_defaults
       names_set = {}
       self.class.ancestors.each do |klass| # look at all ancestors
-        defaults = klass.instance_variable_get("@defaults")
+        defaults =
+          klass.instance_variable_defined?("@defaults") &&
+          klass.instance_variable_get("@defaults")
         next unless defaults
         defaults.each do |key, value|
           next if names_set[key]

--- a/lib/yard/parser/ruby/ast_node.rb
+++ b/lib/yard/parser/ruby/ast_node.rb
@@ -158,6 +158,7 @@ module YARD
           @fallback_line = opts[:listline]
           @fallback_source = opts[:listchar]
           @token = true if opts[:token]
+          @docstring = nil
         end
 
         # @return [Boolean] whether the node is equal to another by checking

--- a/lib/yard/parser/ruby/legacy/ruby_lex.rb
+++ b/lib/yard/parser/ruby/legacy/ruby_lex.rb
@@ -463,6 +463,8 @@ module YARD
         @skip_space = false
         @read_auto_clean_up = false
         @exception_on_syntax_error = true
+
+        @colonblock_seen = false
       end
 
       attr_accessor :skip_space

--- a/lib/yard/parser/ruby/legacy/ruby_lex.rb
+++ b/lib/yard/parser/ruby/legacy/ruby_lex.rb
@@ -663,7 +663,7 @@ module YARD
           if @lex_state != EXPR_END && @lex_state != EXPR_CLASS &&
              (@lex_state != EXPR_ARG || @space_seen)
             c = peek(0)
-            tk = identify_here_document if /[-\w_\"\'\`]/ =~ c
+            tk = identify_here_document if /[-\w\"\'\`]/ =~ c
           end
           if !tk
             @lex_state = EXPR_BEG
@@ -913,7 +913,7 @@ module YARD
         end
 
         @OP.def_rule('@') do
-          if peek(0) =~ /[@\w_]/
+          if peek(0) =~ /[@\w]/
             ungetc
             identify_identifier
           else
@@ -939,7 +939,7 @@ module YARD
           printf "MATCH: start %s: %s\n", op, io.inspect if RubyLex.debug?
           if peek(0) =~ /[0-9]/
             t = identify_number("")
-          elsif peek(0) =~ /[\w_]/
+          elsif peek(0) =~ /[\w]/
             t = identify_identifier
           end
           printf "MATCH: end %s: %s\n", op, io.inspect if RubyLex.debug?

--- a/lib/yard/parser/ruby/legacy/statement_list.rb
+++ b/lib/yard/parser/ruby/legacy/statement_list.rb
@@ -17,6 +17,7 @@ module YARD
       def initialize(content)
         @shebang_line = nil
         @encoding_line = nil
+        @comments_last_line = nil
         if content.is_a? TokenList
           @tokens = content.dup
         elsif content.is_a? String

--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -221,6 +221,8 @@ module YARD
           eof
         end
 
+        undef on_sp
+
         def on_sp(tok)
           add_token(:sp, tok)
           @charno += tok.length

--- a/lib/yard/registry_resolver.rb
+++ b/lib/yard/registry_resolver.rb
@@ -15,6 +15,7 @@ module YARD
     #   object
     def initialize(registry = Registry)
       @registry = registry
+      @default_sep = nil
     end
 
     # Performs a lookup on a given path in the registry. Resolution will occur

--- a/lib/yard/server/templates/doc_server/library_list/html/listing.erb
+++ b/lib/yard/server/templates/doc_server/library_list/html/listing.erb
@@ -1,6 +1,6 @@
 <ul>
   <% @libraries.sort_by {|name, y| name.downcase }.each do |name, library_versions| %>
-  <li class="r<%= @row = @row == 1 ? 2 : 1 %>">
+  <li class="r<%= @row = (!defined?(@row) || @row == 1) ? 2 : 1 %>">
     <% library_versions = library_versions.dup %>
     <% first_lib = library_versions.pop %>
     <a href="<%= abs_url(router.docs_prefix, first_lib.name) %>"><%= name %></a>

--- a/lib/yard/tags/library.rb
+++ b/lib/yard/tags/library.rb
@@ -157,13 +157,14 @@ module YARD
         def define_tag(label, tag, meth = nil)
           tag_meth = tag_method_name(tag)
           if meth.is_a?(Class) && Tag > meth
-            class_eval <<-eof, __FILE__, __LINE__
+            class_eval(<<-eof, __FILE__, __LINE__ + 1)
               def #{tag_meth}(text)
                 #{meth}.new(#{tag.inspect}, text)
               end
             eof
           else
-            class_eval <<-eof, __FILE__, __LINE__
+            class_eval(<<-eof, __FILE__, __LINE__ + 1)
+              begin; undef #{tag_meth}; rescue NameError; end
               def #{tag_meth}(text)
                 send_to_factory(#{tag.inspect}, #{meth.inspect}, text)
               end

--- a/lib/yard/templates/erb_cache.rb
+++ b/lib/yard/templates/erb_cache.rb
@@ -15,7 +15,7 @@ module YARD
       end
 
       def self.clear!
-        return unless @methods
+        return unless defined?(@methods) && @methods
         @methods.clear
       end
     end

--- a/lib/yard/templates/helpers/base_helper.rb
+++ b/lib/yard/templates/helpers/base_helper.rb
@@ -8,7 +8,7 @@ module YARD::Templates::Helpers
     #   page. Might not be the current {#object} when inside sub-templates.
     attr_reader :owner
     undef owner
-    def owner; @owner || object.namespace end
+    def owner; (defined?(@owner) && @owner) || object.namespace end
 
     # @group Managing Global Template State
 

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -237,8 +237,8 @@ module YARD
             link = linkify(name, title)
             if (link == name || link == title) && (name + ' ' + link !~ /\A<a\s.*>/)
               match = /(.+)?(\{#{Regexp.quote name}(?:\s.*?)?\})(.+)?/.match(text)
-              file = ((defined?(@file) && @file) ? @file.filename : object.file) || '(unknown)'
-              line = ((defined?(@file) && @file) ? 1 : (object.docstring.line_range ? object.docstring.line_range.first : 1)) + (match ? $`.count("\n") : 0)
+              file = (defined?(@file) && @file ? @file.filename : object.file) || '(unknown)'
+              line = (defined?(@file) && @file ? 1 : (object.docstring.line_range ? object.docstring.line_range.first : 1)) + (match ? $`.count("\n") : 0)
               log.warn "In file `#{file}':#{line}: Cannot resolve link to #{name} from text" + (match ? ":" : ".") +
                        "\n\t" + (match[1] ? '...' : '') + match[2].delete("\n") + (match[3] ? '...' : '') if match
             end

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -237,8 +237,8 @@ module YARD
             link = linkify(name, title)
             if (link == name || link == title) && (name + ' ' + link !~ /\A<a\s.*>/)
               match = /(.+)?(\{#{Regexp.quote name}(?:\s.*?)?\})(.+)?/.match(text)
-              file = (@file ? @file.filename : object.file) || '(unknown)'
-              line = (@file ? 1 : (object.docstring.line_range ? object.docstring.line_range.first : 1)) + (match ? $`.count("\n") : 0)
+              file = ((defined?(@file) && @file) ? @file.filename : object.file) || '(unknown)'
+              line = ((defined?(@file) && @file) ? 1 : (object.docstring.line_range ? object.docstring.line_range.first : 1)) + (match ? $`.count("\n") : 0)
               log.warn "In file `#{file}':#{line}: Cannot resolve link to #{name} from text" + (match ? ":" : ".") +
                        "\n\t" + (match[1] ? '...' : '') + match[2].delete("\n") + (match[3] ? '...' : '') if match
             end
@@ -552,7 +552,7 @@ module YARD
       # @since 0.5.4
       def charset
         has_encoding = defined?(::Encoding)
-        if @file && has_encoding
+        if defined?(@file) && @file && has_encoding
           lang = @file.contents.encoding.to_s
         else
           return 'utf-8' unless has_encoding || ENV['LANG']

--- a/lib/yard/verifier.rb
+++ b/lib/yard/verifier.rb
@@ -131,6 +131,7 @@ module YARD
       expr = expressions.map {|e| "(#{parse_expression(e)})" }.join(" && ")
 
       instance_eval(<<-eof, __FILE__, __LINE__ + 1)
+        begin; undef __execute; rescue NameError; end
         def __execute; #{expr}; end
       eof
     end

--- a/spec/cli/command_parser_spec.rb
+++ b/spec/cli/command_parser_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::CLI::CommandParser do
+RSpec.describe YARD::CLI::CommandParser do
   describe "#run" do
     before do
       @cmd = CLI::CommandParser.new

--- a/spec/cli/command_parser_spec.rb
+++ b/spec/cli/command_parser_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::CommandParser do
   describe "#run" do

--- a/spec/cli/command_spec.rb
+++ b/spec/cli/command_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + "/../spec_helper"
 require 'optparse'
 
 describe YARD::CLI::Command do

--- a/spec/cli/command_spec.rb
+++ b/spec/cli/command_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'optparse'
 
-describe YARD::CLI::Command do
+RSpec.describe YARD::CLI::Command do
   describe "#parse_options" do
     before do
       @options = OptionParser.new

--- a/spec/cli/config_spec.rb
+++ b/spec/cli/config_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'yaml'
 
-describe YARD::CLI::Config do
+RSpec.describe YARD::CLI::Config do
   before do
     @config = YARD::CLI::Config.new
     YARD::Config.options = YARD::Config::DEFAULT_CONFIG_OPTIONS.dup

--- a/spec/cli/config_spec.rb
+++ b/spec/cli/config_spec.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
-
 require 'yaml'
 
 describe YARD::CLI::Config do

--- a/spec/cli/diff_spec.rb
+++ b/spec/cli/diff_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 require 'stringio'
 require 'open-uri'
 

--- a/spec/cli/diff_spec.rb
+++ b/spec/cli/diff_spec.rb
@@ -2,7 +2,7 @@
 require 'stringio'
 require 'open-uri'
 
-describe YARD::CLI::Diff do
+RSpec.describe YARD::CLI::Diff do
   before do
     allow(CLI::Yardoc).to receive(:run)
     allow(CLI::Gems).to receive(:run)

--- a/spec/cli/display_spec.rb
+++ b/spec/cli/display_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::CLI::Display do
+RSpec.describe YARD::CLI::Display do
   before do
     allow(Registry).to receive(:load)
     @object = CodeObjects::ClassObject.new(:root, :Foo)

--- a/spec/cli/display_spec.rb
+++ b/spec/cli/display_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::Display do
   before do

--- a/spec/cli/gems_spec.rb
+++ b/spec/cli/gems_spec.rb
@@ -2,7 +2,7 @@
 require 'ostruct'
 require 'rubygems'
 
-describe YARD::CLI::Gems do
+RSpec.describe YARD::CLI::Gems do
   before do
     @rebuild = false
     @gem1 = build_mock('gem1')

--- a/spec/cli/gems_spec.rb
+++ b/spec/cli/gems_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 require 'ostruct'
 require 'rubygems'
 

--- a/spec/cli/graph_spec.rb
+++ b/spec/cli/graph_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::Graph do
   it "serializes output" do

--- a/spec/cli/graph_spec.rb
+++ b/spec/cli/graph_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::CLI::Graph do
+RSpec.describe YARD::CLI::Graph do
   it "serializes output" do
     allow(Registry).to receive(:load).at_least(1).times
     allow(subject).to receive(:yardopts) { [] }

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::Help do
   describe "#run" do

--- a/spec/cli/help_spec.rb
+++ b/spec/cli/help_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::CLI::Help do
+RSpec.describe YARD::CLI::Help do
   describe "#run" do
     it "accepts help command" do
       expect(CLI::Yardoc).to receive(:run).with('--help')

--- a/spec/cli/i18n_spec.rb
+++ b/spec/cli/i18n_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::I18n do
   before do

--- a/spec/cli/i18n_spec.rb
+++ b/spec/cli/i18n_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::CLI::I18n do
+RSpec.describe YARD::CLI::I18n do
   before do
     @i18n = YARD::CLI::I18n.new
     @i18n.use_document_file = false

--- a/spec/cli/list_spec.rb
+++ b/spec/cli/list_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::List do
   it "passes command off to Yardoc with --list" do

--- a/spec/cli/list_spec.rb
+++ b/spec/cli/list_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::CLI::List do
+RSpec.describe YARD::CLI::List do
   it "passes command off to Yardoc with --list" do
     expect(YARD::CLI::Yardoc).to receive(:run).with('-c', '--list', '--foo')
     YARD::CLI::List.run('--foo')

--- a/spec/cli/markup_types_spec.rb
+++ b/spec/cli/markup_types_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::MarkupTypes do
   it "lists all available markup types" do

--- a/spec/cli/markup_types_spec.rb
+++ b/spec/cli/markup_types_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::CLI::MarkupTypes do
+RSpec.describe YARD::CLI::MarkupTypes do
   it "lists all available markup types" do
     YARD::CLI::MarkupTypes.run
     data = log.io.string

--- a/spec/cli/server_spec.rb
+++ b/spec/cli/server_spec.rb
@@ -2,7 +2,7 @@
 
 class Server::WebrickAdapter; def start; end end
 
-describe YARD::CLI::Server do
+RSpec.describe YARD::CLI::Server do
   before do
     allow(CLI::Yardoc).to receive(:run)
     @no_verify_libraries = false

--- a/spec/cli/server_spec.rb
+++ b/spec/cli/server_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 class Server::WebrickAdapter; def start; end end
 

--- a/spec/cli/stats_spec.rb
+++ b/spec/cli/stats_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 require 'stringio'
 
 describe YARD::CLI::Stats do

--- a/spec/cli/stats_spec.rb
+++ b/spec/cli/stats_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'stringio'
 
-describe YARD::CLI::Stats do
+RSpec.describe YARD::CLI::Stats do
   before do
     Registry.clear
     YARD.parse_string <<-eof

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::CLI::Yardoc do
+RSpec.describe YARD::CLI::Yardoc do
   before do
     @yardoc = YARD::CLI::Yardoc.new
     @yardoc.statistics = false

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::CLI::Yardoc do
   before do

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe YARD::CLI::Yardoc do
       @counter ||= 0
       @counter += 1
       counter = @counter
+      define_method("test_options_#{@counter}", &block)
       args.each do |arg|
-        define_method("test_options_#{@counter}", &block)
         it("accepts #{arg}") { send("test_options_#{counter}", arg) }
       end
     end

--- a/spec/cli/yri_spec.rb
+++ b/spec/cli/yri_spec.rb
@@ -6,7 +6,7 @@ class TestYRI < YARD::CLI::YRI
   def print_object(*args) test_stub; super end
 end
 
-describe YARD::CLI::YRI do
+RSpec.describe YARD::CLI::YRI do
   before do
     @yri = TestYRI.new
     allow(Registry).to receive(:load)

--- a/spec/cli/yri_spec.rb
+++ b/spec/cli/yri_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 class TestYRI < YARD::CLI::YRI
   public :optparse, :find_object, :cache_object

--- a/spec/code_objects/base_spec.rb
+++ b/spec/code_objects/base_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects::Base do
+RSpec.describe YARD::CodeObjects::Base do
   before { Registry.clear }
 
   it "does not allow empty object name" do

--- a/spec/code_objects/class_object_spec.rb
+++ b/spec/code_objects/class_object_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects::ClassObject do
+RSpec.describe YARD::CodeObjects::ClassObject do
   describe "#inheritance_tree" do
     before(:all) do
       Registry.clear

--- a/spec/code_objects/code_object_list_spec.rb
+++ b/spec/code_objects/code_object_list_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects::CodeObjectList do
+RSpec.describe YARD::CodeObjects::CodeObjectList do
   before { Registry.clear }
 
   describe "#push" do

--- a/spec/code_objects/constants_spec.rb
+++ b/spec/code_objects/constants_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects do
+RSpec.describe YARD::CodeObjects do
   describe :CONSTANTMATCH do
     it "matches a constant" do
       expect("Constant"[CodeObjects::CONSTANTMATCH]).to eq "Constant"

--- a/spec/code_objects/extra_file_object_spec.rb
+++ b/spec/code_objects/extra_file_object_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects::ExtraFileObject do
+RSpec.describe YARD::CodeObjects::ExtraFileObject do
   describe "#initialize" do
     it "attempts to read contents from filesystem if contents=nil" do
       expect(File).to receive(:read).with('file.txt').and_return('')

--- a/spec/code_objects/macro_object_spec.rb
+++ b/spec/code_objects/macro_object_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects::MacroObject do
+RSpec.describe YARD::CodeObjects::MacroObject do
   before do
     Registry.clear
   end

--- a/spec/code_objects/method_object_spec.rb
+++ b/spec/code_objects/method_object_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects::MethodObject do
+RSpec.describe YARD::CodeObjects::MethodObject do
   before do
     Registry.clear
     @yard = ModuleObject.new(:root, :YARD)

--- a/spec/code_objects/module_object_spec.rb
+++ b/spec/code_objects/module_object_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects::ModuleObject do
+RSpec.describe YARD::CodeObjects::ModuleObject do
   describe "#meths" do
     before do
       Registry.clear

--- a/spec/code_objects/namespace_object_spec.rb
+++ b/spec/code_objects/namespace_object_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects::NamespaceObject do
+RSpec.describe YARD::CodeObjects::NamespaceObject do
   before { Registry.clear }
 
   describe "#child" do

--- a/spec/code_objects/proxy_spec.rb
+++ b/spec/code_objects/proxy_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::CodeObjects::Proxy do
+RSpec.describe YARD::CodeObjects::Proxy do
   before { Registry.clear }
 
   it "returns the object if it's in the Registry" do

--- a/spec/code_objects/spec_helper.rb
+++ b/spec/code_objects/spec_helper.rb
@@ -1,4 +1,3 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), "..", "spec_helper")
 
 include CodeObjects

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'yaml'
 
-describe YARD::Config do
+RSpec.describe YARD::Config do
   describe ".load" do
     before do
       expect(File).to receive(:file?).twice.with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).and_return(false)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -1,6 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), "spec_helper")
-
 require 'yaml'
 
 describe YARD::Config do

--- a/spec/core_ext/array_spec.rb
+++ b/spec/core_ext/array_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Array do
+RSpec.describe Array do
   describe "#place" do
     it "creates an Insertion object" do
       expect([].place('x')).to be_kind_of(Insertion)

--- a/spec/core_ext/array_spec.rb
+++ b/spec/core_ext/array_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe Array do
   describe "#place" do

--- a/spec/core_ext/file_spec.rb
+++ b/spec/core_ext/file_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe File do
+RSpec.describe File do
   describe ".relative_path" do
     it "returns the relative path between two files" do
       expect(File.relative_path('a/b/c/d.html', 'a/b/d/q.html')).to eq '../d/q.html'

--- a/spec/core_ext/file_spec.rb
+++ b/spec/core_ext/file_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe File do
   describe ".relative_path" do

--- a/spec/core_ext/hash_spec.rb
+++ b/spec/core_ext/hash_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe Hash do
   describe ".[]" do

--- a/spec/core_ext/hash_spec.rb
+++ b/spec/core_ext/hash_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Hash do
+RSpec.describe Hash do
   describe ".[]" do
     it "accepts an Array argument (Ruby 1.8.6 and older)" do
       list = [['foo', 'bar'], ['foo2', 'bar2']]

--- a/spec/core_ext/insertion_spec.rb
+++ b/spec/core_ext/insertion_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Insertion do
+RSpec.describe Insertion do
   describe "#before" do
     it "places an object before another" do
       expect([1, 2].place(3).before(2)).to eq [1, 3, 2]

--- a/spec/core_ext/insertion_spec.rb
+++ b/spec/core_ext/insertion_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe Insertion do
   describe "#before" do

--- a/spec/core_ext/module_spec.rb
+++ b/spec/core_ext/module_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe Module do
   describe "#class_name" do

--- a/spec/core_ext/module_spec.rb
+++ b/spec/core_ext/module_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Module do
+RSpec.describe Module do
   describe "#class_name" do
     it "returns just the name of the class/module" do
       expect(YARD::CodeObjects::Base.class_name).to eq "Base"

--- a/spec/core_ext/string_spec.rb
+++ b/spec/core_ext/string_spec.rb
@@ -3,7 +3,7 @@
 # described_in_docs String, '#camelcase'
 # described_in_docs String, '#underscore'
 
-describe String do
+RSpec.describe String do
   describe "#shell_split" do
     it "splits simple non-quoted text" do
       expect("a b c".shell_split).to eq %w(a b c)

--- a/spec/core_ext/string_spec.rb
+++ b/spec/core_ext/string_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 # described_in_docs String, '#camelcase'
 # described_in_docs String, '#underscore'

--- a/spec/core_ext/symbol_hash_spec.rb
+++ b/spec/core_ext/symbol_hash_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe SymbolHash do
+RSpec.describe SymbolHash do
   it "allows access to keys as String or Symbol" do
     h = SymbolHash.new(false)
     h['test'] = true

--- a/spec/core_ext/symbol_hash_spec.rb
+++ b/spec/core_ext/symbol_hash_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
 
 describe SymbolHash do
   it "allows access to keys as String or Symbol" do

--- a/spec/docstring_parser_spec.rb
+++ b/spec/docstring_parser_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + "/spec_helper"
 
 describe YARD::DocstringParser do
   after(:all) do

--- a/spec/docstring_parser_spec.rb
+++ b/spec/docstring_parser_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::DocstringParser do
+RSpec.describe YARD::DocstringParser do
   after(:all) do
     YARD::Registry.clear
   end

--- a/spec/docstring_parser_spec.rb
+++ b/spec/docstring_parser_spec.rb
@@ -149,8 +149,8 @@ eof
     end
 
     it "handles directives with @! prefix syntax" do
-      TestLibrary.define_directive('dir1', Tags::ScopeDirective)
-      docstring("@!dir1 class")
+      TestLibrary.define_directive('dir2', Tags::ScopeDirective)
+      docstring("@!dir2 class")
       expect(@parser.state.scope).to eq :class
     end
   end

--- a/spec/docstring_spec.rb
+++ b/spec/docstring_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Docstring do
+RSpec.describe YARD::Docstring do
   before { YARD::Registry.clear }
 
   describe "#initialize" do

--- a/spec/docstring_spec.rb
+++ b/spec/docstring_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/spec_helper'
 
 describe YARD::Docstring do
   before { YARD::Registry.clear }

--- a/spec/handlers/alias_handler_spec.rb
+++ b/spec/handlers/alias_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}AliasHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}AliasHandler" do
   before(:all) { parse_file :alias_handler_001, __FILE__ }
 
   it "throws alias into namespace object list" do

--- a/spec/handlers/attribute_handler_spec.rb
+++ b/spec/handlers/attribute_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}AttributeHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}AttributeHandler" do
   before(:all) { parse_file :attribute_handler_001, __FILE__ }
 
   def read_write(namespace, name, read, write, scope = :instance)

--- a/spec/handlers/base_spec.rb
+++ b/spec/handlers/base_spec.rb
@@ -161,9 +161,9 @@ RSpec.describe YARD::Handlers::Base do
     def create_handler(stmts, parser_type)
       $handler_counter ||= 0
       sklass = parser_type == :ruby ? "Base" : "Legacy::Base"
-      instance_eval(<<-eof)
+      instance_eval(<<-eof, __FILE__, __LINE__ + 1)
         class ::InFileHandler#{$handler_counter += 1} < Handlers::Ruby::#{sklass}
-          handles /^class/
+          handles(/^class/)
           #{stmts}
           def process; MethodObject.new(:root, :FOO) end
         end
@@ -199,13 +199,13 @@ RSpec.describe YARD::Handlers::Base do
         end
 
         it "allows a Regexp as argument and test against full path" do
-          test_handler 'file_a.rbx', 'in_file /\.rbx$/', true, parser_type
-          test_handler '/path/to/file_a.rbx', 'in_file /\/to\/file_/', true, parser_type
-          test_handler '/path/to/file_a.rbx', 'in_file /^\/path/', true, parser_type
+          test_handler 'file_a.rbx', 'in_file(/\.rbx$/)', true, parser_type
+          test_handler '/path/to/file_a.rbx', 'in_file(/\/to\/file_/)', true, parser_type
+          test_handler '/path/to/file_a.rbx', 'in_file(/^\/path/)', true, parser_type
         end
 
         it "allows multiple in_file declarations" do
-          stmts = 'in_file "x"; in_file /y/; in_file "foo.rb"'
+          stmts = 'in_file "x"; in_file(/y/); in_file "foo.rb"'
           test_handler 'foo.rb', stmts, true, parser_type
           test_handler 'xyzzy.rb', stmts, true, parser_type
           test_handler 'x', stmts, true, parser_type

--- a/spec/handlers/base_spec.rb
+++ b/spec/handlers/base_spec.rb
@@ -4,7 +4,7 @@ require 'ostruct'
 
 include Parser
 
-describe YARD::Handlers::Base do
+RSpec.describe YARD::Handlers::Base do
   describe "#handles and inheritance" do
     before do
       allow(Handlers::Base).to receive(:inherited)

--- a/spec/handlers/c/alias_handler_spec.rb
+++ b/spec/handlers/c/alias_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::AliasHandler do
+RSpec.describe YARD::Handlers::C::AliasHandler do
   it "allows defining of aliases (rb_define_alias)" do
     parse <<-eof
       /* FOO */

--- a/spec/handlers/c/attribute_handler_spec.rb
+++ b/spec/handlers/c/attribute_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::AttributeHandler do
+RSpec.describe YARD::Handlers::C::AttributeHandler do
   def run(read, write, commented = nil)
     parse <<-eof
       /* FOO */

--- a/spec/handlers/c/class_handler_spec.rb
+++ b/spec/handlers/c/class_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::ClassHandler do
+RSpec.describe YARD::Handlers::C::ClassHandler do
   it "registers classes" do
     parse_init 'cFoo = rb_define_class("Foo", rb_cObject);'
     expect(Registry.at('Foo').type).to eq :class

--- a/spec/handlers/c/constant_handler_spec.rb
+++ b/spec/handlers/c/constant_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::ConstantHandler do
+RSpec.describe YARD::Handlers::C::ConstantHandler do
   it "registers constants" do
     parse_init <<-eof
       mFoo = rb_define_module("Foo");

--- a/spec/handlers/c/init_handler_spec.rb
+++ b/spec/handlers/c/init_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::InitHandler do
+RSpec.describe YARD::Handlers::C::InitHandler do
   it "adds documentation in Init_ClassName() to ClassName" do
     parse(<<-eof)
       // Bar!

--- a/spec/handlers/c/method_handler_spec.rb
+++ b/spec/handlers/c/method_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::MethodHandler do
+RSpec.describe YARD::Handlers::C::MethodHandler do
   it "registers methods" do
     parse_init <<-eof
       mFoo = rb_define_module("Foo");

--- a/spec/handlers/c/mixin_handler_spec.rb
+++ b/spec/handlers/c/mixin_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::MixinHandler do
+RSpec.describe YARD::Handlers::C::MixinHandler do
   it "adds includes to modules or classes" do
     parse_init <<-eof
       mFoo = rb_define_module("Foo");

--- a/spec/handlers/c/module_handler_spec.rb
+++ b/spec/handlers/c/module_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::ClassHandler do
+RSpec.describe YARD::Handlers::C::ClassHandler do
   it "registers modules" do
     parse_init 'mFoo = rb_define_module("Foo");'
     expect(Registry.at('Foo').type).to eq :module

--- a/spec/handlers/c/override_comment_handler_spec.rb
+++ b/spec/handlers/c/override_comment_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::OverrideCommentHandler do
+RSpec.describe YARD::Handlers::C::OverrideCommentHandler do
   [:class, :module].each do |type|
     it "handles Document-#{type}" do
       parse(<<-eof)

--- a/spec/handlers/c/path_handler_spec.rb
+++ b/spec/handlers/c/path_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Handlers::C::PathHandler do
+RSpec.describe YARD::Handlers::C::PathHandler do
   it "tracks variable names defined under namespaces" do
     parse_init <<-eof
       mFoo = rb_define_module("Foo");

--- a/spec/handlers/c/spec_helper.rb
+++ b/spec/handlers/c/spec_helper.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + "/../spec_helper"
 
 def parse(src, file = '(stdin)')
   YARD::Registry.clear

--- a/spec/handlers/c/struct_handler_spec.rb
+++ b/spec/handlers/c/struct_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Handlers::C::StructHandler do
+RSpec.describe YARD::Handlers::C::StructHandler do
   after { Registry.clear }
 
   it "handles Struct class definitions" do

--- a/spec/handlers/class_condition_handler_spec.rb
+++ b/spec/handlers/class_condition_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassConditionHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassConditionHandler" do
   before(:all) { parse_file :class_condition_handler_001, __FILE__ }
 
   def verify_method(*names)

--- a/spec/handlers/class_handler_spec.rb
+++ b/spec/handlers/class_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassHandler" do
   before(:all) { parse_file :class_handler_001, __FILE__ }
 
   it "parses a class block with docstring" do

--- a/spec/handlers/class_method_handler_shared_examples.rb
+++ b/spec/handlers/class_method_handler_shared_examples.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-shared_examples "class method visibility decorator" do
+RSpec.shared_examples "class method visibility decorator" do
   # Use let(:visibility) to specify the name of the x_class_method
   # visibility decorator to test.
 

--- a/spec/handlers/class_variable_handler_spec.rb
+++ b/spec/handlers/class_variable_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassVariableHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassVariableHandler" do
   before(:all) { parse_file :class_variable_handler_001, __FILE__ }
 
   it "does not parse class variables inside methods" do

--- a/spec/handlers/constant_handler_spec.rb
+++ b/spec/handlers/constant_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ConstantHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ConstantHandler" do
   before(:all) { parse_file :constant_handler_001, __FILE__ }
 
   it "does not parse constants inside methods" do

--- a/spec/handlers/decorator_handler_methods_spec.rb
+++ b/spec/handlers/decorator_handler_methods_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::DecoratorHandlerMethods" do
+RSpec.describe "YARD::Handlers::Ruby::DecoratorHandlerMethods" do
   describe "#process_decorator" do
     # Create a YARD decorator handler.
     # @param name [Symbol] name of the mock decorator

--- a/spec/handlers/dsl_handler_spec.rb
+++ b/spec/handlers/dsl_handler_spec.rb
@@ -2,7 +2,7 @@
 require File.dirname(__FILE__) + '/spec_helper'
 require 'ostruct'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}DSLHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}DSLHandler" do
   before(:all) { parse_file :dsl_handler_001, __FILE__ }
 
   it "creates a readable attribute when @!attribute r is found" do

--- a/spec/handlers/exception_handler_spec.rb
+++ b/spec/handlers/exception_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ExceptionHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ExceptionHandler" do
   before(:all) { parse_file :exception_handler_001, __FILE__ }
 
   it "does not document an exception outside of a method" do

--- a/spec/handlers/extend_handler_spec.rb
+++ b/spec/handlers/extend_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ExtendHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ExtendHandler" do
   before(:all) { parse_file :extend_handler_001, __FILE__ }
 
   it "includes modules at class scope" do

--- a/spec/handlers/legacy_base_spec.rb
+++ b/spec/handlers/legacy_base_spec.rb
@@ -3,7 +3,7 @@ require File.dirname(__FILE__) + '/spec_helper'
 
 include Parser::Ruby::Legacy
 
-describe YARD::Handlers::Ruby::Legacy::Base, "#tokval" do
+RSpec.describe YARD::Handlers::Ruby::Legacy::Base, "#tokval" do
   before { @handler = Handlers::Ruby::Legacy::Base.new(nil, nil) }
 
   def tokval(code, *types)
@@ -64,7 +64,7 @@ describe YARD::Handlers::Ruby::Legacy::Base, "#tokval" do
   # it "obeys documentation expectations" do docspec end
 end
 
-describe YARD::Handlers::Base, "#tokval_list" do
+RSpec.describe YARD::Handlers::Base, "#tokval_list" do
   before { @handler = Handlers::Ruby::Legacy::Base.new(nil, nil) }
 
   def tokval_list(code, *types)

--- a/spec/handlers/method_condition_handler_spec.rb
+++ b/spec/handlers/method_condition_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodConditionHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodConditionHandler" do
   before(:all) { parse_file :method_condition_handler_001, __FILE__ }
 
   it "does not parse regular if blocks in methods" do

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHandler" do
   before(:all) do
     log.enter_level(Logger::ERROR) do
       parse_file :method_handler_001, __FILE__

--- a/spec/handlers/mixin_handler_spec.rb
+++ b/spec/handlers/mixin_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MixinHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MixinHandler" do
   before(:all) { parse_file :mixin_handler_001, __FILE__ }
 
   it "handles includes from classes or modules" do

--- a/spec/handlers/module_function_handler_spec.rb
+++ b/spec/handlers/module_function_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}VisibilityHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}VisibilityHandler" do
   after { Registry.clear }
 
   def assert_module_function(namespace, name)

--- a/spec/handlers/module_handler_spec.rb
+++ b/spec/handlers/module_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ModuleHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ModuleHandler" do
   before(:all) { parse_file :module_handler_001, __FILE__ }
 
   it "parses a module block" do

--- a/spec/handlers/private_class_method_handler_spec.rb
+++ b/spec/handlers/private_class_method_handler_spec.rb
@@ -2,7 +2,7 @@
 require File.dirname(__FILE__) + '/spec_helper'
 require File.dirname(__FILE__) + '/class_method_handler_shared_examples'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}PrivateClassMethodHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}PrivateClassMethodHandler" do
   before { Registry.clear }
 
   let(:visibility) { :private }

--- a/spec/handlers/private_constant_handler_spec.rb
+++ b/spec/handlers/private_constant_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}PrivateConstantHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}PrivateConstantHandler" do
   before(:all) { parse_file :private_constant_handler_001, __FILE__ }
 
   it "handles private_constant statement" do

--- a/spec/handlers/processor_spec.rb
+++ b/spec/handlers/processor_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Handlers::Processor do
+RSpec.describe YARD::Handlers::Processor do
   before do
     @proc = Handlers::Processor.new(OpenStruct.new(:parser_type => :ruby))
   end

--- a/spec/handlers/public_class_method_handler_spec.rb
+++ b/spec/handlers/public_class_method_handler_spec.rb
@@ -2,7 +2,7 @@
 require File.dirname(__FILE__) + '/spec_helper'
 require File.dirname(__FILE__) + '/class_method_handler_shared_examples'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}PublicClassMethodHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}PublicClassMethodHandler" do
   before { Registry.clear }
 
   let(:visibility) { :public }

--- a/spec/handlers/ruby/base_spec.rb
+++ b/spec/handlers/ruby/base_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Handlers::Ruby::Base, '#valid_handler?' do
   include YARD::Parser::Ruby

--- a/spec/handlers/ruby/base_spec.rb
+++ b/spec/handlers/ruby/base_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Handlers::Ruby::Base, '#valid_handler?' do
+RSpec.describe YARD::Handlers::Ruby::Base, '#valid_handler?' do
   include YARD::Parser::Ruby
   YARD::Parser::Ruby::AstNode # rubocop:disable Lint/Void
 

--- a/spec/handlers/ruby/legacy/base_spec.rb
+++ b/spec/handlers/ruby/legacy/base_spec.rb
@@ -2,7 +2,7 @@
 
 include Parser::Ruby::Legacy
 
-describe YARD::Handlers::Ruby::Legacy::Base, "#handles and inheritance" do
+RSpec.describe YARD::Handlers::Ruby::Legacy::Base, "#handles and inheritance" do
   before do
     allow(Handlers::Ruby::Legacy::Base).to receive(:inherited)
     if RUBY_VERSION > '1.8.7'

--- a/spec/handlers/ruby/legacy/base_spec.rb
+++ b/spec/handlers/ruby/legacy/base_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../../spec_helper'
 
 include Parser::Ruby::Legacy
 

--- a/spec/handlers/spec_helper.rb
+++ b/spec/handlers/spec_helper.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), "..", "spec_helper")
 require 'stringio'
 
 include Handlers

--- a/spec/handlers/visibility_handler_spec.rb
+++ b/spec/handlers/visibility_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}VisibilityHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}VisibilityHandler" do
   before(:all) { parse_file :visibility_handler_001, __FILE__ }
 
   it "is able to set visibility to public" do

--- a/spec/handlers/yield_handler_spec.rb
+++ b/spec/handlers/yield_handler_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}YieldHandler" do
+RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}YieldHandler" do
   before(:all) { parse_file :yield_handler_001, __FILE__ }
 
   it "only parses yield blocks in methods" do

--- a/spec/i18n/locale_spec.rb
+++ b/spec/i18n/locale_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::I18n::Locale do
+RSpec.describe YARD::I18n::Locale do
   def locale(name)
     YARD::I18n::Locale.new(name)
   end

--- a/spec/i18n/locale_spec.rb
+++ b/spec/i18n/locale_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::I18n::Locale do
   def locale(name)

--- a/spec/i18n/message_spec.rb
+++ b/spec/i18n/message_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::I18n::Message do
   def message(id)

--- a/spec/i18n/message_spec.rb
+++ b/spec/i18n/message_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::I18n::Message do
+RSpec.describe YARD::I18n::Message do
   def message(id)
     YARD::I18n::Message.new(id)
   end

--- a/spec/i18n/messages_spec.rb
+++ b/spec/i18n/messages_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::I18n::Messages do
+RSpec.describe YARD::I18n::Messages do
   def message(id)
     YARD::I18n::Message.new(id)
   end

--- a/spec/i18n/messages_spec.rb
+++ b/spec/i18n/messages_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::I18n::Messages do
   def message(id)

--- a/spec/i18n/pot_generator_spec.rb
+++ b/spec/i18n/pot_generator_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::I18n::PotGenerator do
   def create_messages(messages)

--- a/spec/i18n/pot_generator_spec.rb
+++ b/spec/i18n/pot_generator_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::I18n::PotGenerator do
+RSpec.describe YARD::I18n::PotGenerator do
   def create_messages(messages)
     yard_messages = YARD::I18n::Messages.new
     add_messages(yard_messages, messages)

--- a/spec/i18n/text_spec.rb
+++ b/spec/i18n/text_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::I18n::Text do
+RSpec.describe YARD::I18n::Text do
   describe "#extract_messages" do
     def extract_messages(input, options = {})
       text = YARD::I18n::Text.new(StringIO.new(input), options)

--- a/spec/i18n/text_spec.rb
+++ b/spec/i18n/text_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::I18n::Text do
   describe "#extract_messages" do

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), "spec_helper")
 
 describe YARD::Logger do
   describe "#show_backtraces" do

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Logger do
+RSpec.describe YARD::Logger do
   describe "#show_backtraces" do
     it "is true if debug level is on" do
       log.show_backtraces = true

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Options do
+RSpec.describe YARD::Options do
   class FooOptions < YARD::Options
     attr_accessor :foo
     def initialize; self.foo = "abc" end

--- a/spec/options_spec.rb
+++ b/spec/options_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/spec_helper'
 
 describe YARD::Options do
   class FooOptions < YARD::Options

--- a/spec/parser/base_spec.rb
+++ b/spec/parser/base_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Parser::Base do
+RSpec.describe YARD::Parser::Base do
   describe "#initialize" do
     class MyParser < Parser::Base; def initialize(a, b) end end
 

--- a/spec/parser/base_spec.rb
+++ b/spec/parser/base_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
 
 describe YARD::Parser::Base do
   describe "#initialize" do

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
 
 describe YARD::Parser::C::CParser do
   describe "#parse" do

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Parser::C::CParser do
+RSpec.describe YARD::Parser::C::CParser do
   describe "#parse" do
     def parse(contents)
       Registry.clear

--- a/spec/parser/ruby/ast_node_spec.rb
+++ b/spec/parser/ruby/ast_node_spec.rb
@@ -4,7 +4,7 @@ require 'stringio'
 
 include YARD::Parser::Ruby
 
-describe YARD::Parser::Ruby::AstNode do
+RSpec.describe YARD::Parser::Ruby::AstNode do
   describe "#jump" do
     it "jumps to the first specific inner node if found" do
       ast = s(:paren, s(:paren, s(:params, s(s(:ident, "hi"), s(:ident, "bye")))))

--- a/spec/parser/ruby/ast_node_spec.rb
+++ b/spec/parser/ruby/ast_node_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', '..', 'spec_helper')
 require 'pp'
 require 'stringio'
 

--- a/spec/parser/ruby/legacy/statement_list_spec.rb
+++ b/spec/parser/ruby/legacy/statement_list_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', '..', '..', 'spec_helper')
 
 describe YARD::Parser::Ruby::Legacy::StatementList do
   def stmts(code) YARD::Parser::Ruby::Legacy::StatementList.new(code) end

--- a/spec/parser/ruby/legacy/statement_list_spec.rb
+++ b/spec/parser/ruby/legacy/statement_list_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Parser::Ruby::Legacy::StatementList do
+RSpec.describe YARD::Parser::Ruby::Legacy::StatementList do
   def stmts(code) YARD::Parser::Ruby::Legacy::StatementList.new(code) end
   def stmt(code) stmts(code).first end
 

--- a/spec/parser/ruby/legacy/token_list_spec.rb
+++ b/spec/parser/ruby/legacy/token_list_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', '..', '..', 'spec_helper')
 
 include YARD::Parser::Ruby::Legacy
 include YARD::Parser::Ruby::Legacy::RubyToken

--- a/spec/parser/ruby/legacy/token_list_spec.rb
+++ b/spec/parser/ruby/legacy/token_list_spec.rb
@@ -3,7 +3,7 @@
 include YARD::Parser::Ruby::Legacy
 include YARD::Parser::Ruby::Legacy::RubyToken
 
-describe YARD::Parser::Ruby::Legacy::TokenList do
+RSpec.describe YARD::Parser::Ruby::Legacy::TokenList do
   describe "#initialize / #push" do
     it "accepts a tokenlist (via constructor or push)" do
       expect { TokenList.new(TokenList.new) }.not_to raise_error

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', '..', 'spec_helper')
 
 describe YARD::Parser::Ruby::RubyParser do
   def stmt(stmt)

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Parser::Ruby::RubyParser do
+RSpec.describe YARD::Parser::Ruby::RubyParser do
   def stmt(stmt)
     YARD::Parser::Ruby::RubyParser.new(stmt, nil).parse.root.first
   end

--- a/spec/parser/ruby/token_resolver_spec.rb
+++ b/spec/parser/ruby/token_resolver_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', '..', 'spec_helper')
 
 describe YARD::Parser::Ruby::TokenResolver do
   before(:all) do

--- a/spec/parser/ruby/token_resolver_spec.rb
+++ b/spec/parser/ruby/token_resolver_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Parser::Ruby::TokenResolver do
+RSpec.describe YARD::Parser::Ruby::TokenResolver do
   before(:all) do
     YARD.parse_string <<-eof
       module A

--- a/spec/parser/source_parser_spec.rb
+++ b/spec/parser/source_parser_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
 
 class MyParser < Parser::Base; end
 

--- a/spec/parser/source_parser_spec.rb
+++ b/spec/parser/source_parser_spec.rb
@@ -2,14 +2,14 @@
 
 class MyParser < Parser::Base; end
 
-shared_examples_for "parser type registration" do
+RSpec.shared_examples_for "parser type registration" do
   after do
     Parser::SourceParser.parser_types.delete(:my_parser)
     Parser::SourceParser.parser_type_extensions.delete(:my_parser)
   end
 end
 
-describe YARD::Parser::SourceParser do
+RSpec.describe YARD::Parser::SourceParser do
   before do
     Registry.clear
   end

--- a/spec/parser/tag_parsing_spec.rb
+++ b/spec/parser/tag_parsing_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), '..', 'spec_helper')
 
 describe YARD::Parser, "tag handling" do
   before { parse_file :tag_handler_001, __FILE__ }

--- a/spec/parser/tag_parsing_spec.rb
+++ b/spec/parser/tag_parsing_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Parser, "tag handling" do
+RSpec.describe YARD::Parser, "tag handling" do
   before { parse_file :tag_handler_001, __FILE__ }
 
   it "knows the list of all available tags" do

--- a/spec/rake/yardoc_task_spec.rb
+++ b/spec/rake/yardoc_task_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Rake::YardocTask do
   before do

--- a/spec/rake/yardoc_task_spec.rb
+++ b/spec/rake/yardoc_task_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Rake::YardocTask do
+RSpec.describe YARD::Rake::YardocTask do
   before do
     @yardoc = YARD::CLI::Yardoc.new
     @yardoc.statistics = false

--- a/spec/registry_spec.rb
+++ b/spec/registry_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), "spec_helper")
 include CodeObjects
 
 require "thread"

--- a/spec/registry_spec.rb
+++ b/spec/registry_spec.rb
@@ -3,7 +3,7 @@ include CodeObjects
 
 require "thread"
 
-describe YARD::Registry do
+RSpec.describe YARD::Registry do
   before { Registry.clear }
 
   describe ".yardoc_file_for_gem" do

--- a/spec/registry_store_spec.rb
+++ b/spec/registry_store_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), "spec_helper")
 
 describe YARD::RegistryStore do
   before do

--- a/spec/registry_store_spec.rb
+++ b/spec/registry_store_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::RegistryStore do
+RSpec.describe YARD::RegistryStore do
   before do
     FileUtils.rm_rf("foo")
     @store = RegistryStore.new

--- a/spec/rubygems/doc_manager_spec.rb
+++ b/spec/rubygems/doc_manager_spec.rb
@@ -2,7 +2,7 @@
 require File.join(YARD::ROOT, 'rubygems_plugin')
 require 'fileutils'
 
-describe Gem::DocManager do
+RSpec.describe Gem::DocManager do
   before do
     # Ensure filesystem integrity
     allow(FileUtils).to receive(:mkdir_p)

--- a/spec/rubygems/doc_manager_spec.rb
+++ b/spec/rubygems/doc_manager_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 require File.join(YARD::ROOT, 'rubygems_plugin')
 require 'fileutils'
 

--- a/spec/serializers/file_system_serializer_spec.rb
+++ b/spec/serializers/file_system_serializer_spec.rb
@@ -3,7 +3,7 @@ require File.join(File.dirname(__FILE__), "spec_helper")
 
 require 'stringio'
 
-describe YARD::Serializers::FileSystemSerializer do
+RSpec.describe YARD::Serializers::FileSystemSerializer do
   before do
     allow(FileUtils).to receive(:mkdir_p)
     allow(File).to receive(:open)

--- a/spec/serializers/spec_helper.rb
+++ b/spec/serializers/spec_helper.rb
@@ -1,3 +1,2 @@
 # frozen_string_literal: true
-require File.join(File.dirname(__FILE__), "..", "spec_helper")
 include YARD

--- a/spec/serializers/yardoc_serializer_spec.rb
+++ b/spec/serializers/yardoc_serializer_spec.rb
@@ -8,7 +8,7 @@ instance_eval do
   end
 end
 
-describe YARD::Serializers::YardocSerializer do
+RSpec.describe YARD::Serializers::YardocSerializer do
   before do
     @serializer = YARD::Serializers::YardocSerializer.new('.yardoc')
 

--- a/spec/server/adapter_spec.rb
+++ b/spec/server/adapter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Server::Adapter do
+RSpec.describe YARD::Server::Adapter do
   after(:all) { Server::Adapter.shutdown }
 
   describe "#add_library" do

--- a/spec/server/commands/base_spec.rb
+++ b/spec/server/commands/base_spec.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 class MyProcCommand < Base
-  def initialize(&block) self.class.send(:define_method, :run, &block) end
+  def initialize(&block)
+    self.class.send(:undef_method, :run)
+    self.class.send(:define_method, :run, &block)
+  end
 end
 
 class MyCacheCommand < Base

--- a/spec/server/commands/base_spec.rb
+++ b/spec/server/commands/base_spec.rb
@@ -8,7 +8,7 @@ class MyCacheCommand < Base
   def run; cache 'foo' end
 end
 
-describe YARD::Server::Commands::Base do
+RSpec.describe YARD::Server::Commands::Base do
   describe "#cache" do
     before do
       @command = MyCacheCommand.new(:adapter => mock_adapter, :caching => true)

--- a/spec/server/commands/base_spec.rb
+++ b/spec/server/commands/base_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 class MyProcCommand < Base
   def initialize(&block) self.class.send(:define_method, :run, &block) end

--- a/spec/server/commands/library_command_spec.rb
+++ b/spec/server/commands/library_command_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require 'ostruct'
 
-describe YARD::Server::Commands::LibraryCommand do
+RSpec.describe YARD::Server::Commands::LibraryCommand do
   before do
     allow(Templates::Engine).to receive(:render)
     allow(Templates::Engine).to receive(:generate)

--- a/spec/server/commands/library_command_spec.rb
+++ b/spec/server/commands/library_command_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 require 'ostruct'
 
 describe YARD::Server::Commands::LibraryCommand do

--- a/spec/server/doc_server_helper_spec.rb
+++ b/spec/server/doc_server_helper_spec.rb
@@ -27,7 +27,7 @@ class MockDocServerHelper
   def options; OpenStruct.new end
 end
 
-describe YARD::Server::DocServerHelper do
+RSpec.describe YARD::Server::DocServerHelper do
   before do
     @helper = MockDocServerHelper.new
   end

--- a/spec/server/doc_server_serializer_spec.rb
+++ b/spec/server/doc_server_serializer_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Server::DocServerSerializer do
+RSpec.describe YARD::Server::DocServerSerializer do
   describe "#serialized_path" do
     before do
       Registry.clear

--- a/spec/server/rack_adapter_spec.rb
+++ b/spec/server/rack_adapter_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe "YARD::Server::RackMiddleware" do
+RSpec.describe "YARD::Server::RackMiddleware" do
   before do
     begin; require 'rack'; rescue LoadError; pending "rack required for these tests" end
     @superapp = double(:superapp)

--- a/spec/server/router_spec.rb
+++ b/spec/server/router_spec.rb
@@ -9,7 +9,7 @@ class MyRouterSpecRouter < Router
   def check_static_cache; nil end
 end
 
-describe YARD::Server::Router do
+RSpec.describe YARD::Server::Router do
   before do
     @adapter = mock_adapter
     @projects = @adapter.libraries['project']

--- a/spec/server/spec_helper.rb
+++ b/spec/server/spec_helper.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + "/../spec_helper"
 require 'ostruct'
 
 include Server

--- a/spec/server/static_caching_spec.rb
+++ b/spec/server/static_caching_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Server::StaticCaching do
+RSpec.describe YARD::Server::StaticCaching do
   include StaticCaching
 
   describe "#check_static_cache" do

--- a/spec/server/webrick_servlet_spec.rb
+++ b/spec/server/webrick_servlet_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Server::WebrickServlet do
+RSpec.describe YARD::Server::WebrickServlet do
   describe "#do_GET" do
     it "performs a GET" do
       resp = OpenStruct.new

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Server do
+RSpec.describe YARD::Server do
   describe ".register_static_path" do
     it "registers a static path" do
       YARD::Server.register_static_path 'foo'

--- a/spec/server_spec.rb
+++ b/spec/server_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + "/spec_helper"
 
 describe YARD::Server do
   describe ".register_static_path" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -179,7 +179,7 @@ RSpec.configure do |config|
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.
-  #config.warnings = true # FIXME: Too noisy right now
+  config.warnings = true
 
   # Many RSpec users commonly either run the entire suite or an individual
   # file, and it's useful to allow more verbose output when running an

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -127,6 +127,86 @@ RSpec.configure do |config|
     example.run
     log.level = saved_level
   end
+
+  # rspec-expectations config goes here. You can use an alternate
+  # assertion/expectation library such as wrong or the stdlib/minitest
+  # assertions if you prefer.
+  config.expect_with :rspec do |expectations|
+    # This option will default to `true` in RSpec 4. It makes the `description`
+    # and `failure_message` of custom matchers include text for helper methods
+    # defined using `chain`, e.g.:
+    #     be_bigger_than(2).and_smaller_than(4).description
+    #     # => "be bigger than 2 and smaller than 4"
+    # ...rather than:
+    #     # => "be bigger than 2"
+    expectations.include_chain_clauses_in_custom_matcher_descriptions = true
+  end
+
+  # rspec-mocks config goes here. You can use an alternate test double
+  # library (such as bogus or mocha) by changing the `mock_with` option here.
+  config.mock_with :rspec do |mocks|
+    # Prevents you from mocking or stubbing a method that does not exist on
+    # a real object. This is generally recommended, and will default to
+    # `true` in RSpec 4.
+    #mocks.verify_partial_doubles = true # FIXME: Not yet working
+  end
+
+  # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
+  # have no way to turn it off -- the option exists only for backwards
+  # compatibility in RSpec 3). It causes shared context metadata to be
+  # inherited by the metadata hash of host groups and examples, rather than
+  # triggering implicit auto-inclusion in groups with matching metadata.
+  config.shared_context_metadata_behavior = :apply_to_host_groups
+
+  # This allows you to limit a spec run to individual examples or groups
+  # you care about by tagging them with `:focus` metadata. When nothing
+  # is tagged with `:focus`, all examples get run. RSpec also provides
+  # aliases for `it`, `describe`, and `context` that include `:focus`
+  # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
+  config.filter_run_when_matching :focus
+
+  # Allows RSpec to persist some state between runs in order to support
+  # the `--only-failures` and `--next-failure` CLI options. We recommend
+  # you configure your source control system to ignore this file.
+  config.example_status_persistence_file_path = "spec/examples.txt"
+
+  # Limits the available syntax to the non-monkey patched syntax that is
+  # recommended. For more details, see:
+  #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
+  #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
+  #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
+  #config.disable_monkey_patching! # FIXME: Not yet working
+
+  # This setting enables warnings. It's recommended, but in some cases may
+  # be too noisy due to issues in dependencies.
+  #config.warnings = true # FIXME: Too noisy right now
+
+  # Many RSpec users commonly either run the entire suite or an individual
+  # file, and it's useful to allow more verbose output when running an
+  # individual spec file.
+  if config.files_to_run.one?
+    # Use the documentation formatter for detailed output,
+    # unless a formatter has already been configured
+    # (e.g. via a command-line flag).
+    config.default_formatter = 'doc'
+  end
+
+  # Print the N slowest examples and example groups at the
+  # end of the spec run, to help surface which specs are running
+  # particularly slow.
+  config.profile_examples = 5
+
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  #config.order = :random # FIXME: Not yet working
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
 end
 
 include YARD

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -175,7 +175,7 @@ RSpec.configure do |config|
   #   - http://rspec.info/blog/2012/06/rspecs-new-expectation-syntax/
   #   - http://www.teaisaweso.me/blog/2013/05/27/rspecs-new-message-expectation-syntax/
   #   - http://rspec.info/blog/2014/05/notable-changes-in-rspec-3/#zero-monkey-patching-mode
-  #config.disable_monkey_patching! # FIXME: Not yet working
+  config.disable_monkey_patching!
 
   # This setting enables warnings. It's recommended, but in some cases may
   # be too noisy due to issues in dependencies.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -148,7 +148,7 @@ RSpec.configure do |config|
     # Prevents you from mocking or stubbing a method that does not exist on
     # a real object. This is generally recommended, and will default to
     # `true` in RSpec 4.
-    #mocks.verify_partial_doubles = true # FIXME: Not yet working
+    # mocks.verify_partial_doubles = true # FIXME: Not yet working
   end
 
   # This option will default to `:apply_to_host_groups` in RSpec 4 (and will
@@ -200,7 +200,7 @@ RSpec.configure do |config|
   # order dependency and want to debug it, you can fix the order by providing
   # the seed, which is printed after each run.
   #     --seed 1234
-  #config.order = :random # FIXME: Not yet working
+  # config.order = :random # FIXME: Not yet working
 
   # Seed global randomization in this process using the `--seed` CLI option.
   # Setting this allows you to use `--seed` to deterministically reproduce

--- a/spec/tags/default_factory_spec.rb
+++ b/spec/tags/default_factory_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Tags::DefaultFactory do
   before { @f = YARD::Tags::DefaultFactory.new }

--- a/spec/tags/default_factory_spec.rb
+++ b/spec/tags/default_factory_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Tags::DefaultFactory do
+RSpec.describe YARD::Tags::DefaultFactory do
   before { @f = YARD::Tags::DefaultFactory.new }
 
   describe "#parse_tag" do

--- a/spec/tags/default_tag_spec.rb
+++ b/spec/tags/default_tag_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Tags::DefaultTag do
   it "creates a tag with defaults" do

--- a/spec/tags/default_tag_spec.rb
+++ b/spec/tags/default_tag_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Tags::DefaultTag do
+RSpec.describe YARD::Tags::DefaultTag do
   it "creates a tag with defaults" do
     o = YARD::Tags::DefaultTag.new('tagname', 'desc', ['types'], 'name', ['defaults'])
     expect(o.defaults).to eq ['defaults']

--- a/spec/tags/directives_spec.rb
+++ b/spec/tags/directives_spec.rb
@@ -6,7 +6,7 @@ def tag_parse(content, object = nil, handler = nil)
   @parser
 end
 
-describe YARD::Tags::ParseDirective do
+RSpec.describe YARD::Tags::ParseDirective do
   describe "#call" do
     after { Registry.clear }
 
@@ -44,7 +44,7 @@ describe YARD::Tags::ParseDirective do
   end
 end
 
-describe YARD::Tags::GroupDirective do
+RSpec.describe YARD::Tags::GroupDirective do
   describe "#call" do
     it "does nothing if handler=nil" do
       tag_parse("@!group foo")
@@ -58,7 +58,7 @@ describe YARD::Tags::GroupDirective do
   end
 end
 
-describe YARD::Tags::EndGroupDirective do
+RSpec.describe YARD::Tags::EndGroupDirective do
   describe "#call" do
     it "does nothing if handler=nil" do
       tag_parse("@!endgroup foo")
@@ -72,7 +72,7 @@ describe YARD::Tags::EndGroupDirective do
   end
 end
 
-describe YARD::Tags::MacroDirective do
+RSpec.describe YARD::Tags::MacroDirective do
   def handler
     OpenStruct.new(:call_params => %w(a b c),
                    :caller_method => 'foo',
@@ -161,7 +161,7 @@ describe YARD::Tags::MacroDirective do
   end
 end
 
-describe YARD::Tags::MethodDirective do
+RSpec.describe YARD::Tags::MethodDirective do
   describe "#call" do
     after { Registry.clear }
 
@@ -283,7 +283,7 @@ describe YARD::Tags::MethodDirective do
   end
 end
 
-describe YARD::Tags::AttributeDirective do
+RSpec.describe YARD::Tags::AttributeDirective do
   describe "#call" do
     after { Registry.clear }
 
@@ -369,7 +369,7 @@ describe YARD::Tags::AttributeDirective do
   end
 end
 
-describe YARD::Tags::ScopeDirective do
+RSpec.describe YARD::Tags::ScopeDirective do
   describe "#call" do
     after { Registry.clear }
 
@@ -407,7 +407,7 @@ describe YARD::Tags::ScopeDirective do
   end
 end
 
-describe YARD::Tags::VisibilityDirective do
+RSpec.describe YARD::Tags::VisibilityDirective do
   describe "#call" do
     after { Registry.clear }
 

--- a/spec/tags/directives_spec.rb
+++ b/spec/tags/directives_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + "/../spec_helper"
 
 def tag_parse(content, object = nil, handler = nil)
   @parser = DocstringParser.new

--- a/spec/tags/library_spec.rb
+++ b/spec/tags/library_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Tags::Library do
+RSpec.describe YARD::Tags::Library do
   def tag(docstring)
     Docstring.new(docstring).tags.first
   end

--- a/spec/tags/library_spec.rb
+++ b/spec/tags/library_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Tags::Library do
   def tag(docstring)

--- a/spec/tags/overload_tag_spec.rb
+++ b/spec/tags/overload_tag_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Tags::OverloadTag do
   before do

--- a/spec/tags/overload_tag_spec.rb
+++ b/spec/tags/overload_tag_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Tags::OverloadTag do
+RSpec.describe YARD::Tags::OverloadTag do
   before do
     @tag = Tags::OverloadTag.new(:overload, <<-'eof')
       def bar(a, b = 1, &block)

--- a/spec/tags/ref_tag_list_spec.rb
+++ b/spec/tags/ref_tag_list_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Tags::RefTagList do
   before { YARD::Registry.clear }

--- a/spec/tags/ref_tag_list_spec.rb
+++ b/spec/tags/ref_tag_list_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Tags::RefTagList do
+RSpec.describe YARD::Tags::RefTagList do
   before { YARD::Registry.clear }
 
   it "accepts symbol or string as owner's path and convert it into a proxy" do

--- a/spec/tags/types_explainer_spec.rb
+++ b/spec/tags/types_explainer_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Tags::TypesExplainer do
   Type = YARD::Tags::TypesExplainer::Type

--- a/spec/tags/types_explainer_spec.rb
+++ b/spec/tags/types_explainer_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Tags::TypesExplainer do
+RSpec.describe YARD::Tags::TypesExplainer do
   Type = YARD::Tags::TypesExplainer::Type
   CollectionType = YARD::Tags::TypesExplainer::CollectionType
   FixedCollectionType = YARD::Tags::TypesExplainer::FixedCollectionType

--- a/spec/templates/class_spec.rb
+++ b/spec/templates/class_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Templates::Engine.template(:default, :docstring) do
+RSpec.describe YARD::Templates::Engine.template(:default, :docstring) do
   before do
     Registry.clear
     YARD.parse_string <<-'eof'

--- a/spec/templates/constant_spec.rb
+++ b/spec/templates/constant_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/spec_helper"
 
-describe YARD::Templates::Engine.template(:default, :constant) do
+RSpec.describe YARD::Templates::Engine.template(:default, :constant) do
   describe "fully dressed constant" do
     it "renders text format correctly" do
       YARD.parse_string <<-'eof'

--- a/spec/templates/engine_spec.rb
+++ b/spec/templates/engine_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Templates::Engine do
+RSpec.describe YARD::Templates::Engine do
   before { @paths = Engine.template_paths }
   after { Engine.template_paths = @paths }
 

--- a/spec/templates/helpers/base_helper_spec.rb
+++ b/spec/templates/helpers/base_helper_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Templates::Helpers::BaseHelper do
   include YARD::Templates::Helpers::BaseHelper

--- a/spec/templates/helpers/base_helper_spec.rb
+++ b/spec/templates/helpers/base_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Templates::Helpers::BaseHelper do
+RSpec.describe YARD::Templates::Helpers::BaseHelper do
   include YARD::Templates::Helpers::BaseHelper
 
   describe "#run_verifier" do

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -120,7 +120,9 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
       allow(self).to receive(:object).and_return(Registry.root)
       text = String.new("\xB0\xB1")
       if defined?(Encoding)
-        Encoding.default_internal = 'utf-8'
+        utf8 = Encoding.find('utf-8')
+
+        Encoding.default_internal = utf8 unless Encoding.default_internal == utf8
         text = text.force_encoding('binary')
       end
       htmlify(text, :text)

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../../spec_helper'
 require File.dirname(__FILE__) + "/shared_signature_examples"
 require 'ostruct'
 

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -2,7 +2,7 @@
 require File.dirname(__FILE__) + "/shared_signature_examples"
 require 'ostruct'
 
-describe YARD::Templates::Helpers::HtmlHelper do
+RSpec.describe YARD::Templates::Helpers::HtmlHelper do
   include YARD::Templates::Helpers::BaseHelper
   include YARD::Templates::Helpers::HtmlHelper
   include YARD::Templates::Helpers::MethodHelper

--- a/spec/templates/helpers/html_syntax_highlight_helper_spec.rb
+++ b/spec/templates/helpers/html_syntax_highlight_helper_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 describe YARD::Templates::Helpers::HtmlSyntaxHighlightHelper do
   include YARD::Templates::Helpers::HtmlHelper

--- a/spec/templates/helpers/html_syntax_highlight_helper_spec.rb
+++ b/spec/templates/helpers/html_syntax_highlight_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Templates::Helpers::HtmlSyntaxHighlightHelper do
+RSpec.describe YARD::Templates::Helpers::HtmlSyntaxHighlightHelper do
   include YARD::Templates::Helpers::HtmlHelper
   include YARD::Templates::Helpers::HtmlSyntaxHighlightHelper
 

--- a/spec/templates/helpers/markup/rdoc_markup_spec.rb
+++ b/spec/templates/helpers/markup/rdoc_markup_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + "/../../spec_helper"
 
 describe YARD::Templates::Helpers::Markup::RDocMarkup do
   describe "loading mechanism" do

--- a/spec/templates/helpers/markup/rdoc_markup_spec.rb
+++ b/spec/templates/helpers/markup/rdoc_markup_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Templates::Helpers::Markup::RDocMarkup do
+RSpec.describe YARD::Templates::Helpers::Markup::RDocMarkup do
   describe "loading mechanism" do
     before { @good_libs = [] }
 

--- a/spec/templates/helpers/markup_helper_spec.rb
+++ b/spec/templates/helpers/markup_helper_spec.rb
@@ -12,7 +12,7 @@ class GeneratorMock
   end
 end
 
-describe YARD::Templates::Helpers::MarkupHelper do
+RSpec.describe YARD::Templates::Helpers::MarkupHelper do
   before do
     YARD::Templates::Helpers::MarkupHelper.clear_markup_cache
   end

--- a/spec/templates/helpers/markup_helper_spec.rb
+++ b/spec/templates/helpers/markup_helper_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../../spec_helper'
 
 module YARD::Templates::Helpers::MarkupHelper
   public :load_markup_provider, :markup_class, :markup_provider

--- a/spec/templates/helpers/method_helper_spec.rb
+++ b/spec/templates/helpers/method_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Templates::Helpers::MethodHelper do
+RSpec.describe YARD::Templates::Helpers::MethodHelper do
   include YARD::Templates::Helpers::BaseHelper
   include YARD::Templates::Helpers::MethodHelper
 

--- a/spec/templates/helpers/method_helper_spec.rb
+++ b/spec/templates/helpers/method_helper_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + "/../spec_helper"
 
 describe YARD::Templates::Helpers::MethodHelper do
   include YARD::Templates::Helpers::BaseHelper

--- a/spec/templates/helpers/module_helper_spec.rb
+++ b/spec/templates/helpers/module_helper_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + "/../spec_helper"
 
 describe YARD::Templates::Helpers::ModuleHelper do
   include YARD::Templates::Helpers::BaseHelper

--- a/spec/templates/helpers/module_helper_spec.rb
+++ b/spec/templates/helpers/module_helper_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Templates::Helpers::ModuleHelper do
+RSpec.describe YARD::Templates::Helpers::ModuleHelper do
   include YARD::Templates::Helpers::BaseHelper
   include YARD::Templates::Helpers::ModuleHelper
 

--- a/spec/templates/helpers/shared_signature_examples.rb
+++ b/spec/templates/helpers/shared_signature_examples.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
-shared_examples_for "signature" do
+RSpec.shared_examples_for "signature" do
   before do
     YARD::Registry.clear
     @options = Templates::TemplateOptions.new

--- a/spec/templates/helpers/text_helper_spec.rb
+++ b/spec/templates/helpers/text_helper_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + "/shared_signature_examples"
 
-describe YARD::Templates::Helpers::TextHelper do
+RSpec.describe YARD::Templates::Helpers::TextHelper do
   include YARD::Templates::Helpers::BaseHelper
   include YARD::Templates::Helpers::TextHelper
   include YARD::Templates::Helpers::MethodHelper

--- a/spec/templates/helpers/text_helper_spec.rb
+++ b/spec/templates/helpers/text_helper_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../../spec_helper'
 require File.dirname(__FILE__) + "/shared_signature_examples"
 
 describe YARD::Templates::Helpers::TextHelper do

--- a/spec/templates/method_spec.rb
+++ b/spec/templates/method_spec.rb
@@ -4,7 +4,7 @@ require File.dirname(__FILE__) + '/spec_helper'
 # $COPY = :method001
 # $COPYT = :html
 
-describe YARD::Templates::Engine.template(:default, :method) do
+RSpec.describe YARD::Templates::Engine.template(:default, :method) do
   before { Registry.clear }
 
   shared_examples_for "all formats" do

--- a/spec/templates/module_spec.rb
+++ b/spec/templates/module_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Templates::Engine.template(:default, :module) do
+RSpec.describe YARD::Templates::Engine.template(:default, :module) do
   before do
     Registry.clear
     YARD.parse_string <<-'eof'

--- a/spec/templates/onefile_spec.rb
+++ b/spec/templates/onefile_spec.rb
@@ -14,7 +14,7 @@ class StringSerializer < YARD::Serializers::Base
   end
 end
 
-describe YARD::Templates::Engine.template(:default, :onefile) do
+RSpec.describe YARD::Templates::Engine.template(:default, :onefile) do
   before do
     Registry.clear
     if defined?(::Encoding)

--- a/spec/templates/section_spec.rb
+++ b/spec/templates/section_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Templates::Section do
+RSpec.describe YARD::Templates::Section do
   include YARD::Templates
 
   describe "#initialize" do

--- a/spec/templates/spec_helper.rb
+++ b/spec/templates/spec_helper.rb
@@ -3,6 +3,8 @@
 include YARD::Templates
 
 def only_copy?(result, example, type)
+  return false unless defined?($COPY)
+
   if $COPY == :all || $COPY == example
     puts(result) unless $COPYT && $COPYT != type
   end

--- a/spec/templates/spec_helper.rb
+++ b/spec/templates/spec_helper.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/../spec_helper'
 
 include YARD::Templates
 

--- a/spec/templates/tag_spec.rb
+++ b/spec/templates/tag_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Templates::Engine.template(:default, :tags) do
+RSpec.describe YARD::Templates::Engine.template(:default, :tags) do
   before { Registry.clear }
 
   describe "all known tags" do

--- a/spec/templates/template_spec.rb
+++ b/spec/templates/template_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/spec_helper'
 
-describe YARD::Templates::Template do
+RSpec.describe YARD::Templates::Template do
   def template(path)
     YARD::Templates::Engine.template!(path, '/full/path/' + path.to_s)
   end

--- a/spec/verifier_spec.rb
+++ b/spec/verifier_spec.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
-require File.dirname(__FILE__) + '/spec_helper'
 
 describe YARD::Verifier do
   describe "#parse_expressions" do

--- a/spec/verifier_spec.rb
+++ b/spec/verifier_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe YARD::Verifier do
+RSpec.describe YARD::Verifier do
   describe "#parse_expressions" do
     it "creates #__execute method" do
       v = Verifier.new("expr1")

--- a/templates/default/layout/html/setup.rb
+++ b/templates/default/layout/html/setup.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 def init
   @breadcrumb = []
+  @page_title = ''
   if @onefile
     sections :layout
   elsif defined?(@file) && @file

--- a/templates/default/layout/html/setup.rb
+++ b/templates/default/layout/html/setup.rb
@@ -2,6 +2,7 @@
 def init
   @breadcrumb = []
   @page_title = ''
+  @breadcrumb_title = ''
   if @onefile
     sections :layout
   elsif defined?(@file) && @file

--- a/templates/default/layout/html/setup.rb
+++ b/templates/default/layout/html/setup.rb
@@ -3,7 +3,7 @@ def init
   @breadcrumb = []
   if @onefile
     sections :layout
-  elsif @file
+  elsif defined?(@file) && @file
     if @file.attributes[:namespace]
       @object = options.object = Registry.at(@file.attributes[:namespace]) || Registry.root
     end
@@ -44,12 +44,12 @@ def index
 end
 
 def layout
-  @nav_url = url_for_list(!@file || options.index ? 'class' : 'file')
+  @nav_url = url_for_list(!(defined?(@file) && @file) || options.index ? 'class' : 'file')
 
   @path =
     if !object || object.is_a?(String)
       nil
-    elsif @file
+    elsif defined?(@file) && @file
       @file.path
     elsif !object.is_a?(YARD::CodeObjects::NamespaceObject)
       object.parent.path

--- a/templates/default/module/setup.rb
+++ b/templates/default/module/setup.rb
@@ -35,7 +35,7 @@ end
 
 def method_listing(include_specials = true)
   return @smeths ||= method_listing.reject {|o| special_method?(o) } unless include_specials
-  return @meths if @meths
+  return @meths if defined?(@meths) && @meths
   @meths = object.meths(:inherited => false, :included => !options.embed_mixins.empty?)
   unless options.embed_mixins.empty?
     @meths = @meths.reject {|m| options.embed_mixins_match?(m.namespace) == false }

--- a/templates/default/module/setup.rb
+++ b/templates/default/module/setup.rb
@@ -69,7 +69,7 @@ def attr_listing
 end
 
 def constant_listing
-  return @constants if @constants
+  return @constants if defined?(@constants) && @constants
   @constants = object.constants(:included => false, :inherited => false)
   @constants += object.cvars
   @constants = run_verifier(@constants)

--- a/templates/default/module/setup.rb
+++ b/templates/default/module/setup.rb
@@ -51,7 +51,7 @@ def special_method?(meth)
 end
 
 def attr_listing
-  return @attrs if @attrs
+  return @attrs if defined?(@attrs) && @attrs
   @attrs = []
   object.inheritance_tree(true).each do |superclass|
     next if superclass.is_a?(CodeObjects::Proxy)

--- a/templates/default/onefile/html/layout.erb
+++ b/templates/default/onefile/html/layout.erb
@@ -3,12 +3,12 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=<%= charset %>" />
-    <title><%= @title %></title>
+    <title><%= defined?(@title) ? @title : '' %></title>
     <%= erb(:headers) %>
   </head>
   <body>
     <div id="content">
-      <h1><%= @title %></h1>
+      <h1><%= defined?(@title) ? @title : '' %></h1>
       <%= yieldall %>
     </div>
 

--- a/templates/default/onefile/html/setup.rb
+++ b/templates/default/onefile/html/setup.rb
@@ -35,7 +35,7 @@ end
 private
 
 def parse_top_comments_from_file
-  return unless @readme
+  return unless defined?(@readme) && @readme
   return @readme.contents unless @readme.filename =~ /\.rb$/
   data = ""
   tokens = TokenList.new(@readme.contents)

--- a/templates/default/tags/html/tag.erb
+++ b/templates/default/tags/html/tag.erb
@@ -1,4 +1,4 @@
-<p class="tag_title"><%= @label ? @label : YARD::Tags::Library.labels[@name] %>:</p>
+<p class="tag_title"><%= (defined?(@label) && @label) ? @label : YARD::Tags::Library.labels[@name] %>:</p>
 <ul class="<%= @name %>">
   <% object.tags(@name).each do |tag| %>
     <li>

--- a/templates/default/tags/setup.rb
+++ b/templates/default/tags/setup.rb
@@ -23,8 +23,8 @@ private
 def tag(name, opts = nil)
   return unless object.has_tag?(name)
   opts ||= options_for_tag(name)
-  @no_names = true if opts[:no_names]
-  @no_types = true if opts[:no_types]
+  @no_names = !!opts[:no_names]
+  @no_types = !!opts[:no_types]
   @name = name
   out = erb('tag')
   @no_names = nil

--- a/templates/default/tags/setup.rb
+++ b/templates/default/tags/setup.rb
@@ -23,8 +23,8 @@ private
 def tag(name, opts = nil)
   return unless object.has_tag?(name)
   opts ||= options_for_tag(name)
-  @no_names = !!opts[:no_names]
-  @no_types = !!opts[:no_types]
+  @no_names = opts[:no_names] ? true : false
+  @no_types = opts[:no_types] ? true : false
   @name = name
   out = erb('tag')
   @no_names = nil

--- a/templates/default/tags/text/tag.erb
+++ b/templates/default/tags/text/tag.erb
@@ -1,4 +1,4 @@
-<% title = @label ? @label : YARD::Tags::Library.labels[@name] %>
+<% title = (defined?(@label) && @label) ? @label : YARD::Tags::Library.labels[@name] %>
 <%= title %>:
 <%= hr(title.length) %>-
 


### PR DESCRIPTION
# Description

A late holidays gift! I wanted to finish this a few days ago but yeah, it took some work :smiley: 

This PR configures a number of recommended rspec features which are off by default so as to preserve backwards compatibility, and enables printing of ruby warnings during test execution. It then goes after many of the warnings being printed, in an effort to fix them all.

I didn't have the opportunity to fix all the warnings, but only a handful of them remain (that tend repeat a bit, thus causing a somewhat noisy output). I left warnings enabled by default so as to motivate others to help out, but this can be easily disabled again :smile: 

I recommend reviewing this PR commit-by-commit, rather than the whole diff at once as that doesn't make a lot of sense. If you're against any of the warning fixes, I can try to fix in another way or remove that fix entirely.

Thanks, and I hope this contribution is relevant!

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
