### PR TITLE
modify yardopts parsing to ignore hash and c-style comments

### DIFF
--- a/lib/yard/cli/yardopts_command.rb
+++ b/lib/yard/cli/yardopts_command.rb
@@ -65,11 +65,14 @@ module YARD
 
       private
 
-      # Parses the .yardopts file for default yard options
+      # Parses the .yardopts file for default yard options,
+      # ignoring comment lines beginning with // or #
       # @return [Array<String>] an array of options parsed from .yardopts
       def yardopts(file = options_file)
         return [] unless use_yardopts_file
-        File.read_binary(file).shell_split
+        contents = File.read_binary(file)
+        opts = contents.gsub(%r{(#|//).*\n?}, "")
+        opts.shell_split
       rescue Errno::ENOENT
         []
       end

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -510,8 +510,21 @@ RSpec.describe YARD::CLI::Yardoc do
       optsdata = String.new("foo bar")
       expect(optsdata).to receive(:shell_split)
       expect(File).to receive(:read_binary).with("test").and_return(optsdata)
+      allow(optsdata).to receive(:gsub).and_return(optsdata)
       @yardoc.options_file = "test"
       @yardoc.run
+    end
+
+    it "ignores .yardopts tokens that are comments" do
+      optsdata = String.new("--one-file --locale es # --locale en\n// --title not_my_title")
+      expect(File).to receive(:read_binary).with("test").and_return(optsdata)
+      @yardoc.options_file = "test"
+      @yardoc.run
+
+      expect(@yardoc.options.onefile).to be_truthy
+      expect(@yardoc.options.locale).to eq('es')
+      expect(@yardoc.options.title).not_to eq('not_my_title')
+      expect(@yardoc.options.serializer.options)
     end
 
     it "allows opts specified in command line to override yardopts file" do


### PR DESCRIPTION
# Description

Adds support for hash and c-style comments in .yardopts files.

We want this to be able to reduces developer confusion for those new to YARD. Devs can tend to see a .yardopts file, get confused, then just shrug and walk away. 

Being able to comment the options can pull them in more easily, and allow for documenting options that may not be use currently but are of interest.

#### Example
```
# YARD options, see `yardoc -h`
# for valid options and descriptions

# parse inline documentation with
# rdoc markup formatting
--markup "rdoc"

# treat code mixed in via include
# and extend as first class citizens
# of the module without additional directives
--embed-mixins

# clear the yardoc database
# when requesting documentation
# --no-cache

# Additional files to add to documentation tree
-
CHANGELOG.md
CONTRIBUTING.md
LICENSE
```

# Completed Tasks

* [y] I have read the [Contributing Guide][contrib].
* [y] The pull request is complete (implemented / written).
* [y] Git commits have been cleaned up (squash WIP / revert commits).
* [y] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
