### PR TITLE
Deprecate safe_level of ERB.new in Ruby 2.6

### DIFF
--- a/benchmarks/erb_vs_erubis.rb
+++ b/benchmarks/erb_vs_erubis.rb
@@ -45,7 +45,7 @@ Benchmark.bmbm do |x|
   x.report("erb") do
     eval <<-eof
        module YARD; module Templates; module Template
-        def erb_with(str, x) ERB.new(str, nil) end
+        def erb_with(str, x) ERB.new(str) end
       end end end
     eof
 

--- a/benchmarks/template_erb.rb
+++ b/benchmarks/template_erb.rb
@@ -12,7 +12,7 @@ Benchmark.bm do |x|
     module Templates
       module Template
         def erb(section, &block)
-          erb = ERB.new(cache(section), nil)
+          erb = ERB.new(cache(section))
           erb.filename = cache_filename(section).to_s
           erb.result(binding, &block)
         end

--- a/lib/yard/templates/template.rb
+++ b/lib/yard/templates/template.rb
@@ -348,7 +348,11 @@ module YARD
       end
 
       def erb_with(content, filename = nil)
-        erb = ERB.new(content, nil, options.format == :text ? '<>' : nil)
+        erb = if ERB.instance_method(:initialize).parameters.assoc(:key) # Ruby 2.6+
+                ERB.new(content, :trim_mode => options.format == :text ? '<>' : nil)
+              else
+                ERB.new(content, nil, options.format == :text ? '<>' : nil)
+              end
         erb.filename = filename if filename
         erb
       end


### PR DESCRIPTION
# Description

The interface of `ERB.new` will change from Ruby 2.6.

> Add :trim_mode and :eoutvar keyword arguments to ERB.new.
> Now non-keyword arguments other than first one are softly deprecated
> and will be removed when Ruby 2.5 becomes EOL. [Feature #14256]

https://github.com/ruby/ruby/blob/2311087b685e8dc0f21f4a89875f25c22f5c39a9/NEWS#stdlib-updates-outstanding-ones-only

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
