### PR TITLE
Add ruby-head to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ rvm:
   - 2.2.7
   - 2.3.4
   - 2.4.1
+  - ruby-head
 # - jruby
 
 # Define how to run your tests (defaults to `bundle exec rake` or `rake` depending on whether you have a `Gemfile`)


### PR DESCRIPTION
# Description

It's important for tests because [YARD uses Ripper for parsing Ruby code](https://github.com/lsegal/yard/blob/7748eda4b96817b0b9ebd7efffbd32d510829393/lib/yard/parser/ruby/ruby_parser.rb#L27) and Ripper is sometimes updated. For your action, [RDoc is tested on ruby-head](https://github.com/ruby/rdoc/blob/eba6eb0c70d0c9a427984ae701e11e5f5340603a/.travis.yml) because [RDoc is using Ripper](https://github.com/ruby/rdoc/blob/224d4428f105193e566fe154b51f507da7c11252/lib/rdoc/parser/ripper_state_lex.rb#L26) now too.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
