### PR TITLE
Ignore all magic comments at the start of file

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -532,6 +532,8 @@ module YARD
             elsif comment =~ SourceParser::FROZEN_STRING_LINE
               @frozen_string_line = comment
               not_comment = true
+            elsif comment =~ SourceParser::MAGIC_COMMENT
+              not_comment = true
             end
           end
 

--- a/lib/yard/parser/source_parser.rb
+++ b/lib/yard/parser/source_parser.rb
@@ -65,6 +65,7 @@ module YARD
       SHEBANG_LINE  = /\A\s*#!\S+/
       ENCODING_LINE = %r{\A(?:\s*#*!.*\r?\n)?\s*(?:#+|/\*+|//+).*coding\s*[:=]{1,2}\s*([a-z\d_\-]+)}i
       FROZEN_STRING_LINE = /frozen(-|_)string(-|_)literal: true/i
+      MAGIC_COMMENT = /[\w\-_]+\s*\:.*/
 
       # The default glob of files to be parsed.
       # @since 0.9.0

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -501,6 +501,43 @@ eof
       expect(Registry.at(:Bar).docstring).to eq "this is a comment"
     end
 
+    it "removes all magic comments at the start of the buffer" do
+      YARD.parse_string(<<~RUBY)
+        # frozen_string_literal: true
+        # frozen_string_literal : true
+        # encoding: UTF-8
+        # warn_indent: true
+        # also_magic: true
+        # More-magic: true
+        # this is a comment
+        class Foo; end
+      RUBY
+
+      expect(Registry.at(:Foo).docstring).to eq "this is a comment"
+    end
+
+    it "does not remove any magic comment past the beginning of the buffer" do
+      YARD.parse_string(<<~RUBY)
+        1
+        # frozen_string_literal: true
+        # encoding: UTF-8
+        # warn_indent: true
+        # also_magic: true
+        # More-magic: true
+        # this is a comment
+        class Foo; end
+      RUBY
+
+      expect(Registry.at(:Foo).docstring).to eq(<<~COMMENT.chomp)
+        frozen_string_literal: true
+        encoding: UTF-8
+        warn_indent: true
+        also_magic: true
+        More-magic: true
+        this is a comment
+      COMMENT
+    end
+
     it "handles compile errors" do
       expect { stmt(":~$ Do not clobber") }.to raise_error(Parser::ParserSyntaxError)
     end

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -502,7 +502,7 @@ eof
     end
 
     it "removes all magic comments at the start of the buffer" do
-      YARD.parse_string(<<~RUBY)
+      YARD.parse_string(<<-RUBY)
         # frozen_string_literal: true
         # frozen_string_literal : true
         # encoding: UTF-8
@@ -517,7 +517,7 @@ eof
     end
 
     it "does not remove any magic comment past the beginning of the buffer" do
-      YARD.parse_string(<<~RUBY)
+      YARD.parse_string(<<-RUBY)
         1
         # frozen_string_literal: true
         # encoding: UTF-8
@@ -528,7 +528,7 @@ eof
         class Foo; end
       RUBY
 
-      expect(Registry.at(:Foo).docstring).to eq(<<~COMMENT.chomp)
+      expect(Registry.at(:Foo).docstring).to eq(<<-COMMENT.each_line.map(&:strip).join("\n"))
         frozen_string_literal: true
         encoding: UTF-8
         warn_indent: true


### PR DESCRIPTION
# Description

YARD previously recognized three magic comments:
- shebang
- `encoding`
- `frozen_string_literal`

Standard Ruby also comes with another magic comment: `warn_ident`.

The use of magic comments is not limited to what comes built-in with
Ruby, however; some tooling uses magic comments as configuration.

It is desirable for YARD to ignore all magic comments at the beginning
of the file, in order to not clobber module documentation with magic
comments.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
