### PR TITLE
Add --fail-on-warning option

### DIFF
--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -200,6 +200,9 @@ module YARD
       # @since 0.7.0
       attr_accessor :has_markup
 
+      # @return [Boolean] whether yard exits with error status code if a warning occurs
+      attr_accessor :fail_on_warning
+
       # Creates a new instance of the commandline utility
       def initialize
         super
@@ -218,6 +221,7 @@ module YARD
         @list = false
         @save_yardoc = true
         @has_markup = false
+        @fail_on_warning = false
 
         if defined?(::Encoding) && ::Encoding.respond_to?(:default_external=)
           utf8 = ::Encoding.find('utf-8')
@@ -272,6 +276,8 @@ module YARD
             Stats.new(false).run(*args)
           end
         end
+
+        abort if fail_on_warning && log.warned
 
         true
       ensure
@@ -554,6 +560,10 @@ module YARD
 
         opts.on('--exclude REGEXP', 'Ignores a file if it matches path match (regexp)') do |path|
           excluded << path
+        end
+
+        opts.on('--fail-on-warning', 'Exit with error status code if a warning occurs') do
+          self.fail_on_warning = true
         end
       end
 

--- a/lib/yard/logging.rb
+++ b/lib/yard/logging.rb
@@ -47,6 +47,7 @@ module YARD
       self.show_progress = false
       self.level = WARN
       self.formatter = method(:format_log)
+      self.warned = false
       @progress_indicator = 0
       @mutex = Mutex.new
       @progress_msg = nil
@@ -59,6 +60,13 @@ module YARD
       self.level = DEBUG if $DEBUG
       super
     end
+
+    # Remembers when a warning occurs and writes a warning message.
+    def warn(*args)
+      self.warned = true
+      super
+    end
+    attr_accessor :warned
 
     # Captures the duration of a block of code for benchmark analysis. Also
     # calls {#progress} on the message to display it to the user.

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -183,6 +183,11 @@ RSpec.describe YARD::CLI::Yardoc do
       expect(Registry).not_to receive(:save)
       @yardoc.run(arg)
     end
+
+    should_accept('--fail-on-warning') do |arg|
+      expect(YARD).to receive(:parse)
+      @yardoc.run(arg)
+    end
   end
 
   describe "Output options" do
@@ -815,6 +820,20 @@ RSpec.describe YARD::CLI::Yardoc do
     it "does not create processing lock if not saving" do
       expect(Registry).not_to receive(:lock_for_writing)
       @yardoc.run('--no-save')
+    end
+
+    context "with --fail-on-warning" do
+      it "exits with error status code if a warning occurs" do
+        allow(log).to receive(:warned).and_return(true)
+        expect { @yardoc.run("--fail-on-warning") }.to raise_error(SystemExit) do |error|
+          expect(error).not_to be_success
+        end
+      end
+
+      it "does not exit if a warning does not occur" do
+        allow(log).to receive(:warned).and_return(false)
+        expect { @yardoc.run("--fail-on-warning") }.not_to raise_error
+      end
     end
   end
 end

--- a/spec/logging_spec.rb
+++ b/spec/logging_spec.rb
@@ -32,4 +32,13 @@ RSpec.describe YARD::Logger do
       log.enter_level(Logger::INFO) { log.backtrace(exc, :warn) }
     end
   end
+
+  describe '#warn' do
+    before  { log.warned = false }
+    after   { log.warned = false }
+
+    it 'changes #warned from false to true' do
+      expect { log.warn('message') }.to change(log, :warned).from(false).to(true)
+    end
+  end
 end


### PR DESCRIPTION
# Description

Add `--fail-on-warning` option. See #935

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
