### PR TITLE
Fix rescue clause

### DIFF
--- a/lib/yard/code_objects/extra_file_object.rb
+++ b/lib/yard/code_objects/extra_file_object.rb
@@ -113,14 +113,17 @@ module YARD::CodeObjects
       end
       contents
     rescue ArgumentError => e
-      if retried && e.message =~ /invalid byte sequence/
+      raise unless e.message =~ /invalid byte sequence/
+
+      if retried
         # This should never happen.
         log.warn "Could not read #{filename}, #{e.message}. You probably want to set `--charset`."
         return ''
+      else
+        data.force_encoding('binary') if data.respond_to?(:force_encoding)
+        retried = true
+        retry
       end
-      data.force_encoding('binary') if data.respond_to?(:force_encoding)
-      retried = true
-      retry
     end
 
     def translate(data)


### PR DESCRIPTION
# Description

In case of `ArgumentError` unrelated to encoding, it used to enter an infinite loop.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [?] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR). — it is really a border case which would affect contributors rather than users. More serious things are untested. Nevertheless, I can write some, if needed.

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
