### PR TITLE
Fix annotation in CodeObjects::Base#files

### DIFF
--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -132,7 +132,7 @@ module YARD
     # @see NamespaceMapper.register_separator
     class Base
       # The files the object was defined in. To add a file, use {#add_file}.
-      # @return [Array<String>] a list of files
+      # @return [Array<Array<String, Integer>>] a list of files
       # @see #add_file
       attr_reader :files
 

--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -132,7 +132,7 @@ module YARD
     # @see NamespaceMapper.register_separator
     class Base
       # The files the object was defined in. To add a file, use {#add_file}.
-      # @return [Array<Array<String, Integer>>] a list of files
+      # @return [Array<Array(String, Integer)>] a list of files
       # @see #add_file
       attr_reader :files
 


### PR DESCRIPTION
The original annotation incorrectly was Array<String> but the format is

```
[ [file, line] ]
```

Therefore the annotation should be `Array<Array<String, Integer>>`,
given there is no prescribed way to describe tuples

# Description

Describe your pull request and problem statement here.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
