### PR TITLE
Add support for quoted symbols

### DIFF
--- a/lib/yard/handlers/ruby/constant_handler.rb
+++ b/lib/yard/handlers/ruby/constant_handler.rb
@@ -20,7 +20,11 @@ class YARD::Handlers::Ruby::ConstantHandler < YARD::Handlers::Ruby::Base
 
   def process_constant(statement)
     name = statement[0].source
-    value = statement[1].source
+    value = if statement[1].type == :dyna_symbol
+              statement[1].first.source.intern.inspect
+            else
+              statement[1].source
+            end
     obj = P(namespace, name)
     if obj.is_a?(NamespaceObject) && obj.namespace == namespace
       raise YARD::Parser::UndocumentableError, "constant for existing #{obj.type} #{obj}"

--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -285,9 +285,10 @@ module YARD
           if token == :symbeg
             @symbol = [:symbol, data, [lineno, charno]]
           elsif @symbol
-            if token == :tstring_content
+            case token
+            when :tstring_content
               @symbol[1] += data
-            elsif token == :tstring_end || token == :const
+            when :tstring_end, :const, :ident
               @symbol[1] += data
               @tokens << @symbol
               @symbol = nil

--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -282,8 +282,16 @@ module YARD
             end
           end
 
-          if @tokens.last && @tokens.last[0] == :symbeg
-            @tokens[-1] = [:symbol, ":" + data, @tokens.last[2]]
+          if token == :symbeg
+            @symbol = [:symbol, data, [lineno, charno]]
+          elsif @symbol
+            if token == :tstring_content
+              @symbol[1] += data
+            elsif token == :tstring_end || token == :const
+              @symbol[1] += data
+              @tokens << @symbol
+              @symbol = nil
+            end
           elsif @heredoc_state == :started
             @heredoc_tokens << [token, data, [lineno, charno]]
 

--- a/spec/handlers/constant_handler_spec.rb
+++ b/spec/handlers/constant_handler_spec.rb
@@ -33,6 +33,9 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}Constant
     expect(obj.constants[0].docstring).to eq 'A constant.'
     expect(obj.constants[0].name).to eq :CONSTANT
     expect(obj.constants[0].value).to eq "42"
+    expect(obj.constants[1].docstring).to eq 'Special constant (empty symbol)'
+    expect(obj.constants[1].name).to eq :EMPTY
+    expect(obj.constants[1].value).to eq ':""'
   end
 
   it "turns Const = Struct.new('Name', :sym) into class Const with attr :sym" do

--- a/spec/handlers/examples/constant_handler_001.rb.txt
+++ b/spec/handlers/examples/constant_handler_001.rb.txt
@@ -21,6 +21,8 @@ MyEmptyStruct = Struct.new
 MyStructWithConstant = Struct.new do
   # A constant.
   CONSTANT = 42
+  # Special constant (empty symbol)
+  EMPTY = :''
 end
 
 # A crazy struct.

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -307,12 +307,13 @@ eof
       tokens = tokenize(<<-eof)
         class X
           Foo = :''
+          Fuu = :bar
           Bar = :BAR
           Baz = :"B+z"
         end
       eof
       symbols = tokens.select {|t| t[0] == :symbol }.map {|t| t[1] }
-      expect(symbols).to eq %w(:'' :BAR :"B+z")
+      expect(symbols).to eq %w(:'' :bar :BAR :"B+z")
     end
 
     it "parses %w() array in constant declaration" do

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -303,6 +303,18 @@ eof
       end
     end
 
+    it "properly tokenizes symbols" do
+      tokens = tokenize(<<-eof)
+        class X
+          Foo = :''
+          Bar = :BAR
+          Baz = :"B+z"
+        end
+      eof
+      symbols = tokens.select {|t| t[0] == :symbol }.map {|t| t[1] }
+      expect(symbols).to eq %w(:'' :BAR :"B+z")
+    end
+
     it "parses %w() array in constant declaration" do
       s = stmt(<<-eof)
         class Foo

--- a/spec/templates/helpers/method_helper_spec.rb
+++ b/spec/templates/helpers/method_helper_spec.rb
@@ -79,4 +79,29 @@ RSpec.describe YARD::Templates::Helpers::MethodHelper do
       expect(format_block(Registry.at('#foo'))).to eq "{|a, b, c| ... }"
     end
   end
+
+  describe "#format_constant" do
+    include YARD::Templates::Helpers::HtmlHelper
+
+    it "displays correctly constant values which are quoted symbols" do
+      YARD.parse_string %(
+        class TestFmtConst
+          Foo = :''
+          Bar = :BAR
+          Baz = :'B+z'
+        end
+      )
+      # html_syntax_highlight will be called by format_constant for
+      # Foo, Bar and Baz and in turn will enquire for options.highlight
+      expect(self).to receive(:options).exactly(3).times.and_return(
+        Options.new.update(:highlight => false)
+      )
+      foo, bar, baz = %w(Foo Bar Baz).map do |c|
+        Registry.at("TestFmtConst::#{c}").value
+      end
+      expect(format_constant(foo)).to eq ":&quot;&quot;"
+      expect(format_constant(bar)).to eq ':BAR'
+      expect(format_constant(baz)).to eq ":&quot;B+z&quot;"
+    end
+  end
 end


### PR DESCRIPTION
# Description

Constants containing *quoted symbols* can now be documented correctly.

Prior to the fix, the value `:"sym+bol"` would be shown as `sym+bol`
and worse, the empty symbol (`:''`) would have triggered an error in
`MethodHelper#format_constant`, as the corresponding constant value 
was the empty String.

For example, this code:

```ruby
class X
  Y = :''
end
```

would trigger the following error in YARD 0.9.12:

```
[error]: NoMethodError: undefined method `[]' for nil:NilClass
[error]: Stack trace:
        .../lib/yard/templates/helpers/method_helper.rb:69:in `format_constant'
        .../templates/default/module/html/constant_summary.erb:10:in `block in _erb_cache_18'
        .../templates/default/module/html/constant_summary.erb:6:in `each'
        .../templates/default/module/html/constant_summary.erb:6:in `_erb_cache_18'
        .../lib/yard/templates/template.rb:287:in `erb'
        .../lib/yard/templates/template.rb:365:in `render_section'
```	


The `ConstantHandler` didn't treat the `:dyna_symbol` node specially, and
simply calling the source method on that statement would return the characters
making up the symbol, not the actual source code for that symbol (i.e. the prefix `:`
and the wrapping quotes).

This is fixed in commit 5b1dc8ae.

Besides, when investigating the issue, I first followed a wrong track by fixing
an error in the tokenisation code of the parser. This proved to be not
necessary to fix my original error, but I think the change will not harm
so I've left it in the PR as a separate commit (db005970).

Some more details about this other fix: in RubyParser, 
a sequence of tokens gets built, and a  `[:symbeg, :const]` pair 
gets replaced by a `:symbol` token.
However, there are actually three possibilities (maybe more?)
for constructing a Symbol:

 1. `:symbeg`, `:const`  (e.g. `:BAR`)
 2. `:symbeg`, `:tstring_content`, `:tstring_end` (e.g. `:"B+z"`)
 3. `:symbeg`, `:tstring_end` (e.g. `:''`)

So I added support for case 2. and 3. as well.


# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
