### PR TITLE
Remove overlapping character classes to eliminate a warning

### DIFF
--- a/lib/yard/docstring_parser.rb
+++ b/lib/yard/docstring_parser.rb
@@ -116,7 +116,7 @@ module YARD
       @reference, @raw_text = detect_reference(content)
       text = parse_content(@raw_text)
       # Remove trailing/leading whitespace / newlines
-      @text = text.gsub(/\A[\r\n\s]+|[\r\n\s]+\Z/, '')
+      @text = text.gsub(/\A[\s]+|[\s]+\Z/, '')
       call_directives_after_parse
       post_process
       self


### PR DESCRIPTION
# Description

\s already covers the \r and \n characters, so Ruby was emitting a
warning about overlapping characters.

#1067 details the issue.

I didn't change this to just use `.strip`, since I wasn't sure if there was a reason that a regex & gsub were being used. It's possible that `.strip` from the stdlib would be clearer.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
