### PR TITLE
Use latest Ruby versions: 2.2.8, 2.3.5 and 2.4.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,9 @@ cache: bundler
 
 # Specify which ruby versions you wish to run your tests on, each version will be used
 rvm:
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
+  - 2.2.8
+  - 2.3.5
+  - 2.4.2
   - ruby-head
 # - jruby
 


### PR DESCRIPTION
# Description

Use latest Ruby versions: 2.2.8, 2.3.5 and 2.4.2.