### PR TITLE
Fix Ruby 2.4 deprecations

### DIFF
--- a/lib/yard/parser/ruby/legacy/ruby_lex.rb
+++ b/lib/yard/parser/ruby/legacy/ruby_lex.rb
@@ -599,7 +599,7 @@ module YARD
         end
 
         @OP.def_rules(" ", "\t", "\f", "\r", "\13") do |chars, _io|
-          @space_seen = TRUE
+          @space_seen = true
           while (ch = getc) =~ /[ \t\f\r\13]/
             chars << ch
           end
@@ -642,9 +642,9 @@ module YARD
           @colonblock_seen = false
           case @lex_state
           when EXPR_BEG, EXPR_FNAME, EXPR_DOT
-            @continue = TRUE
+            @continue = true
           else
-            @continue = FALSE
+            @continue = false
             @lex_state = EXPR_BEG
           end
           Token(TkNL).set_text("\n")
@@ -1166,8 +1166,8 @@ module YARD
         end
 
         type = TkINTEGER
-        allow_point = TRUE
-        allow_e = TRUE
+        allow_point = true
+        allow_e = true
         while ch = getc
           case ch
           when /[0-9_]/

--- a/spec/code_objects/constants_spec.rb
+++ b/spec/code_objects/constants_spec.rb
@@ -66,7 +66,9 @@ RSpec.describe YARD::CodeObjects do
   describe :BUILTIN_CLASSES do
     it "includes all base classes" do
       bad_names = []
-      YARD::CodeObjects::BUILTIN_CLASSES.each do |name|
+      builtin_classes = YARD::CodeObjects::BUILTIN_CLASSES
+      builtin_classes -= ["Bignum", "Fixnum"] if 0.class == Integer
+      builtin_classes.each do |name|
         begin
           bad_names << name unless eval(name).is_a?(Class)
         rescue NameError


### PR DESCRIPTION
# Description

In Ruby 2.4, `::TRUE` & `::FALSE` constants, as well as the `::Bignum` and `::Fixnum` classes are deprecated. The deprecated boolean constants appear on every run of Yard, while the Integer unification-based deprecations only appear in Yard's tests. This fixes both.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
