### PR TITLE
CHANGELOG: add compare links to each release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
-# 0.9.9 - April 23rd, 2017
+# [0.9.9] - April 23rd, 2017
+
+[0.9.9]: https://github.com/lsegal/yard/compare/v0.9.8...v0.9.9
 
 - Added `gem uninstall` hooks to remove YARD documentation files. (#1083)
 - Added support for C++ namespaces. (#809)
@@ -7,16 +9,22 @@
 - Hide some Ruby warnings.
 - Improve progress indicator icons in terminal.
 
-# 0.9.8 - January 13th, 2017
+# [0.9.8] - January 13th, 2017
+
+[0.9.8]: https://github.com/lsegal/yard/compare/v0.9.7...v0.9.8
 
 - Fixed installed gems not being correctly found in `yard server` and by plugins.
 - Fixed tokenization of `%w(...)` array syntax.
 
-# 0.9.7 - January 9th, 2017
+# [0.9.7] - January 9th, 2017
+
+[0.9.7]: https://github.com/lsegal/yard/compare/v0.9.6...v0.9.7
 
 - Fixed resolution of absolute object paths with ambiguous names. (#1029)
 
-# 0.9.6 - January 7th, 2017
+# [0.9.6] - January 7th, 2017
+
+[0.9.6]: https://github.com/lsegal/yard/compare/v0.9.5...v0.9.6
 
 - Removed official support for Ruby 1.x (1.8/1.9). YARD can still be installed
   in these versions, but support is not guaranteed. Simple bug fixes may still
@@ -37,7 +45,9 @@
 - Use RubyGems 2.x+ API to query gems when available instead of using backport.
 - Various bug fixes
 
-# 0.9.5 - July 22nd, 2016
+# [0.9.5] - July 22nd, 2016
+
+[0.9.5]: https://github.com/lsegal/yard/compare/v0.9.4...v0.9.5
 
 - `yard doc` will now generate `.yardoc/processing` and `.yardoc/complete` files
   to allow other tools to properly detect when YARD is in the middle of parsing
@@ -48,11 +58,15 @@
 - Added warning for macros attached to non-method objects.
 - Fixed a few more parsing errors.
 
-# 0.9.4 - July 21st, 2016
+# [0.9.4] - July 21st, 2016
+
+[0.9.4]: https://github.com/lsegal/yard/compare/v0.9.3...v0.9.4
 
 - Minor Ruby file parsing and CSS bug fixes.
 
-# 0.9.3 - July 20th, 2016
+# [0.9.3] - July 20th, 2016
+
+[0.9.3]: https://github.com/lsegal/yard/compare/v0.9.2...v0.9.3
 
 - Added support for {YARD::Server::RackAdapter} to be mounted under prefix URIs.
 - Fixed regression in `yard server -g` that caused static file assets on index
@@ -60,7 +74,9 @@
 - Fixed regression in `yard server -g` index page that disabled scrolling and
   caused other HTML rendering glitches.
 
-# 0.9.2 - July 19th, 2016
+# [0.9.2] - July 19th, 2016
+
+[0.9.2]: https://github.com/lsegal/yard/compare/v0.9.1...v0.9.2
 
 - Added `yard config --gem-install-[yri|yard]` commands which auto-configure
   your `~/.gemrc` file to run yri/yard instead of ri/rdoc on a `gem install`.
@@ -71,7 +87,9 @@
 - YRI will now search across all gem versions (latest first) for the .yardoc
   database.
 
-# 0.9.1 - July 18th, 2016
+# [0.9.1] - July 18th, 2016
+
+[0.9.1]: https://github.com/lsegal/yard/compare/v0.9.0...v0.9.1
 
 - Added "Attributes" section to `yard stats`.
 - Added support for RubyGems 2.x `--document=yri,yard` flags. You can now run
@@ -104,7 +122,9 @@
 - {YARD::CodeObjects::Base#format} now passes the :type parameter to templates.
 - Hide methods with filtered namespaces in Method Listing.
 
-# 0.9.0 - July 4th, 2016
+# [0.9.0] - July 4th, 2016
+
+[0.9.0]: https://github.com/lsegal/yard/compare/v0.8.7.6...v0.9.0
 
 Special thanks to Alex Dowad, MSP-Greg, and Alex McLain for their extended
 contributions to this version.
@@ -123,12 +143,16 @@ contributions to this version.
 - Fixed deprecation warnings from Rake 10.x.
 - Tests updated for RSpec 3.
 
-# 0.8.7.6 - October 26, 2014
+# [0.8.7.6] - October 26, 2014
+
+[0.8.7.6]: https://github.com/lsegal/yard/compare/v0.8.7.5...v0.8.7.6
 
 - Support using `@option` tag on keyword arg splat parameter. (#729)
 - Add `.stats_options` for `YardocTask`. (#800, #801)
 
-# 0.8.7.5 - October 26, 2014
+# [0.8.7.5] - October 26, 2014
+
+[0.8.7.5]: https://github.com/lsegal/yard/compare/v0.8.7.4...v0.8.7.5
 
 - Fix linking of methods in top level namespace in method listing. (#776)
 - Support using C macros in function declarations. (#810)
@@ -147,6 +171,8 @@ contributions to this version.
 
 # 0.8.7.4 - March 22, 2014
 
+[0.8.7.4]: https://github.com/lsegal/yard/compare/v0.8.7.3...v0.8.7.4
+
 - Mark C methods as explicit but also remove explicit check in stats. (#727)
 - Report unresolved parent namespaces as undocumentable errors instead. (#753)
 - No longer ignore overridden methods from documentation check in stats (#719)
@@ -160,7 +186,9 @@ contributions to this version.
 - Fixed a typo that was causing Windows detection to always fail. (#715)
 - Add debug information when loading a plugin fails. (#711)
 
-# 0.8.7.3 - November 1, 2013
+# [0.8.7.3] - November 1, 2013
+
+[0.8.7.3]: https://github.com/lsegal/yard/compare/v0.8.7.2...v0.8.7.3
 
 - Handle Unicode method/class/file names in server URL encoding (lsegal/rubydoc.info#69).
 - Style keyword style hashes with same symbol color in code highlighting (#707).
@@ -170,34 +198,46 @@ contributions to this version.
 - Add support for extra Ruby 2 symbol types in Ripper (#701).
 - Ensure config directory exists before saving config file (#700).
 
-# 0.8.7.2 - September 18, 2013
+# [0.8.7.2] - September 18, 2013
+
+[0.8.7.2]: https://github.com/lsegal/yard/compare/v0.8.7.1...v0.8.7.2
 
 - Disallow absolute URLs when using frame anchor support.
 - Support casted functions in CRuby method declarations (#697)
 
-# 0.8.7.1 - September 11, 2013
+# [0.8.7.1] - September 11, 2013
+
+[0.8.7.1]: https://github.com/lsegal/yard/compare/v0.8.7...v0.8.7.1
 
 - Fix potential XSS issue with frame anchor support.
 - Add support for gettext 3.x gem.
 
-# 0.8.7 - July 26, 2013
+# [0.8.7] - July 26, 2013
+
+[0.8.7]: https://github.com/lsegal/yard/compare/v0.8.6.2...v0.8.7
 
 - Added `--hide-api API` option to hide objects with a given `@api` tag (#685).
 - Added "Returns ...." prefix to summary when a lone @return tag is used.
 - Fixed issue that caused ref tags to be added to a docstring twice (#678).
 - Fixed formatting issue in docstring summaries (#686)
 
-# 0.8.6.2 - June 27, 2013
+# [0.8.6.2] - June 27, 2013
+
+[0.8.6.2]: https://github.com/lsegal/yard/compare/v0.8.6.1...v0.8.6.2
 
 - Fixed issue where `yard graph` was not displaying methods
 
-# 0.8.6.1 - April 14, 2013
+# [0.8.6.1] - April 14, 2013
+
+[0.8.6.1]: https://github.com/lsegal/yard/compare/v0.8.6...v0.8.6.1
 
 - Fixed broken links in File menu on default HTML template
 - Added --layout switch to `yard display` to wrap output in layout template.
 - See {file:docs/WhatsNew.md} for more information on added features.
 
-# 0.8.6 - April 13, 2013
+# [0.8.6] - April 13, 2013
+
+[0.8.6]: https://github.com/lsegal/yard/compare/v0.8.5.2...v0.8.6
 
 - Various fixes and improved Ruby 2.x compatibility support
 - Added support for `asciidoc` markup type
@@ -205,24 +245,34 @@ contributions to this version.
 - Added `yard display` command to display and format an individual object
 - See {file:docs/WhatsNew.md} for more information on added features.
 
-# 0.8.5.2 - February 26, 2013
+# [0.8.5.2] - February 26, 2013
+
+[0.8.5.2]: https://github.com/lsegal/yard/compare/v0.8.5.1...v0.8.5.2
 
 - Support new keyword argument syntax in method signatures (Ruby 2.x)
 
-# 0.8.5.1 - February 25, 2013
+# [0.8.5.1] - February 25, 2013
+
+[0.8.5.1]: https://github.com/lsegal/yard/compare/v0.8.5...v0.8.5.1
 
 - Fix `yard diff` of gem files with RubyGems 2.x
 
-# 0.8.5 - February 24, 2013
+# [0.8.5] - February 24, 2013
+
+[0.8.5]: https://github.com/lsegal/yard/compare/v0.8.4.1...v0.8.5
 
 - Basic support for Ruby 2.0 (fix compat issues in RDoc 4.0, RubyGems 2.0)
 - Add CSS styling for tables in default HTML template
 
-# 0.8.4.1 - February 5, 2013
+# [0.8.4.1] - February 5, 2013
+
+[0.8.4.1]: https://github.com/lsegal/yard/compare/v0.8.4...v0.8.4.1
 
 - Fix regression that broke loading of existing yardoc dbs (#648)
 
-# 0.8.4 - February 4, 2013
+# [0.8.4] - February 4, 2013
+
+[0.8.4]: https://github.com/lsegal/yard/compare/v0.8.3...v0.8.4
 
 - Add `-B/--bind` switch to yard server (#593, #608)
 - Add CodeObjects::Base#title for plugins to customize how object
@@ -234,7 +284,9 @@ contributions to this version.
 - Fix line range for class/module node bodies (#626)
 - Search extended modules for attached DSL macros (#553)
 
-# 0.8.3 - October 14, 2012
+# [0.8.3] - October 14, 2012
+
+[0.8.3]: https://github.com/lsegal/yard/compare/v0.8.2.1...v0.8.3
 
 - Add `--non-transitive-tag` to disable tag transitivity (#571)
 - Support --db inside .yardopts for graph/server commands (#583, #586)
@@ -245,11 +297,15 @@ contributions to this version.
 - Fix to `--api` and `--no-api` support (#559)
 - Fix class nesting issues when path starts with "::" (#552)
 
-# 0.8.2.1 - June 9, 2012
+# [0.8.2.1] - June 9, 2012
+
+[0.8.2.1]: https://github.com/lsegal/yard/compare/v0.8.2...v0.8.2.1
 
 - Fix a set of regressions in yard server search and dynamic generation
 
-# 0.8.2 - June 7, 2012
+# [0.8.2] - June 7, 2012
+
+[0.8.2]: https://github.com/lsegal/yard/compare/v0.8.1...v0.8.2
 
 - Added progress style output in tty terminals
 - Embedded mixins should ignore methods defined on module (#539)
@@ -259,14 +315,18 @@ contributions to this version.
 - Fixed regression that caused various commands to not show output (#548)
 - Respect current visibility when parsing class conditions (#551)
 
-# 0.8.1 - May 2, 2012
+# [0.8.1] - May 2, 2012
+
+[0.8.1]: https://github.com/lsegal/yard/compare/v0.8.0...v0.8.1
 
 - Added `--[no-]api` switch to generate docs for API sets (see {file:docs/WhatsNew.md} for details) (#532)
 - The `yard list` command now uses cache by default (#533)
 - Fix `yardoc` generating incorrectly named method list file (#528)
 - Fix HTML output occasionally showing trailing mdash on options list (#522)
 
-# 0.8.0 - April 30, 2012
+# [0.8.0] - April 30, 2012
+
+[0.8.0]: https://github.com/lsegal/yard/compare/v0.7.5...v0.8.0
 
 - See {file:docs/WhatsNew.md} for a list of added features
 - Over 20 bug fixes:
@@ -295,11 +355,15 @@ contributions to this version.
   - Fix search bar not redirecting to method page. (#509)
   - Fix server returning exception message bodies as String (#518)
 
-# 0.7.5 - January 31, 2012
+# [0.7.5] - January 31, 2012
+
+[0.7.5]: https://github.com/lsegal/yard/compare/v0.7.4...v0.7.5
 
 - Various minor bug fixes
 
-# 0.7.4 - December 2, 2011
+# [0.7.4] - December 2, 2011
+
+[0.7.4]: https://github.com/lsegal/yard/compare/v0.7.3...v0.7.4
 
 - Redcarpet is now the default Markdown formatting library. GFM now works out-of-box (#404)
 - Fix server side searching for elements that are marked private (#420)
@@ -312,14 +376,18 @@ contributions to this version.
 - Improve support for has_rdoc in RubyGems 1.8.x (#401)
 - See the {file:docs/WhatsNew.md} document for details on added features
 
-# 0.7.3 - October 15, 2011
+# [0.7.3] - October 15, 2011
+
+[0.7.3]: https://github.com/lsegal/yard/compare/v0.7.2...v0.7.3
 
 - Improve support for parsing under Ruby 1.9.2p290 and 1.9.3 (#365, #370)
 - Add support for SWIG generated CRuby code (#369)
 - Add support for `rb_define_attr` calls in CRuby code (#362)
 - Handle file pointers in CRuby code (#358)
 
-# 0.7.2 - June 14, 2011
+# [0.7.2] - June 14, 2011
+
+[0.7.2]: https://github.com/lsegal/yard/compare/v0.7.1...v0.7.2
 
 - Fix `yard --help` not showing proper output
 - YARD now expands path to `.yardoc` file in daemon mode for server (#328)
@@ -329,11 +397,15 @@ contributions to this version.
 - Fix bug in constant documentation when using `%w()` (#348)
 - Fix YARD style URL links when using autolinking markdown (#353)
 
-# 0.7.1 - May 18, 2011
+# [0.7.1] - May 18, 2011
+
+[0.7.1]: https://github.com/lsegal/yard/compare/v0.7.0...v0.7.1
 
 - Fixes a bug in `yard server` not displaying class list properly.
 
-# 0.7.0 - May 17, 2011
+# [0.7.0] - May 17, 2011
+
+[0.7.0]: https://github.com/lsegal/yard/compare/v0.6.8...v0.7.0
 
 - See the {file:docs/WhatsNew.md} document for details on added features
 - Make sure that Docstring#line_range is filled when possible (#243)
@@ -344,23 +416,31 @@ contributions to this version.
 - Ignore keyboard shortcuts when an input is active (#312)
 - And more...
 
-# 0.6.8 - April 14, 2011
+# [0.6.8] - April 14, 2011
+
+[0.6.8]: https://github.com/lsegal/yard/compare/v0.6.7...v0.6.8
 
 - Fix regression in RDoc 1.x markup loading
 - Fix regression in loading of markup libraries for `yard server`
 
-# 0.6.7 - April 6, 2011
+# [0.6.7] - April 6, 2011
+
+[0.6.7]: https://github.com/lsegal/yard/compare/v0.6.6...v0.6.7
 
 - Fix has_rdoc gem specification issue with new RubyGems plugin API (oops!)
 
-# 0.6.6 - April 6, 2011
+# [0.6.6] - April 6, 2011
+
+[0.6.6]: https://github.com/lsegal/yard/compare/v0.6.5...v0.6.6
 
 - Fix error message when RDoc is not present (#270)
 - Add markup type 'none' to perform basic HTML translation (fallback when RDoc is not present)
 - Add support for RubyGems 1.7.x (#272)
 - Fix rendering of `{url description}` syntax when description contains newline
 
-# 0.6.5 - March 13, 2011
+# [0.6.5] - March 13, 2011
+
+[0.6.5]: https://github.com/lsegal/yard/compare/v0.6.4...v0.6.5
 
 - Support `ripper` gem in Ruby 1.8.7
 - Upgrade jQuery to 1.5.1
@@ -383,7 +463,9 @@ contributions to this version.
 - Support `private_constant` class method for 1.9.3 (#219)
 - Do not assume RDoc is installed (#214)
 
-# 0.6.4 - December 21, 2010
+# [0.6.4] - December 21, 2010
+
+[0.6.4]: https://github.com/lsegal/yard/compare/v0.6.3...v0.6.4
 
 - Fix yri tool crashing with new Config class (gh-217)
 - Fix support for ::TopLevelConstants (gh-216)
@@ -395,11 +477,15 @@ contributions to this version.
 - Disallow `extend self` inside of a class (gh-202)
 - Constants now recognized in C extensions (gh-201)
 
-# 0.6.3 - November 21, 2010
+# [0.6.3] - November 21, 2010
+
+[0.6.3]: https://github.com/lsegal/yard/compare/v0.6.2...v0.6.3
 
 - Fixed regression that caused `yardoc --markup` to silently exit
 
-# 0.6.2 - November 15, 2010
+# [0.6.2] - November 15, 2010
+
+[0.6.2]: https://github.com/lsegal/yard/compare/v0.6.1...v0.6.2
 
 - **Plugins no longer automatically load, use `--plugin` to load a plugin**
 - Added YARD::Config and ~/.yard/config YAML configuration file
@@ -414,7 +500,9 @@ contributions to this version.
 - Improved support for JRuby 1.6.4+. YARD now passes all specs in JRuby (gh-185)
 - Improved YARD documentation (gh-172,191,196)
 
-# 0.6.1 - September 06, 2010
+# [0.6.1] - September 06, 2010
+
+[0.6.1]: https://github.com/lsegal/yard/compare/v0.6.0...v0.6.1
 
 - Fixed TOC showing on top of class/method list in no-frames view
 - A message now displays when running `yard server` with Rack/Mongrel installed
@@ -424,7 +512,9 @@ contributions to this version.
 - Fixed support for loading .yardoc files under Windows
 - Fixed inheritance tree arrows not displaying in certain environments
 
-# 0.6.0 - August 29, 2010
+# [0.6.0] - August 29, 2010
+
+[0.6.0]: https://github.com/lsegal/yard/compare/v0.5.8...v0.6.0
 
 - Added dynamic local documentation server
 - Added @group/@endgroup declarations to organize methods into groups
@@ -438,11 +528,15 @@ contributions to this version.
 - Removed `yard-graph` executable
 - See more changes in the {file:docs/WhatsNew.md what's new document}
 
-# 0.5.8 - June 22, 2010
+# [0.5.8] - June 22, 2010
+
+[0.5.8]: https://github.com/lsegal/yard/compare/v0.5.7...v0.5.8
 
 - Merge fix from 0.6 branch for --no-private visibility checking
 
-# 0.5.7 - June 21, 2010
+# [0.5.7] - June 21, 2010
+
+[0.5.7]: https://github.com/lsegal/yard/compare/v0.5.6...v0.5.7
 
 - Fixed visibility flag parsing in `yardoc`
 - Updated Parser Architecture documentation with new SourceParser API
@@ -450,36 +544,52 @@ contributions to this version.
 - Fix loading of .yardoc file as cache (and preserving aliases)
 - Fix "lib" directory missing when running YARD on installed gems
 
-# 0.5.6 - June 12, 2010
+# [0.5.6] - June 12, 2010
+
+[0.5.6]: https://github.com/lsegal/yard/compare/v0.5.5...v0.5.6
 
 - Bug fixes for RubyGems plugin, `has_rdoc=false` should now work
 - New API for registering custom parsers. See {file:docs/WhatsNew.md}
 
-# 0.5.5 - May 22, 2010
+# [0.5.5] - May 22, 2010
+
+[0.5.5]: https://github.com/lsegal/yard/compare/v0.5.4...v0.5.5
 
 - Various bug fixes
 
-# 0.5.4 - March 22, 2010
+# [0.5.4] - March 22, 2010
+
+[0.5.4]: https://github.com/lsegal/yard/compare/v0.5.3...v0.5.4
 
 - See {file:docs/WhatsNew.md what's new document} for changes
 
-# 0.5.3 - January 11, 2010
+# [0.5.3] - January 11, 2010
+
+[0.5.3]: https://github.com/lsegal/yard/compare/v0.5.2...v0.5.3
 
 - See {file:docs/WhatsNew.md what's new document} for changes
 
-# 0.5.2 - December 16, 2009
+# [0.5.2] - December 16, 2009
+
+[0.5.2]: https://github.com/lsegal/yard/compare/v0.5.1...v0.5.2
 
 - See {file:docs/WhatsNew.md what's new document} for changes
 
-# 0.5.1 - December 15, 2009
+# [0.5.1] - December 15, 2009
+
+[0.5.1]: https://github.com/lsegal/yard/compare/v0.5.0...v0.5.1
 
 - See {file:docs/WhatsNew.md what's new document} for changes
 
-# 0.5.0 - December 13, 2009
+# [0.5.0] - December 13, 2009
+
+[0.5.0]: https://github.com/lsegal/yard/compare/v0.4.0...v0.5.0
 
 - See {file:docs/WhatsNew.md what's new document} for changes
 
-# 0.4.0 - November 15, 2009
+# [0.4.0] - November 15, 2009
+
+[0.4.0]: https://github.com/lsegal/yard/compare/v0.2.3.5...v0.4.0
 
 - Added new templating engine based on [tadpole](http://github.com/lsegal/tadpole)
 - Added YARD queries (`--query` CLI argument to yardoc)
@@ -489,19 +599,27 @@ contributions to this version.
 - Changed default rake task to `rake yard`
 - Read about changes in {file:docs/WhatsNew.md}
 
-# 0.2.3.5 - August 13, 2009
+# [0.2.3.5] - August 13, 2009
+
+[0.2.3.5]: https://github.com/lsegal/yard/compare/v0.2.3.4...v0.2.3.5
 
 - Minor bug fixes.
 
-# 0.2.3.4 - August 07, 2009
+# [0.2.3.4] - August 07, 2009
+
+[0.2.3.4]: https://github.com/lsegal/yard/compare/v0.2.3.3...v0.2.3.4
 
 - Minor bug fixes.
 
-# 0.2.3.3 - July 26, 2009
+# [0.2.3.3] - July 26, 2009
+
+[0.2.3.3]: https://github.com/lsegal/yard/compare/v0.2.3.2...v0.2.3.3
 
 - Minor bug fixes.
 
-# 0.2.3.2 - July 06, 2009
+# [0.2.3.2] - July 06, 2009
+
+[0.2.3.2]: https://github.com/lsegal/yard/compare/v0.2.3.1...v0.2.3.2
 
 - Fix Textile hard-break issues
 - Add description for @see tag to use as link title in HTML docs.
@@ -515,23 +633,31 @@ contributions to this version.
 
         yardoc --private lib/**/*.rb - FAQ LICENSE
 
-# 0.2.3.1 - June 13, 2009
+# [0.2.3.1] - June 13, 2009
+
+[0.2.3.1]: https://github.com/lsegal/yard/compare/v0.2.3...v0.2.3.1
 
 - Add a RubyGems 1.3.2+ plugin to generate YARD documentation instead of
   RDoc. To take advantage of this plugin, set `has_rdoc = 'yard'` in your
   .gemspec file.
 
-# 0.2.3 - June 07, 2009
+# [0.2.3] - June 07, 2009
+
+[0.2.3]: https://github.com/lsegal/yard/compare/v0.2.2...v0.2.3
 
 - See the {file:docs/WhatsNew.md} file for a list of important new features.
 
-# 0.2.2 - Jun 16, 2008
+# [0.2.2] - Jun 16, 2008
+
+[0.2.2]: https://github.com/lsegal/yard/compare/v0.2.1...v0.2.2
 
 - This is the largest changset since yard's conception and involves a complete
   overhaul of the parser and API to make it more robust and far easier to
   extend and use for the developer.
 
-# 0.2.1 - February 20, 2008
+# [0.2.1] - February 20, 2008
+
+[0.2.1]: https://github.com/lsegal/yard/compare/v0.1a...v0.2.1
 
 - See the {file:docs/WhatsNew.md} file for a list of important new features.
 


### PR DESCRIPTION
This PR **adds links** on the version name of each release, linking **to the GitHub compare view** of this release vs the previous one.

  - inspired by [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)