### PR TITLE
Add gem removal hook to remove YARD and yri data on uninstalling gems

### DIFF
--- a/lib/yard/rubygems/hook.rb
+++ b/lib/yard/rubygems/hook.rb
@@ -72,6 +72,14 @@ module YARD
     end
 
     ##
+    # Pre uninstalls hook that removes documentation
+    #
+
+    def self.removal_hook(uninstaller)
+      new(uninstaller.spec).remove
+    end
+
+    ##
     # Loads the YARD generator
 
     def self.load_yard
@@ -160,7 +168,30 @@ module YARD
         FileUtils.mkdir_p @doc_dir
       end
     end
+
+    def uninstall_yard
+      if File.exist?(@yard_dir)
+        raise Gem::FilePermissionError, @yard_dir unless File.writable?(@yard_dir)
+        FileUtils.rm_rf @yard_dir
+      end
+    end
+
+    def uninstall_yri
+      if File.exist?(@yri_dir)
+        raise Gem::FilePermissionError, @yri_dir unless File.writable?(@yri_dir)
+        FileUtils.rm_rf @yri_dir
+      end
+    end
+
+    ##
+    # Removes YARD and yri data
+
+    def remove
+      uninstall_yri
+      uninstall_yard
+    end
   end
 end
 
 Gem.done_installing(&YARD::RubygemsHook.method(:generation_hook))
+Gem.pre_uninstall(&YARD::RubygemsHook.method(:removal_hook))


### PR DESCRIPTION
# Description

When you uninstall some gems, YARD and yri data should be removed as well as RDoc data(see 
[here][rdoc]).

[rdoc]: https://github.com/ruby/ruby/blob/68c9c97f139c8e4f0543a3f431fdb567ad6b1ac3/lib/rubygems/uninstaller.rb#L271

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
