### PR TITLE
fix duplication of return tags in C

### DIFF
--- a/lib/yard/handlers/c/handler_methods.rb
+++ b/lib/yard/handlers/c/handler_methods.rb
@@ -67,7 +67,9 @@ module YARD
             register_visibility(obj, visibility)
             find_method_body(obj, func_name)
             obj.explicit = true
-            obj.add_tag(Tags::Tag.new(:return, '', 'Boolean')) if name =~ /\?$/
+            if name.end_with?("?") && !(obj.tag(:return) || (obj.tag(:overload) && obj.tag(:overload).tag(:return)))
+              obj.add_tag(Tags::Tag.new(:return, '', 'Boolean'))
+            end
           end
         end
 


### PR DESCRIPTION
# Description

fix duplication of return tags on methods end with a question mark in C

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
