### PR TITLE
Support i18n in tag text

### DIFF
--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -594,7 +594,15 @@ module YARD
         text = I18n::Text.new(@docstring)
         localized_text = text.translate(locale)
         docstring = Docstring.new(localized_text, self)
-        docstring.add_tag(*@docstring.tags)
+        @docstring.tags.each do |tag|
+          if tag.is_a?(Tags::Tag)
+            localized_tag = tag.clone
+            localized_tag.text = I18n::Text.new(tag.text).translate(locale)
+            docstring.add_tag(localized_tag)
+          else
+            docstring.add_tag(tag)
+          end
+        end
         docstring
       end
     end

--- a/spec/code_objects/base_spec.rb
+++ b/spec/code_objects/base_spec.rb
@@ -358,6 +358,17 @@ RSpec.describe YARD::CodeObjects::Base do
         expect(o.docstring('fr')).to eq "Bonjour"
       end
 
+      it "returns localized docstring tag" do
+        o = CodeObjects::MethodObject.new(:root, 'Hello#message')
+        o.docstring.add_tag(Tags::Tag.new('return', 'Hello'))
+
+        fr_locale = YARD::I18n::Locale.new('fr')
+        allow(fr_locale).to receive(:translate).with('Hello').and_return('Bonjour')
+        allow(Registry).to receive(:locale).with('fr').and_return(fr_locale)
+
+        expect(o.docstring('fr').tags.map(&:text)).to eq ['Bonjour']
+      end
+
       it "returns updated localized docstring" do
         fr_locale = YARD::I18n::Locale.new('fr')
         allow(Registry).to receive(:locale).with('fr').and_return(fr_locale)


### PR DESCRIPTION
# Description

`yard --locale ja` doesn't translate tag text such as `Hello` in `@return Hello`. Class/method descriptions are translated.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
