### PR TITLE
Fix unknown param warning with inline method modifier

### DIFF
--- a/lib/yard/handlers/ruby/dsl_handler_methods.rb
+++ b/lib/yard/handlers/ruby/dsl_handler_methods.rb
@@ -7,8 +7,9 @@ module YARD
         include Parser
 
         IGNORE_METHODS = Hash[*%w(alias alias_method autoload attr attr_accessor
-          attr_reader attr_writer extend include public private protected
-          private_constant).map {|n| [n, true] }.flatten]
+          attr_reader attr_writer extend include module_function public private
+          protected private_constant private_class_method public_class_method).
+          map {|n| [n, true] }.flatten]
 
         def handle_comments
           return if IGNORE_METHODS[caller_method]

--- a/spec/docstring_parser_spec.rb
+++ b/spec/docstring_parser_spec.rb
@@ -241,6 +241,24 @@ eof
         alias bar foo
       eof
     end
+
+    it "does not warn on matching param with inline method modifier" do
+      expect(log).to_not receive(:warn)
+      YARD.parse_string <<-eof
+        # @param [Numeric] a
+        # @return [Numeric]
+        private_class_method def self.foo(a); a + 1; end
+      eof
+    end
+
+    it "warns on mismatching param with inline method modifier" do
+      expect(log).to receive(:warn).with(/@param tag has unknown parameter name: notaparam/)
+      YARD.parse_string <<-eof
+        # @param [Numeric] notaparam
+        # @return [Numeric]
+        private_class_method def self.foo(a); a + 1; end
+      eof
+    end
   end
 
   describe "after_parse (see)" do


### PR DESCRIPTION
# Description

Adds remaining core inline method modifiers (`module_function`, `private_class_method`, `public_class_method`) to `YARD::Handlers::Ruby::DSLHandlerMethods::IGNORE_METHODS`.

This resolves an issue where "unknown parameter" warnings are emitted when using the previously omitted inline method modifiers, as described in https://github.com/lsegal/yard/issues/1162. 

(This PR does not attempt full support of inline method modifiers, but merely to avoid the spurious warning messages.)

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
