### PR TITLE
API docs for CLI: avoid misrendered dashes

### DIFF
--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -117,7 +117,7 @@ module YARD
     #
     #   --tag overload:"Overloaded Method"
     #
-    # See +yardoc --help+ for a description of the various options.
+    # See +yard help doc+ for a description of the various options.
     #
     # Tags added in this way are automatically displayed in output. To add
     # a meta-data tag that does not show up in output, use +--hide-tag TAG+.


### PR DESCRIPTION
This change avoids rendering `--` as a single emdash character in the generated HTML.

By pointing at the `yard help doc` invocation, we side-step the issue altogether.