### PR TITLE
Allow keyword options in option.erb templates

### DIFF
--- a/templates/default/tags/html/option.erb
+++ b/templates/default/tags/html/option.erb
@@ -1,6 +1,6 @@
 <% if object.has_tag?(:option) %>
   <% object.parameters.each do |param, default| %>
-    <% tags = object.tags(:option).select {|x| x.name.to_s == param.to_s.sub(/^\*+/, '') } %>
+    <% tags = object.tags(:option).select {|x| x.name.to_s == param.to_s.sub(/^\*+|:$/, '') } %>
     <% next if tags.empty? %>
     <p class="tag_title">Options Hash (<tt><%= param %></tt>):</p>
     <ul class="option">

--- a/templates/default/tags/text/option.erb
+++ b/templates/default/tags/text/option.erb
@@ -1,6 +1,6 @@
 <% if object.has_tag?(:option) %>
 <% object.parameters.each do |param, default| %>
-<% tags = object.tags(:option).select {|x| x.name.to_s == param.to_s } %>
+<% tags = object.tags(:option).select {|x| x.name.to_s == param.to_s.sub(/^\*+|:$/, '') } %>
 <% next if tags.empty? %>
 Options Hash (<%= param %>):
 --------------<%= hr(param.to_s.length) %>--


### PR DESCRIPTION
See #1050.  Updated text template to match html.

# Description

`option.erb` templates do not select options for keyword parameters due to trailing `:` character.  Text template was also missing regex to remove starting splat (`*`) characters.

# Completed Tasks

* [X] I have read the [Contributing Guide][contrib].
* [X] The pull request is complete (implemented / written).
* [X] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

Sorry about no test.  I think the current test just seems to be on the text template.  Happy New Year...

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
