### PR TITLE
Remove decorator tag

### DIFF
--- a/lib/yard/handlers/ruby/decorator_handler_methods.rb
+++ b/lib/yard/handlers/ruby/decorator_handler_methods.rb
@@ -107,12 +107,6 @@ module YARD::Handlers::Ruby::DecoratorHandlerMethods
     # Transfer source to methods passed to the helper as parameters.
     method.source = statement.source if transfer_source && node.def?
 
-    # Tag decorator on decorated method.
-    if method.respond_to? :add_tag
-      method.add_tag YARD::Tags::Tag.new(:decorator,
-        statement.jump(:command).jump(:ident).source)
-    end
-
     # Transfer decorator docstring to methods passed to the helper as parameters.
     if transfer_docstring && node.def? &&
        statement.docstring && method.docstring.empty?

--- a/spec/handlers/decorator_handler_methods_spec.rb
+++ b/spec/handlers/decorator_handler_methods_spec.rb
@@ -388,25 +388,6 @@ RSpec.describe "YARD::Handlers::Ruby::DecoratorHandlerMethods" do
           expect(subject.source).to eq make_defs(*method_defs)
         end
       end
-
-      describe "are tagged" do
-        let(:method_defs)  { [:foo, :bar] }
-        let(:param_string) { method_defs.map(&:inspect).join(',') }
-
-        specify do
-          expect(subject.tags.count).to eq 3
-
-          subject.tags.each do |tag|
-            expect(tag.tag_name).to eq 'decorator'
-          end
-
-          expect(subject.tags.map(&:text)).to eq [
-            'third_decorator',
-            'second_decorator',
-            'first_decorator'
-          ]
-        end
-      end
     end
   end # process_decorator
 end unless LEGACY_PARSER


### PR DESCRIPTION
# Description

For #1047 (see for reproduction of the issue).

This PR removes the `@decorator` tag that was added by the `process_decorator` helper method. This fixes a warning that would occur when a decorated method was aliased:
`[warn]: Unknown tag @decorator in file 'lib/gi_1047.rb' near line 8`

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
