### PR TITLE
Fix test example

### DIFF
--- a/spec/code_objects/extra_file_object_spec.rb
+++ b/spec/code_objects/extra_file_object_spec.rb
@@ -103,10 +103,11 @@ RSpec.describe YARD::CodeObjects::ExtraFileObject do
     it "attempts to re-parse data as 8-bit ascii if parsing fails" do
       expect(log).not_to receive(:warn)
       str, out = *([String.new("\xB0")] * 2)
-      if str.respond_to?(:force_encoding)
-        str.force_encoding('utf-8')
-        out.force_encoding('binary')
+      if str.respond_to?(:force_encoding!)
+        str.force_encoding!('utf-8')
+        out.force_encoding!('binary')
       end
+      expect(str.valid_encoding?).to be(false)
       file = ExtraFileObject.new('file.txt', str)
       expect(file.contents).to eq out
     end


### PR DESCRIPTION
# Description

A test example has been introduced in 523256605c04376a9961a347, which is expected to cover situation when processed document includes some byte sequence which is invalid in given encoding.  However, due to a subtle bug, the tested string was not satisfying this requirement, and thus example setup was incorrect.

This commit changes string encoding to UTF-8, in which it has invalid sequence of bytes, which is expected.  Also, yet another assertion is added in order to prevent this bug from being re-introduced.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).
