### PR TITLE
Add a smoke test (running yard on yard's own source)

### DIFF
--- a/spec/cli/yard_on_yard_spec.rb
+++ b/spec/cli/yard_on_yard_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+$TOPDIR = File.expand_path(File.join(File.dirname(__FILE__), '../..'))
+
+require 'fileutils'
+
+RSpec.describe YARD::CLI::Yardoc do
+  include FileUtils
+
+  context 'building the documentation of YARD itself' do
+    before(:context) do
+      rm_rf File.join($TOPDIR, 'doc')
+      rm_rf File.join($TOPDIR, '.yardoc')
+
+      # Note: as this is very time consuming, we do it only once
+      Dir.chdir($TOPDIR) do
+        @res = YARD::CLI::Yardoc.new.run('--title', 'YARD-On-YARD')
+      end
+    end
+
+    it 'succeeds and creates doc/ and .yardoc/' do
+      expect(@res).to be true
+      expect(Dir.exist?('doc')).to be true
+      expect(Dir.exist?('.yardoc')).to be true
+    end
+
+    it 'writes the given title in each documentation file' do
+      Dir.glob(File.join($TOPDIR, 'doc/**/*.html')) do |htmlfile|
+        next if %w(
+          frames file_list class_list method_list tag_list _index
+        ).include?(File.basename(htmlfile, '.html'))
+        html = File.read(htmlfile)
+
+        expect(html.index('&mdash; YARD-On-YARD')).to be >= 0
+      end
+    end
+  end
+end

--- a/spec/cli/yard_on_yard_spec.rb
+++ b/spec/cli/yard_on_yard_spec.rb
@@ -35,4 +35,4 @@ RSpec.describe YARD::CLI::Yardoc do
       end
     end
   end
-end
+end if ENV['CI'] || ENV['YY']

--- a/spec/parser/ruby/legacy/token_list_spec.rb
+++ b/spec/parser/ruby/legacy/token_list_spec.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# Note: including YARD::Parser::Ruby::Legacy at top-level is problematic
-#       for other tests (e.g cli/yard_on_yard_spec.rb)
-
 RSpec.describe YARD::Parser::Ruby::Legacy::TokenList do
   Legacy = YARD::Parser::Ruby::Legacy
   TokenList = Legacy::TokenList

--- a/spec/parser/ruby/legacy/token_list_spec.rb
+++ b/spec/parser/ruby/legacy/token_list_spec.rb
@@ -1,9 +1,13 @@
 # frozen_string_literal: true
 
-include YARD::Parser::Ruby::Legacy
-include YARD::Parser::Ruby::Legacy::RubyToken
+# Note: including YARD::Parser::Ruby::Legacy at top-level is problematic
+#       for other tests (e.g cli/yard_on_yard_spec.rb)
 
 RSpec.describe YARD::Parser::Ruby::Legacy::TokenList do
+  Legacy = YARD::Parser::Ruby::Legacy
+  TokenList = Legacy::TokenList
+  LT = Legacy::RubyToken
+
   describe "#initialize / #push" do
     it "accepts a tokenlist (via constructor or push)" do
       expect { TokenList.new(TokenList.new) }.not_to raise_error
@@ -11,8 +15,9 @@ RSpec.describe YARD::Parser::Ruby::Legacy::TokenList do
     end
 
     it "accept a token (via constructor or push)" do
-      expect { TokenList.new(Token.new(0, 0)) }.not_to raise_error
-      expect(TokenList.new.push(Token.new(0, 0), Token.new(1, 1)).size).to eq 2
+      expect { TokenList.new(LT::Token.new(0, 0)) }.not_to raise_error
+      expect(TokenList.new.push(LT::Token.new(0, 0),
+                                LT::Token.new(1, 1)).size).to eq 2
     end
 
     it "accepts a string and parse it as code (via constructor or push)" do
@@ -30,15 +35,15 @@ RSpec.describe YARD::Parser::Ruby::Legacy::TokenList do
     it "does not interpolate string data" do
       x = TokenList.new('x = "hello #{world}"')
       expect(x.size).to eq 6
-      expect(x[4].class).to eq TkDSTRING
+      expect(x[4].class).to eq LT::TkDSTRING
       expect(x.to_s).to eq 'x = "hello #{world}"' + "\n"
     end
 
     it "handles label syntax" do
       x = TokenList.new('a:1,b:2')
-      expect(x[0].class).to eq TkLABEL
+      expect(x[0].class).to eq LT::TkLABEL
       expect(x[0].text).to eq 'a:'
-      expect(x[3].class).to eq TkLABEL
+      expect(x[3].class).to eq LT::TkLABEL
       expect(x[3].text).to eq 'b:'
     end
   end
@@ -46,13 +51,13 @@ RSpec.describe YARD::Parser::Ruby::Legacy::TokenList do
   describe "#to_s" do
     before do
       @t = TokenList.new
-      @t << TkDEF.new(1, 1, "def")
-      @t << TkSPACE.new(1, 1)
-      @t << TkIDENTIFIER.new(1, 1, "x")
-      @t << TkStatementEnd.new(1, 1)
-      @t << TkSEMICOLON.new(1, 1) << TkSPACE.new(1, 1)
-      @t << TkBlockContents.new(1, 1)
-      @t << TkSPACE.new(1, 1) << TkEND.new(1, 1, "end")
+      @t << LT::TkDEF.new(1, 1, "def")
+      @t << LT::TkSPACE.new(1, 1)
+      @t << LT::TkIDENTIFIER.new(1, 1, "x")
+      @t << LT::TkStatementEnd.new(1, 1)
+      @t << LT::TkSEMICOLON.new(1, 1) << LT::TkSPACE.new(1, 1)
+      @t << LT::TkBlockContents.new(1, 1)
+      @t << LT::TkSPACE.new(1, 1) << LT::TkEND.new(1, 1, "end")
       @t[0].set_text "def"
       @t[1].set_text " "
       @t[2].set_text "x"


### PR DESCRIPTION
# Description

Being able to run yard on a real-life project can be a nice complement to the more focused unit-tests.
Though coarse grained, it might uncover unanticipated side-effects of code changes that would otherwise be left undetected by the test suite or by running yard on smaller projects.

Therefore, exercising yard on yard itself should prove useful.

The only downside is a longer running time for the test suite (e.g. ~32s instead of just 6s before).

#### Note about the preliminary changeset

The smoke test was working fine when run in isolation, but failed in a weird way when run as part of the whole suite:

<details><summary>backtrace</summary>

```
  1) YARD::CLI::Yardoc building the documentation of YARD itself succeeds and creates doc/ and .yardoc/
     Failure/Error: html = @@markup.convert(@text, @@formatter)

     NameError:
       uninitialized constant RDoc::RubyToken::AlreadyDefinedToken
     # ./lib/yard/templates/helpers/markup/rdoc_markup.rb:53:in `block in to_html'
     # ./lib/yard/templates/helpers/markup/rdoc_markup.rb:51:in `synchronize'
     # ./lib/yard/templates/helpers/markup/rdoc_markup.rb:51:in `to_html'
     # ./lib/yard/templates/helpers/html_helper.rb:85:in `html_markup_markdown'
     # ./lib/yard/templates/helpers/html_helper.rb:59:in `htmlify'
     # ./templates/default/layout/html/setup.rb:67:in `diskfile'
     # ./lib/yard/templates/template.rb:367:in `render_section'
     # ./lib/yard/templates/template.rb:259:in `block (2 levels) in run'
     # ./lib/yard/templates/template.rb:256:in `each'
     # ./lib/yard/templates/template.rb:256:in `block in run'
     # ./lib/yard/templates/template.rb:398:in `add_options'
     # ./lib/yard/templates/template.rb:255:in `run'
     # ./lib/yard/templates/template.rb:277:in `block in yieldall'
     # ./lib/yard/templates/template.rb:412:in `with_section'
     # ./lib/yard/templates/template.rb:277:in `yieldall'
     # ./templates/default/layout/html/layout.erb:21:in `_erb_cache_6'
     # ./lib/yard/templates/template.rb:287:in `erb'
     # ./templates/default/layout/html/setup.rb:62:in `layout'
     # ./lib/yard/templates/template.rb:367:in `render_section'
     # ./lib/yard/templates/template.rb:259:in `block (2 levels) in run'
     # ./lib/yard/templates/template.rb:256:in `each'
     # ./lib/yard/templates/template.rb:256:in `block in run'
     # ./lib/yard/templates/template.rb:398:in `add_options'
     # ./lib/yard/templates/template.rb:255:in `run'
     # ./lib/yard/templates/template.rb:136:in `run'
     # ./templates/default/fulldoc/html/setup.rb:52:in `block in serialize_index'
     # ./lib/yard/templates/engine.rb:123:in `block in with_serializer'
     # ./lib/yard/logging.rb:82:in `capture'
     # ./lib/yard/templates/engine.rb:121:in `with_serializer'
     # ./templates/default/fulldoc/html/setup.rb:51:in `serialize_index'
     # ./templates/default/fulldoc/html/setup.rb:68:in `serialize_file'
     # ./templates/default/fulldoc/html/setup.rb:11:in `block in init'
     # ./templates/default/fulldoc/html/setup.rb:10:in `each'
     # ./templates/default/fulldoc/html/setup.rb:10:in `each_with_index'
     # ./templates/default/fulldoc/html/setup.rb:10:in `init'
     # ./lib/yard/templates/template.rb:193:in `initialize'
     # ./lib/yard/templates/template.rb:131:in `new'
     # ./lib/yard/templates/template.rb:136:in `run'
     # ./lib/yard/templates/engine.rb:105:in `generate'
     # ./lib/yard/cli/yardoc.rb:355:in `run_generate'
     # ./lib/yard/cli/yardoc.rb:267:in `run'
     # ./spec/cli/yard_on_yard_spec.rb:19:in `block (4 levels) in <top (required)>'
     # ./spec/cli/yard_on_yard_spec.rb:18:in `chdir'
     # ./spec/cli/yard_on_yard_spec.rb:18:in `block (3 levels) in <top (required)>'
     # ------------------
     # --- Caused by: ---
     # NameError:
     #   uninitialized constant RDoc::RubyToken::AlreadyDefinedToken
     #   ./lib/yard/templates/helpers/markup/rdoc_markup.rb:53:in `block in to_html'
```
</details>
<br/>

I didn't fully understand what was going on here, but I was able to pin point the other test file that when included was triggering the above. This was spec/parser/ruby/legacy/token_list_spec.rb and in particular its two toplevel include statements:
```ruby
include YARD::Parser::Ruby::Legacy
include YARD::Parser::Ruby::Legacy::RubyToken
```

One can easily reproduce that error by copying these 2 lines at the top of the new spec/cli/yard_on_yard_spec.rb test. Well, the `RubyToken` one is enough actually. By avoiding these includes, the whole test suite would now pass.

I also tried alternatives solutions to 2ab0eea, like moving these includes inside the describe block, but nothing really worked and I didn't understand why either, as usually that would work, cf. the `include FileUtils` in b4c0de2.

So if you can shed any light on this, that would be welcome, and I might then be able to find a better fix than 2ab0eea.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
