### PR TITLE
Fix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,10 @@ before_install:
 
 # Specify which ruby versions you wish to run your tests on, each version will be used
 rvm:
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - "2.2"
+  - "2.3"
+  - "2.4"
+  - "2.5"
 # - ruby-head
 # - jruby
 

--- a/Rakefile
+++ b/Rakefile
@@ -41,7 +41,12 @@ task :rubocop do
   sh "rubocop"
 end
 
-task :default => [:rubocop, :spec]
+desc "Generate documentation for Yard, and fail if there are any warnings"
+task :test_doc do
+  sh "bin/yard --fail-on-warning #{"--no-progress" if ENV["CI"]}"
+end
+
+task :default => [:rubocop, :spec, :test_doc]
 
 YARD::Rake::YardocTask.new do |t|
   t.options += ['--title', "YARD #{YARD::VERSION} Documentation"]

--- a/Rakefile
+++ b/Rakefile
@@ -36,6 +36,7 @@ rescue LoadError
   nil # noop
 end
 
+desc "Check code style with Rubocop"
 task :rubocop do
   sh "rubocop"
 end

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -184,9 +184,22 @@ RSpec.describe YARD::CLI::Yardoc do
       @yardoc.run(arg)
     end
 
+    # This example relies on processing Yard's own documentation, and with
+    # --fail-on-warning option on, will raise a SystemExit error if building
+    # that documentation produces any one warning.
+    #
+    # Unless handled, it will cause immediate and abnormal process exit,
+    # without running remaining tests, and with non-successful exit status.
+    #
+    # While suppressing exceptions is generally a bad practice and against this
+    # project's style guide, here it is well advocated,
+    # hence Lint/HandleExceptions cop is disabled.
     should_accept('--fail-on-warning') do |arg|
       expect(YARD).to receive(:parse)
-      @yardoc.run(arg)
+      begin
+        @yardoc.run(arg)
+      rescue SystemExit # rubocop:disable Lint/HandleExceptions
+      end
     end
   end
 


### PR DESCRIPTION
# Problem description

Currently, CI builds are failing after running ca. 10% of total number of examples. This happens due to a subtle bug in Yard's documentation introduced in 5deb08c329c0609429c2b8670ff139eb7a446635 (#1185).

Many RSpec examples rely on processing Yard's own documentation. Among them, following one: https://github.com/lsegal/yard/blob/75ca29898d2f6a9b1425125e6db4e42a2f3c2c4b/spec/cli/yardoc_spec.rb#L187-L190 The problem is that running Yard with `--fail-on-warning` option may cause abnormal exit in case of warnings. And this is actually happening, because `@param` tag should be followed by description:
https://github.com/lsegal/yard/blob/5deb08c329c0609429c2b8670ff139eb7a446635/lib/yard/docstring.rb#L380

# Changes

The aforementioned RSpec example has been surrounded with begin-rescue-end block, so it no longer breaks builds in situations like this. Apart from that, a new Rake task `test_doc` has been implemented, which tests Yard's own documentation, and ensures that no warnings are generated. Finally, this Rake test has been included in Rake's default task, so documentation well-formedness is now tested in CI.

The build will fail, but this is expected. Bug introduced in #1185 hasn't been fixed (and I'm not going to fix it because people who know this project well will do it better, probably). Nevertheless, all tests are run now, and the build output is meaningful. Also, Rubies that Travis tests against have been updated.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
