### PR TITLE
Markup agnostic extra files

### DIFF
--- a/lib/yard/code_objects/extra_file_object.rb
+++ b/lib/yard/code_objects/extra_file_object.rb
@@ -80,7 +80,8 @@ module YARD::CodeObjects
     # @param [String] data the file contents
     def parse_contents(data)
       retried = false
-      cut_index = 0
+      cut_index_begin = 0
+      cut_index_end = 0
       data = translate(data)
       data = data.split("\n")
       data.each_with_index do |line, index|
@@ -89,19 +90,21 @@ module YARD::CodeObjects
           if index == 0
             attributes[:markup] = $1
           else
-            cut_index = index
+            cut_index_end = index
             break
           end
         when /^\s*#\s*@(\S+)\s*(.+?)\s*$/
           attributes[$1] = $2
-        when /^\s*<!--\s*$/, /^\s*-->\s*$/
-          # Ignore HTML comments
         else
-          cut_index = index
-          break
+          if index == 0
+            cut_index_begin = 1
+          else
+            cut_index_end = index
+            break
+          end
         end
       end
-      data = data[cut_index..-1] if cut_index > 0
+      data[cut_index_begin...cut_index_end] = [] if cut_index_end > cut_index_begin
       contents = data.join("\n")
 
       if contents.respond_to?(:force_encoding) && attributes[:encoding]

--- a/spec/code_objects/extra_file_object_spec.rb
+++ b/spec/code_objects/extra_file_object_spec.rb
@@ -38,13 +38,25 @@ RSpec.describe YARD::CodeObjects::ExtraFileObject do
     it "allows the attributes section to be wrapped in an HTML comment" do
       file = ExtraFileObject.new('file.txt', "<!--\n# @title X\n-->\nFOO BAR")
       expect(file.attributes[:title]).to eq "X"
-      expect(file.contents).to eq "FOO BAR"
+      expect(file.contents).to eq "<!--\n-->\nFOO BAR"
     end
 
     it "allows whitespace around ignored HTML comment" do
       file = ExtraFileObject.new('file.txt', " \t <!-- \n# @title X\n \t --> \nFOO BAR")
       expect(file.attributes[:title]).to eq "X"
-      expect(file.contents).to eq "FOO BAR"
+      expect(file.contents).to eq " \t <!-- \n \t --> \nFOO BAR"
+    end
+
+    it "allows the attributes section to be wrapped in an AsciiDoc comment" do
+      file = ExtraFileObject.new('file.txt', "````\n# @title X\n````\nFOO BAR")
+      expect(file.attributes[:title]).to eq "X"
+      expect(file.contents).to eq "````\n````\nFOO BAR"
+    end
+
+    it "allows the attributes section to be wrapped in a Textile comment" do
+      file = ExtraFileObject.new('file.txt', "###.\n# @title X\n\nFOO BAR")
+      expect(file.attributes[:title]).to eq "X"
+      expect(file.contents).to eq "###.\n\nFOO BAR"
     end
 
     it "parses out old-style #!markup shebang format" do

--- a/spec/code_objects/extra_file_object_spec.rb
+++ b/spec/code_objects/extra_file_object_spec.rb
@@ -70,10 +70,10 @@ RSpec.describe YARD::CodeObjects::ExtraFileObject do
       expect(file.contents).to eq " #!foobar\nHello"
     end
 
-    it "does not parse out attributes if there are newlines prior to attributes" do
-      file = ExtraFileObject.new('file.txt', "\n# @title\nFOO BAR")
+    it "does not parse out attributes if there are at least two newlines prior to attributes" do
+      file = ExtraFileObject.new('file.txt', "\n\n# @title\nFOO BAR")
       expect(file.attributes).to be_empty
-      expect(file.contents).to eq "\n# @title\nFOO BAR"
+      expect(file.contents).to eq "\n\n# @title\nFOO BAR"
     end
 
     it "sets contents to data after attributes" do


### PR DESCRIPTION
# Description

Rewrite how comments are handled in textual files (extra objects).  Prefer markup-agnosticism over sticking to HTML comments.  Do not remove comment tags, as they are bound to specific markup, and hidden from user's eye anyway. As an effect, more types of comments are now supported, including ones from AsciiDoc and Textile. Fixes #1192.

This is a somewhat breaking change (see).

# Possible improvements

If required, I can restore previous behaviour changed in dc5788a, making this change a non-breaking one. Well, at least in terms of how it was formally specified in specs.

It's just a matter of adding following lines to the altered `case` construct:

```ruby
when /^\s*$/
  cut_index_end = index
  break
```

# See also

- discussion in [Yard's mailing list](https://groups.google.com/forum/#!topic/yardoc/Y700TGceoII)

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
