### PR TITLE
Use String#strip, rather than regex

### DIFF
--- a/lib/yard/docstring_parser.rb
+++ b/lib/yard/docstring_parser.rb
@@ -115,8 +115,7 @@ module YARD
       @handler = handler
       @reference, @raw_text = detect_reference(content)
       text = parse_content(@raw_text)
-      # Remove trailing/leading whitespace / newlines
-      @text = text.gsub(/\A[\r\n\s]+|[\r\n\s]+\Z/, '')
+      @text = text.strip
       call_directives_after_parse
       post_process
       self


### PR DESCRIPTION
The previous regex was emitting a warning about overlapping character
classes, and the regex was complicated. Use the stdlib's strip function
since it's more clear, and also doesn't emit warnings.

# Description

An updated PR for #1068 

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits). **this is why I have a new PR here**
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
