### PR TITLE
Fixes for trunk as of svn 60140 2017-10-08

### DIFF
--- a/lib/yard/parser/ruby/ast_node.rb
+++ b/lib/yard/parser/ruby/ast_node.rb
@@ -412,7 +412,14 @@ module YARD
 
         def double_splat_param
           return nil unless YARD.ruby2?
-          self[-2] if self[-2].is_a?(AstNode) && self[-2].type == :ident
+          if (node = self[-2]).is_a?(AstNode)
+            if node.type == :ident
+              node
+            elsif node.type == :kwrest_param
+              # See https://bugs.ruby-lang.org/issues/12387
+              node.last
+            end
+          end
         end
 
         def block_param

--- a/lib/yard/rubygems/specification.rb
+++ b/lib/yard/rubygems/specification.rb
@@ -35,8 +35,16 @@ class Gem::Specification
     alias _dump_without_rdoc _dump
     alias _dump _dump_with_rdoc
 
-    @@default_value[:has_rdoc] = true if defined?(@@default_value)
-    @@attributes << 'has_rdoc' if defined?(@@attributes)
-    @@nil_attributes << 'has_rdoc' if defined?(@@nil_attributes)
+    if class_variable_defined?(:@@default_value)
+      if @@default_value.frozen?
+        t = @@default_value.dup
+        t[:has_rdoc] = true
+        @@default_value = t.freeze
+      else
+        @@default_value[:has_rdoc] = true
+      end
+    end
+    @@attributes << 'has_rdoc' if class_variable_defined?(:@@attributes)
+    @@nil_attributes << 'has_rdoc' if class_variable_defined?(:@@nil_attributes)
   end
 end


### PR DESCRIPTION
# Description

Two new failures occur with `ruby 2.5.0dev (2017-10-08 trunk 60140) [x64-mingw32]`.

The first, in `ast_node.rb`, is detailed in <https://bugs.ruby-lang.org/issues/12387>.

The second, in `specification.rb`, is due to `@@default_value` being frozen.

With these two changes, and some fixes over in ruby/ruby, trunk passes all tests locally.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
