### PR TITLE
Document block for Struct.new if present

### DIFF
--- a/lib/yard/handlers/ruby/constant_handler.rb
+++ b/lib/yard/handlers/ruby/constant_handler.rb
@@ -35,6 +35,7 @@ class YARD::Handlers::Ruby::ConstantHandler < YARD::Handlers::Ruby::Base
     if lhs.type == :const
       klass = create_class(lhs[0], P(:Struct))
       create_attributes(klass, extract_parameters(statement[1]))
+      parse_block(statement[1].block[1], :namespace => klass) unless statement[1].block.nil?
     else
       raise YARD::Parser::UndocumentableError, "Struct assignment to #{statement[0].source}"
     end

--- a/spec/handlers/constant_handler_spec.rb
+++ b/spec/handlers/constant_handler_spec.rb
@@ -27,6 +27,14 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}Constant
     end
   end
 
+  it 'documents block for Struct.new if present' do
+    obj = Registry.at("MyStructWithConstant")
+    expect(obj).to be_kind_of(CodeObjects::ClassObject)
+    expect(obj.constants[0].docstring).to eq 'A constant.'
+    expect(obj.constants[0].name).to eq :CONSTANT
+    expect(obj.constants[0].value).to eq "42"
+  end
+
   it "turns Const = Struct.new('Name', :sym) into class Const with attr :sym" do
     obj = Registry.at("NotMyClass")
     expect(obj).to be_kind_of(CodeObjects::ClassObject)

--- a/spec/handlers/examples/constant_handler_001.rb.txt
+++ b/spec/handlers/examples/constant_handler_001.rb.txt
@@ -18,6 +18,11 @@ MyClass = Struct.new(:a, :b, :c)
 NotMyClass = Struct.new("NotMyClass2", :b, :c)
 MyEmptyStruct = Struct.new
 
+MyStructWithConstant = Struct.new do
+  # A constant.
+  CONSTANT = 42
+end
+
 # A crazy struct.
 #
 # @attr [String] bar An attr


### PR DESCRIPTION
# Description
The documentation of Ruby says:
> If a block is given it will be evaluated in the context of StructClass, assing the created class as a parameter:
> (snip)
> This is the recommended way to customize a struct. Subclassing an anonymous struct creates an extra anonymous class that will never be used.

This change implements documentation for such usage.

# Completed Tasks

* [X] I have read the [Contributing Guide][contrib].
* [X] The pull request is complete (implemented / written).
* [X] Git commits have been cleaned up (squash WIP / revert commits).
* [X] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md