### PR TITLE
Stable sort tags in Docstring#to_raw.

### DIFF
--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -205,7 +205,7 @@ module YARD
     # @since 0.7.0
     # @todo Add Tags::Tag#to_raw and refactor
     def to_raw
-      tag_data = tags.sort_by(&:tag_name).map do |tag|
+      tag_data = tags.map do |tag|
         case tag
         when Tags::OverloadTag
           tag_text = "@#{tag.tag_name} #{tag.signature}\n"
@@ -271,7 +271,7 @@ module YARD
     # @param [#to_s] name the tag name to return data for, or nil for all tags
     # @return [Array<Tags::Tag>] the list of tags by the specified tag name
     def tags(name = nil)
-      list = @tags + convert_ref_tags
+      list = stable_sort_by(@tags + convert_ref_tags, &:tag_name)
       return list unless name
       list.select {|tag| tag.tag_name.to_s == name.to_s }
     end
@@ -373,6 +373,14 @@ module YARD
       @unresolved_reference = parser.reference
       add_tag(*parser.tags)
       parser.text
+    end
+
+    # A stable sort_by method.
+    #
+    # @param [Enumerable]
+    # @return [Array]
+    def stable_sort_by(list)
+      list.each_with_index.sort_by {|tag, i| [yield(tag), i] }.map(&:first)
     end
   end
 end

--- a/spec/docstring_spec.rb
+++ b/spec/docstring_spec.rb
@@ -296,6 +296,15 @@ RSpec.describe YARD::Docstring do
       expect(doc.to_raw).to eq doc.all
     end
 
+    it "is stable sorting tags" do
+      expected = Docstring.new("123\n@param x\n@param y\n@version A")
+      doc = Docstring.new("123")
+      doc.add_tag(Tags::Tag.new('version', 'A'))
+      doc.add_tag(Tags::Tag.new('param', 'x'))
+      doc.add_tag(Tags::Tag.new('param', 'y'))
+      expect(doc.to_raw).to eq expected.all
+    end
+
     # @bug gh-563
     it "handles full @option tags" do
       doc = Docstring.new("@option foo [String] bar (nil) baz")


### PR DESCRIPTION
# Description

My team is maintaining a large Ruby API for our application. It's all written in C/C++. To aid developers we have been generating Ruby stubs of the API which IDEs can use to provide code insight and auto-complete. For that we've used YARD, via a custom template.

But we have had some issues where the `@param` tags got reordered.

I found the culprit in `Docstring.to_raw`. More specifically `tags.sort_by(&:tag_name)`. Because Ruby's sorting methods aren't stable (https://stackoverflow.com/questions/15442298/is-sort-in-ruby-stable) tags of the same type might end up being re-ordered.

(I was using `Docstring.to_raw` because in the process of generating Ruby stubs from the C++ source I had to make some smaller changes for them to work better.)

This change makes the sorting of tags in `Docstring#to_raw` stable.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
