### PR TITLE
Add "svg" as a extension of image filenames

### DIFF
--- a/lib/yard/server/commands/display_file_command.rb
+++ b/lib/yard/server/commands/display_file_command.rb
@@ -11,7 +11,7 @@ module YARD
         def run
           filename = File.cleanpath(File.join(library.source_path, path))
           raise NotFoundError unless File.file?(filename)
-          if filename =~ /\.(jpe?g|gif|png|bmp)$/i
+          if filename =~ /\.(jpe?g|gif|png|bmp|svg)$/i
             headers['Content-Type'] = StaticFileCommand::DefaultMimeTypes[$1.downcase] || 'text/html'
             render File.read_binary(filename)
           else


### PR DESCRIPTION
# Description

SVG images are recognized by modern browsers and shouldn't be displayed as text but as image. SVG is also a very useful format for documentation purposes.
The project I use Yard and SVG for is [Eventbox](https://github.com/larskanis/eventbox).

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
