### PR TITLE
Enable groups for constants (Resolves #610)

### DIFF
--- a/spec/templates/examples/module001.html
+++ b/spec/templates/examples/module001.html
@@ -54,7 +54,11 @@
   
 </p>
 
-  <h2>Constant Summary</h2>
+  <h2>
+    Constant Summary
+
+    <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+  </h2>
   
     <dl class="constants">
       

--- a/spec/templates/examples/module003.html
+++ b/spec/templates/examples/module003.html
@@ -28,7 +28,11 @@
 </div>
 
 
-  <h2>Constant Summary</h2>
+  <h2>
+    Constant Summary
+
+    <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+  </h2>
   
     <dl class="constants">
       

--- a/spec/templates/examples/module005.html
+++ b/spec/templates/examples/module005.html
@@ -1,0 +1,72 @@
+<h1>Module: A
+
+
+
+</h1>
+<div class="box_info">
+
+
+
+
+
+
+
+
+
+
+
+  <dl>
+    <dt>Defined in:</dt>
+    <dd>(stdin)</dd>
+  </dl>
+
+</div>
+
+
+
+    <h2>
+      Foo
+      <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+    </h2>
+
+    <dl class="constants">
+
+        <dt id="FOO-constant" class="">FOO =
+
+        </dt>
+        <dd><pre class="code">1</pre></dd>
+
+        <dt id="BAR-constant" class="">BAR =
+
+        </dt>
+        <dd><pre class="code">2</pre></dd>
+
+    </dl>
+
+    <h2>
+      Bar
+      <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+    </h2>
+
+    <dl class="constants">
+
+        <dt id="BAZ-constant" class="">BAZ =
+
+        </dt>
+        <dd><pre class="code">3</pre></dd>
+
+    </dl>
+
+    <h2>
+      Constant Summary
+      <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+    </h2>
+
+    <dl class="constants">
+
+        <dt id="WORLD-constant" class="">WORLD =
+
+        </dt>
+        <dd><pre class="code">4</pre></dd>
+
+    </dl>

--- a/spec/templates/examples/module005.html
+++ b/spec/templates/examples/module005.html
@@ -36,8 +36,18 @@
         </dt>
         <dd><pre class="code">1</pre></dd>
 
-        <dt id="BAR-constant" class="">BAR =
+        <dt id="BAR-constant" class="deprecated">BAR =
+          <div class="docstring">
+  <div class="discussion">
+    <div class="note deprecated"><strong>Deprecated.</strong> <div class='inline'></div></div>
 
+
+  </div>
+</div>
+<div class="tags">
+
+
+</div>
         </dt>
         <dd><pre class="code">2</pre></dd>
 

--- a/spec/templates/module_spec.rb
+++ b/spec/templates/module_spec.rb
@@ -179,4 +179,23 @@ RSpec.describe YARD::Templates::Engine.template(:default, :module) do
 
     html_equals(Registry.at('A').format(html_options(:embed_mixins => ['Foo', 'Bar', 'Baz::A*'])), :module004)
   end
+
+  it "renders constant groups correctly in html" do
+    Registry.clear
+    YARD.parse_string <<-'eof'
+      module A
+        # @group Foo
+        FOO = 1
+        BAR = 2
+
+        # @group Bar
+        BAZ = 3
+
+        # @endgroup
+
+        WORLD = 4
+      end
+    eof
+    html_equals(Registry.at('A').format(html_options), :module005)
+  end
 end

--- a/spec/templates/module_spec.rb
+++ b/spec/templates/module_spec.rb
@@ -186,6 +186,8 @@ RSpec.describe YARD::Templates::Engine.template(:default, :module) do
       module A
         # @group Foo
         FOO = 1
+
+        # @deprecated
         BAR = 2
 
         # @group Bar

--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -329,6 +329,7 @@ ul.summary a, ul.summary a:visited {
 ul.summary li { margin-bottom: 5px; }
 .summary_signature { padding: 4px 8px; background: #f8f8f8; border: 1px solid #f0f0f0; border-radius: 5px; }
 .summary_signature:hover { background: #CFEBFF; border-color: #A4CCDA; cursor: pointer; }
+.summary_signature.deprecated { background: #ffe5e5; border-color: #e9dada; }
 ul.summary.compact li { display: inline-block; margin: 0px 5px 0px 0px; line-height: 2.6em;}
 ul.summary.compact .summary_signature { padding: 5px 7px; padding-right: 4px; }
 #content .summary_signature:hover a,

--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -245,6 +245,7 @@ ul.toplevel { list-style: none; padding-left: 0; font-size: 1.1em; }
 
 dl.constants { margin-left: 10px; }
 dl.constants dt { font-weight: bold; font-size: 1.1em; margin-bottom: 5px; }
+dl.constants.compact dt { display: inline-block; font-weight: normal }
 dl.constants dd { width: 75%; white-space: pre; font-family: monospace; margin-bottom: 18px; }
 dl.constants .docstring .note:first-child { margin-top: 5px; }
 
@@ -326,12 +327,7 @@ ul.summary a, ul.summary a:visited {
   text-decoration: none; font-size: 1.1em;
 }
 ul.summary li { margin-bottom: 5px; }
-.summary .summary_signature {
-  padding: 4px 8px;
-  background: #f8f8f8;
-  border: 1px solid #f0f0f0;
-  border-radius: 5px;
-}
+.summary_signature { padding: 4px 8px; background: #f8f8f8; border: 1px solid #f0f0f0; border-radius: 5px; }
 .summary_signature:hover { background: #CFEBFF; border-color: #A4CCDA; cursor: pointer; }
 ul.summary.compact li { display: inline-block; margin: 0px 5px 0px 0px; line-height: 2.6em;}
 ul.summary.compact .summary_signature { padding: 5px 7px; padding-right: 4px; }

--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -120,6 +120,41 @@ function summaryToggle() {
   } else { localStorage.summaryCollapsed = "expand"; }
 }
 
+function constantSummaryToggle() {
+  $('.constants_summary_toggle').click(function(e) {
+    e.preventDefault();
+    localStorage.summaryCollapsed = $(this).text();
+    $('.constants_summary_toggle').each(function() {
+      $(this).text($(this).text() == "collapse" ? "expand" : "collapse");
+      var next = $(this).parent().parent().nextAll('dl.constants').first();
+      if (next.hasClass('compact')) {
+        next.toggle();
+        next.nextAll('dl.constants').first().toggle();
+      }
+      else if (next.hasClass('constants')) {
+        var list = $('<dl class="constants compact" />');
+        list.html(next.html());
+        list.find('dt').each(function() {
+          $(this).addClass('summary_signature');
+          $(this).text($(this).text().split('=')[0]);
+        });
+        // Add the value of the constant as "Tooltip" to the summary object
+        list.find('pre.code').each(function() {
+          console.log($(this).parent());
+          $(this).parent().prev().attr('title', $(this).text());
+        });
+        list.find('.docstring, .tags, dd').remove();
+        next.before(list);
+        next.toggle();
+      }
+    });
+    return false;
+  });
+  if (localStorage.summaryCollapsed == "collapse") {
+    $('.constants_summary_toggle').first().click();
+  } else { localStorage.summaryCollapsed = "expand"; }
+}
+
 function generateTOC() {
   if ($('#filecontents').length === 0) return;
   var _toc = $('<ol class="top"></ol>');
@@ -241,6 +276,7 @@ $(document).ready(function() {
   searchFrameButtons();
   linkSummaries();
   summaryToggle();
+  constantSummaryToggle();
   generateTOC();
   mainFocus();
 });

--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -135,13 +135,21 @@ function constantSummaryToggle() {
         var list = $('<dl class="constants compact" />');
         list.html(next.html());
         list.find('dt').each(function() {
-          $(this).addClass('summary_signature');
-          $(this).text($(this).text().split('=')[0]);
+           $(this).addClass('summary_signature');
+           $(this).text( $(this).text().split('=')[0]);
+          if ($(this).has(".deprecated").length) {
+             $(this).addClass('deprecated');
+          };
         });
         // Add the value of the constant as "Tooltip" to the summary object
         list.find('pre.code').each(function() {
           console.log($(this).parent());
-          $(this).parent().prev().attr('title', $(this).text());
+          var dt_element = $(this).parent().prev();
+          var tooltip = $(this).text();
+          if (dt_element.hasClass("deprecated")) {
+             tooltip = 'Deprecated. ' + tooltip;
+          };
+          dt_element.attr('title', tooltip);
         });
         list.find('.docstring, .tags, dd').remove();
         next.before(list);

--- a/templates/default/module/html/constant_summary.erb
+++ b/templates/default/module/html/constant_summary.erb
@@ -1,11 +1,17 @@
 <% if constant_listing.size > 0 %>
-  <h2>Constant Summary</h2>
-  <dl class="constants">
-    <% constant_listing.each do |cnst| %>
-      <dt id="<%= anchor_for(cnst) %>" class="<%= cnst.has_tag?(:deprecated) ? 'deprecated' : '' %>"><%= cnst.name %> =
-        <%= yieldall :object => cnst %>
-      </dt>
-      <dd><pre class="code"><%= format_constant cnst.value %></pre></dd>
-    <% end %>
-  </dl>
+  <% groups(constant_listing, "Constant") do |list, name| %>
+    <h2>
+      <%= name %>
+      <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+    </h2>
+
+    <dl class="constants">
+      <% list.each do |cnst| %>
+        <dt id="<%= anchor_for(cnst) %>" class="<%= cnst.has_tag?(:deprecated) ? 'deprecated' : '' %>"><%= cnst.name %> =
+          <%= yieldall :object => cnst %>
+        </dt>
+        <dd><pre class="code"><%= format_constant cnst.value %></pre></dd>
+      <% end %>
+    </dl>
+  <% end %>
 <% end %>

--- a/templates/default/module/setup.rb
+++ b/templates/default/module/setup.rb
@@ -131,17 +131,22 @@ def groups(list, type = "Method")
   else
     others = []
     group_data = {}
-    list.each do |meth|
-      if meth.group
-        (group_data[meth.group] ||= []) << meth
+    list.each do |itm|
+      if itm.group
+        (group_data[itm.group] ||= []) << itm
       else
-        others << meth
+        others << itm
       end
     end
     group_data.each {|group, items| yield(items, group) unless items.empty? }
   end
 
-  scopes(others) {|items, scope| yield(items, "#{scope.to_s.capitalize} #{type} Summary") }
+  return if others.empty?
+  if others.first.respond_to?(:scope)
+    scopes(others) {|items, scope| yield(items, "#{scope.to_s.capitalize} #{type} Summary") }
+  else
+    yield(others, "#{type} Summary")
+  end
 end
 
 def scopes(list)


### PR DESCRIPTION
# Description

I started contributing to gosu this month and while working on some issues there I stumbled upon a huge list of constants in the docs and it would be really helpfull if we could group and collapse them. @jlnr found an old issue #610 which stated that this is a feature I have to implement on my own. So this is my first approach. Its definitely not finished yet, but the easy part is done and its functional but not that pretty yet. So I would like to get some feedback if my basic idea was right and if I can look further into this to make it pretty.

# Screenshots

![const_summary_expanded](https://cloud.githubusercontent.com/assets/310475/21886515/65c129d2-d8bc-11e6-888c-9c803ee0bc5f.png)
![const_summary_collapsed](https://cloud.githubusercontent.com/assets/310475/21886518/68fe32b6-d8bc-11e6-91b7-7d129532c457.png)

# ToDo

* [x] Change the stylesheet to make the folded list look like the folded method list (all names in colored boxes, no "linebreak" after each name)
* [x] Add a test

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
