### PR TITLE
Allowing YARD to parse content of C++ namespaces. Fixes #809.

### DIFF
--- a/lib/yard/parser/c/c_parser.rb
+++ b/lib/yard/parser/c/c_parser.rb
@@ -38,6 +38,7 @@ module YARD
             when '#'; consume_directive
             when '/'; consume_comment
             when /\s/; consume_whitespace
+            when '}'; advance # Skip possible C++ namespace closing brackets.
             else consume_toplevel_statement
             end
           end
@@ -75,6 +76,8 @@ module YARD
           line = @line
           decl = consume_until(/[{;]/)
           return nil if decl =~ /\A\s*\Z/
+          # Skip C++ namespace - treat content as top level statement.
+          return nil if decl =~ /\A(namespace)/
           statement = ToplevelStatement.new(nil, @file, line)
           @statements << statement
           attach_comment(statement)

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -26,6 +26,29 @@ RSpec.describe YARD::Parser::C::CParser do
       end
     end
 
+    describe "C++ namespace" do
+      before(:all) do
+        file = File.join(File.dirname(__FILE__), 'examples', 'namespace.cpp.txt')
+        parse(File.read(file))
+      end
+
+      it "parses Rect class" do
+        obj = YARD::Registry.at('Rect')
+        expect(obj).not_to be nil
+        expect(obj.docstring).not_to be_blank
+      end
+
+      it "parses method inside of namespace" do
+        obj = YARD::Registry.at('Rect#inspect')
+        expect(obj.docstring).not_to be_blank
+      end
+
+      it "parses method after namespace" do
+        obj = YARD::Registry.at('Rect#hello_world')
+        expect(obj.docstring).not_to be_blank
+      end
+    end
+
     describe "Source located in extra files" do
       before(:all) do
         @multifile = File.join(File.dirname(__FILE__), 'examples', 'multifile.c.txt')

--- a/spec/parser/examples/namespace.cpp.txt
+++ b/spec/parser/examples/namespace.cpp.txt
@@ -1,0 +1,68 @@
+VALUE rb_cWXRect;
+
+namespace RubyWX {
+namespace Rect {
+
+VALUE _alloc(VALUE self)
+{
+    return wrap(new wxRect());
+}
+
+/*
+ * call-seq:
+ *   inspect -> String
+ *
+ * Human-readable description.
+ * ===Return value
+ * String
+*/
+VALUE _inspect(VALUE self)
+{
+    return rb_sprintf( "%s(%d, %d, %d, %d)",
+        rb_obj_classname( self ),
+        FIX2INT(_getX(self)),
+        FIX2INT(_getY(self)),
+        FIX2INT(_getWidth(self)),
+        FIX2INT(_getHeight(self)));
+}
+
+} // namespace Rect
+} // namespace RubyWX
+
+
+/*
+ * call-seq:
+ *   hello_world -> String
+ *
+ * Human-readable description.
+ * ===Return value
+ * String
+*/
+VALUE _hello_world(VALUE self)
+{
+    return rb_sprintf( "%s(%d, %d, %d, %d)",
+        rb_obj_classname( self ),
+        FIX2INT(_getX(self)),
+        FIX2INT(_getY(self)),
+        FIX2INT(_getWidth(self)),
+        FIX2INT(_getHeight(self)));
+}
+
+/* Arrays are ordered, integer-indexed collections of any object.
+ * Array indexing starts at 0, as in C or Java.  A negative index is
+ * assumed to be relative to the end of the array---that is, an index of -1
+ * indicates the last element of the array, -2 is the next to last
+ * element in the array, and so on.
+ */
+
+void Init_Rect()
+{
+    using namespace RubyWX::Rect;
+    rb_cWXRect = rb_define_class("Rect",rb_cObject);
+
+    rb_define_alloc_func(rb_cWXRect,_alloc);
+
+    rb_define_method(rb_cWXRect,"inspect",RUBY_METHOD_FUNC(_inspect),0);
+    rb_define_method(rb_cWXRect,"hello_world",RUBY_METHOD_FUNC(_hello_world),0);
+
+}


### PR DESCRIPTION
# Description

This Pull Request attempts to address #809 - where content inside of C++ namespaces isn't processed. This is an issue for source code that use the Ruby C API in a C++ environment.

What this fix do is simply make the C Parser not treat the content of namespaces as body statements. Instead it just ignores the namespaces all together.

I'm not sure if it's perfect, but we're working on getting a very sizable amount of code parsed so I'll follow up with improvements as needed if we run into them.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
