### PR TITLE
Un-pend a spec since Kramdown::Document also supports tables

### DIFF
--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -184,7 +184,8 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
 
     it "creates tables (markdown specific)" do
       log.enter_level(Logger::FATAL) do
-        unless markup_class(:markdown).to_s == "RedcarpetCompat"
+        supports_table = %w(RedcarpetCompat Kramdown::Document)
+        unless supports_table.include?(markup_class(:markdown).to_s)
           pending "This test depends on a markdown engine that supports tables"
         end
       end


### PR DESCRIPTION
# Description

This PR changes a test not to be pending for "does Kramdown::Document support tables?"

This allows JRuby to pass that test.

JRuby version used: `jruby 9.1.14.0 (2.3.3) 2017-11-08 2176f24 Java HotSpot(TM) 64-Bit Server VM 25.111-b14 on 1.8.0_111-b14 +jit [darwin-x86_64]`

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
