### PR TITLE
allow aliases of class methods in C

### DIFF
--- a/lib/yard/handlers/c/alias_handler.rb
+++ b/lib/yard/handlers/c/alias_handler.rb
@@ -1,16 +1,26 @@
 # frozen_string_literal: true
 class YARD::Handlers::C::AliasHandler < YARD::Handlers::C::Base
-  MATCH = /rb_define_alias
+  MATCH1 = /rb_define_alias
              \s*\(\s*([\w\.]+),
              \s*"([^"]+)",
              \s*"([^"]+)"\s*\)/xm
-  handles MATCH
+  MATCH2 = /rb_define_alias
+             \s*\(\s*rb_singleton_class\s*\(\s*([\w\.]+)\s*\)\s*,
+             \s*"([^"]+)",
+             \s*"([^"]+)"\s*\)/xm
+  handles MATCH1
+  handles MATCH2
   statement_class BodyStatement
 
   process do
-    statement.source.scan(MATCH) do |var_name, new_name, old_name|
+    statement.source.scan(MATCH1) do |var_name, new_name, old_name|
       var_name = "rb_cObject" if var_name == "rb_mKernel"
       handle_alias(var_name, new_name, old_name)
+    end
+
+    statement.source.scan(MATCH2) do |var_name, new_name, old_name|
+      var_name = "rb_cObject" if var_name == "rb_mKernel"
+      handle_alias(var_name, new_name, old_name, :class)
     end
   end
 end

--- a/lib/yard/handlers/c/handler_methods.rb
+++ b/lib/yard/handlers/c/handler_methods.rb
@@ -82,13 +82,13 @@ module YARD
           end
         end
 
-        def handle_alias(var_name, new_name, old_name)
+        def handle_alias(var_name, new_name, old_name, scope = :instance)
           namespace = namespace_for_variable(var_name)
           return if namespace.nil?
           new_meth = new_name.to_sym
           old_meth = old_name.to_sym
-          old_obj = namespace.child(:name => old_meth, :scope => :instance)
-          new_obj = register MethodObject.new(namespace, new_meth, :instance) do |o|
+          old_obj = namespace.child(:name => old_meth, :scope => scope)
+          new_obj = register MethodObject.new(namespace, new_meth, scope) do |o|
             register_visibility(o, visibility)
             register_file_info(o, statement.file, statement.line)
           end

--- a/spec/handlers/c/alias_handler_spec.rb
+++ b/spec/handlers/c/alias_handler_spec.rb
@@ -31,4 +31,19 @@ RSpec.describe YARD::Handlers::C::AliasHandler do
     expect(Registry.at('Foo#foo')).to be_reader
     expect(Registry.at('Foo#foo?')).to be_is_alias
   end
+
+  it "allows defining of aliases (rb_define_alias) of class methods" do
+    parse <<-eof
+      /* FOO */
+      VALUE foo(VALUE x) { int value = x; }
+      void Init_Foo() {
+        rb_cFoo = rb_define_class("Foo", rb_cObject);
+        rb_define_singleton_method(rb_cFoo, "foo", foo, 1);
+        rb_define_alias(rb_singleton_class(rb_cFoo), "bar", "foo");
+      }
+    eof
+
+    expect(Registry.at('Foo.bar')).to be_is_alias
+    expect(Registry.at('Foo.bar').docstring).to eq 'FOO'
+  end
 end


### PR DESCRIPTION
# Description

To allow aliases of class methods in C.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
