### PR TITLE
Change some type annotation in YARD doc

### DIFF
--- a/lib/yard/cli/server.rb
+++ b/lib/yard/cli/server.rb
@@ -13,7 +13,7 @@ module YARD
       # @return [Hash] a list of library names and yardoc files to serve
       attr_accessor :libraries
 
-      # @return [Adapter] the adapter to use for loading the web server
+      # @return [YARD::Server::Adapter] the adapter to use for loading the web server
       attr_accessor :adapter
 
       # @return [Array<String>] a list of scripts to load

--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -67,7 +67,7 @@ module YARD
     # when creating the new docstring object.
     #
     # @param [String] text the textual portion of the docstring
-    # @param [Array<Tag>] tags the list of tag objects in the docstring
+    # @param [Array<Tags::Tag>] tags the list of tag objects in the docstring
     # @param [CodeObjects::Base, nil] object the object associated with the
     #   docstring. May be nil.
     # @param [String] raw_data the complete docstring, including all

--- a/lib/yard/docstring_parser.rb
+++ b/lib/yard/docstring_parser.rb
@@ -35,11 +35,11 @@ module YARD
     # @return [String] the complete input string to the parser.
     attr_accessor :raw_text
 
-    # @return [Array<Tag>] the list of meta-data tags identified
+    # @return [Array<Tags::Tag>] the list of meta-data tags identified
     #   by the parser
     attr_accessor :tags
 
-    # @return [Array<Directive>] a list of directives identified
+    # @return [Array<Tags::Directive>] a list of directives identified
     #   by the parser. This list will not be passed on to the
     #   Docstring object.
     attr_accessor :directives
@@ -228,7 +228,7 @@ module YARD
     end
 
     # Creates a new directive using the registered {#library}
-    # @return [Directive] the directive object that is created
+    # @return [Tags::Directive] the directive object that is created
     def create_directive(tag_name, tag_buf)
       if library.has_directive?(tag_name)
         dir = library.directive_create(tag_name, tag_buf, self)

--- a/lib/yard/handlers/base.rb
+++ b/lib/yard/handlers/base.rb
@@ -181,7 +181,7 @@ module YARD
         # the handlers, otherwise the same code will be parsed
         # multiple times and slow YARD down.
         #
-        # @param [Parser::RubyToken, Symbol, String, Regexp] matches
+        # @param [Parser::Ruby::Legacy::RubyToken, Symbol, String, Regexp] matches
         #   statements that match the declaration will be
         #   processed by this handler. A {String} match is
         #   equivalent to a +/\Astring/+ regular expression

--- a/lib/yard/handlers/processor.rb
+++ b/lib/yard/handlers/processor.rb
@@ -88,7 +88,7 @@ module YARD
       attr_accessor :extra_state
 
       # Creates a new Processor for a +file+.
-      # @param [SourceParser] parser the parser used to initialize the processor
+      # @param [Parser::SourceParser] parser the parser used to initialize the processor
       def initialize(parser)
         @file = parser.file || "(stdin)"
         @namespace = YARD::Registry.root

--- a/lib/yard/server/commands/base.rb
+++ b/lib/yard/server/commands/base.rb
@@ -45,7 +45,7 @@ module YARD
 
         # @group Attributes Set Per Request
 
-        # @return [Request] request object
+        # @return [Rack::Request] request object
         attr_accessor :request
 
         # @return [String] the path after the command base URI


### PR DESCRIPTION
# Description

Some of the type annotations in the documentation referrenced types that
were not in scope for the annotation. This means that a compiler
generating the doc could incorrectly associate the constants with
another type which would be in scope.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* ~~[ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).~~ (no code)

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
