### PR TITLE
stats update - none stable sort

### DIFF
--- a/lib/yard/cli/stats.rb
+++ b/lib/yard/cli/stats.rb
@@ -79,8 +79,9 @@ module YARD
         log.puts
         log.puts "Undocumented Objects:"
 
-        objects = @undoc_list.sort_by {|o| o.file.to_s }
-        max = objects.sort_by {|o| o.path.length }.last.path.length
+        # array needed for sort due to unstable sort
+        objects = @undoc_list.sort_by {|o| [o.file.to_s, o.path] }
+        max = objects.max {|a, b| a.path.length <=> b.path.length }.path.length
         if @compact
           objects.each do |object|
             log.puts("%-#{max}s     (%s)" % [object.path,

--- a/spec/cli/stats_spec.rb
+++ b/spec/cli/stats_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe YARD::CLI::Stats do
 Undocumented Objects:
 
 (in file: (stdin))
-B
 A
-A::CONST
 A#foo
+A::CONST
+B
 eof
   end
 
@@ -69,10 +69,10 @@ eof
     expect(@output.string).to eq <<-eof
 #{@main_stats}
 Undocumented Objects:
-B            ((stdin):11)
 A            ((stdin):1)
-A::CONST     ((stdin):2)
 A#foo        ((stdin):4)
+A::CONST     ((stdin):2)
+B            ((stdin):11)
 eof
   end
 


### PR DESCRIPTION
# Description

Recent Ruby builds may introduce unstable sorting; this was causing test failures with Windows builds.

Ran fork with Travis.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
