### PR TITLE
Generate documentation for File singleton methods

### DIFF
--- a/lib/yard/handlers/c/method_handler.rb
+++ b/lib/yard/handlers/c/method_handler.rb
@@ -15,8 +15,13 @@ class YARD::Handlers::C::MethodHandler < YARD::Handlers::C::Base
                 \s*"([^"]+)",
                 \s*(?:RUBY_METHOD_FUNC\(|VALUEFUNC\(|\(\w+\))?(\w+)\)?,
                 \s*(-?\w+)\s*\)/xm
+  MATCH3 = /define_filetest_function\s*\(
+                \s*"([^"]+)",
+                \s*(?:RUBY_METHOD_FUNC\(|VALUEFUNC\(|\(\w+\))?(\w+)\)?,
+                \s*(-?\w+)\s*\)/xm
   handles MATCH1
   handles MATCH2
+  handles MATCH3
   statement_class BodyStatement
 
   process do
@@ -31,6 +36,10 @@ class YARD::Handlers::C::MethodHandler < YARD::Handlers::C::Base
 
     statement.source.scan(MATCH2) do |name, func_name, _param_count|
       handle_method("method", "rb_mKernel", name, func_name)
+    end
+
+    statement.source.scan(MATCH3) do |name, func_name, _param_count|
+      handle_method("singleton_method", "rb_cFile", name, func_name)
     end
   end
 end

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -178,6 +178,19 @@ RSpec.describe YARD::Parser::C::CParser do
         expect(Registry.at('Foo#func').docstring).to eq "docstring"
       end
     end
+
+    describe "File singleton methods" do
+      before(:all) do
+        file = File.join(File.dirname(__FILE__), 'examples', 'file.c.txt')
+        parse(File.read(file))
+      end
+  
+      it "parses methods from define_filetest_function" do
+        obj = YARD::Registry.at('File.exist?')
+        expect(obj).not_to be nil
+        expect(obj.docstring).not_to be_blank
+      end
+    end  
   end
 
   describe "Override comments" do

--- a/spec/parser/c_parser_spec.rb
+++ b/spec/parser/c_parser_spec.rb
@@ -184,13 +184,13 @@ RSpec.describe YARD::Parser::C::CParser do
         file = File.join(File.dirname(__FILE__), 'examples', 'file.c.txt')
         parse(File.read(file))
       end
-  
+
       it "parses methods from define_filetest_function" do
         obj = YARD::Registry.at('File.exist?')
         expect(obj).not_to be nil
         expect(obj.docstring).not_to be_blank
       end
-    end  
+    end
   end
 
   describe "Override comments" do

--- a/spec/parser/examples/file.c.txt
+++ b/spec/parser/examples/file.c.txt
@@ -1,0 +1,28 @@
+VALUE rb_cFile;
+
+/*
+ * call-seq:
+ *    File.exist?(file_name)    ->  true or false
+ *
+ * Return <code>true</code> if the named file exists.
+ *
+ * _file_name_ can be an IO object.
+ *
+ * "file exists" means that stat() or fstat() system call is successful.
+ */
+
+static VALUE
+rb_file_exist_p(VALUE obj, VALUE fname)
+{
+    struct stat st;
+
+    if (rb_stat(fname, &st) < 0) return Qfalse;
+    return Qtrue;
+}
+
+void
+Init_File(void)
+{
+	rb_cFile = rb_define_class("File", rb_cIO);
+    define_filetest_function("exist?", rb_file_exist_p, 1);
+}


### PR DESCRIPTION
# Description

When generating documentation from the Ruby source, some File methods do not get parsed into the yardoc.

## Steps to reproduce

This is the minimal reproduction for the issue. I've done my best to remove
all extraneous code and unique environment state on my machine before providing
these steps:

1. Run the following command in the Ruby source: `yardoc *.c`
2. Run `yri File.exist?`

## Actual Output

No documentation for `File.exist?'

## Expected Output

The documentation from the source code.

## Solution

In the Ruby core, `file.c` uses `define_filetest_function()` to define certain File singleton methods, including `File.exist?` YARD's C parser doesn't find them.

This PR modifies `YARD::Handlers::C::MethodHandler` to process `define_filetest_function`.

# Completed Tasks

* [X] I have read the [Contributing Guide][contrib].
* [X] The pull request is complete (implemented / written).
* [X] Git commits have been cleaned up (squash WIP / revert commits).
* [X] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
