### PR TITLE
Allow "@param foo" to document a _foo parameter

### DIFF
--- a/lib/yard/docstring_parser.rb
+++ b/lib/yard/docstring_parser.rb
@@ -278,6 +278,8 @@ module YARD
       next unless parser.object.is_a?(CodeObjects::MethodObject)
       next if parser.object.is_alias?
       names = parser.object.parameters.map {|l| l.first.gsub(/\W/, '') }
+      alt_names = names.find_all {|n| n.start_with?("_") }.map {|n| n[1..-1] }
+      names.concat(alt_names)
       seen_names = []
       infile_info = "\n    in file `#{parser.object.file}' " \
                     "near line #{parser.object.line}"

--- a/spec/docstring_parser_spec.rb
+++ b/spec/docstring_parser_spec.rb
@@ -215,6 +215,14 @@ eof
       eof
     end
 
+    it "does not warn about unused named parameters" do
+      expect(log).to_not receive(:warn).with(/@param tag has unknown parameter name: bar/)
+      YARD.parse_string <<-eof
+        # @param bar useful in subclasses
+        def foo(_bar) end
+      eof
+    end
+
     it "warns about invalid named parameters on @!method directives" do
       expect(log).to receive(:warn).with(/@param tag has unknown parameter name: notaparam/)
       YARD.parse_string <<-eof


### PR DESCRIPTION
# Description

Consider this example of an abstract base and a concrete implementation:

```ruby
class Base
  # This method is very important and here is its description.
  # @param thing [Foo] the thing to process
  def process(_thing)
    raise NotImplementedError,
      "Subclasses of #{Module.nesting.first} must override #{__method__}"
  end
end

class Concrete < Base
  # (see Base#process)
  def process(thing)
    thing.foo
  end
end
```

The base class documents the *thing* parameter but it does not use it.
Accordingly, the parameter is renamed to `_thing` (which makes RuboCop happy).

But YARD gives a warning "@param tag has unknown parameter name: thing" for `Base`.
If we used "@param _thing" then an analogous warning would be given for `Concrete` (which uses the `(see Class#method)` shortcut for docs copying).

Therefore I propose this change, which allows `@param foo` to match a parameter named `_foo`.

(For reference, the actual code from my team's work affected by this is: [source](https://github.com/config-files-api/config_files_api/blob/7f411362acbecd8d723ba2dd730a012c9f766be0/lib/cfa/placer.rb#L6), [rendered docs](http://www.rubydoc.info/github/config-files-api/config_files_api/CFA/Placer#new_element-instance_method))

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
