### PR TITLE
Make the output reproducible.

### DIFF
--- a/lib/yard/parser/source_parser.rb
+++ b/lib/yard/parser/source_parser.rb
@@ -111,7 +111,7 @@ module YARD
             reject {|p| !File.file?(p) || excluded.any? {|re| p =~ re } }
 
           log.enter_level(level) do
-            parse_in_order(*files.uniq)
+            parse_in_order(*files.sort.uniq)
           end
         end
 


### PR DESCRIPTION
Whilst working on the Reproducible Builds effort [0], we noticed
that yardoc generates output that is not reproducible due to the
use of a fallback glob that relies on (non-deterministic)
filesystem ordering.

 [0] https://reproducible-builds.org/

Signed-off-by: Chris Lamb <chris@chris-lamb.co.uk>

# Description

Describe your pull request and problem statement here.

# Completed Tasks

* [ ] I have read the [Contributing Guide][contrib].
* [ ] The pull request is complete (implemented / written).
* [ ] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
