### PR TITLE
Fix copyright year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2007-2016 Loren Segal
+Copyright (c) 2007-2018 Loren Segal
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ See {file:CHANGELOG.md} for a list of changes.
 
 ## License
 
-YARD &copy; 2007-2016 by [Loren Segal](mailto:lsegal@soen.ca). YARD is
+YARD &copy; 2007-2018 by [Loren Segal](mailto:lsegal@soen.ca). YARD is
 licensed under the MIT license except for some files which come from the
 RDoc/Ruby distributions. Please see the {file:LICENSE} and {file:LEGAL}
 documents for more information.


### PR DESCRIPTION
# Description

Copyright years are out of date, switch end years to 2018.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
