### PR TITLE
Fix multiline method signatures

### DIFF
--- a/lib/yard/handlers/ruby/dsl_handler_methods.rb
+++ b/lib/yard/handlers/ruby/dsl_handler_methods.rb
@@ -41,8 +41,9 @@ module YARD
           end
 
           object = MethodObject.new(namespace, method_name, scope)
+          object = register(object)
           object.signature = method_signature
-          register(object)
+          object
         end
 
         def register_docstring(object, docstring = @docstring, stmt = statement)

--- a/lib/yard/handlers/ruby/method_handler.rb
+++ b/lib/yard/handlers/ruby/method_handler.rb
@@ -110,7 +110,17 @@ class YARD::Handlers::Ruby::MethodHandler < YARD::Handlers::Ruby::Base
   def method_signature
     method_name = statement.method_name(true)
     if statement.parameters.any? {|e| e }
-      "def #{method_name}(#{statement.parameters.source})"
+      formatted_args = format_args.map do |name, default|
+        next name unless default
+
+        if name.end_with?(':')
+          [name, default].join(' ')
+        else
+          [name, default].join(' = ')
+        end
+      end.join(', ')
+
+      "def #{method_name}(#{formatted_args})"
     else
       "def #{method_name}"
     end

--- a/lib/yard/handlers/ruby/method_handler.rb
+++ b/lib/yard/handlers/ruby/method_handler.rb
@@ -19,10 +19,10 @@ class YARD::Handlers::Ruby::MethodHandler < YARD::Handlers::Ruby::Base
 
     nobj = P(namespace, nobj.value) while nobj.type == :constant
     obj = register MethodObject.new(nobj, meth, mscope) do |o|
-      o.signature = method_signature
       o.explicit = true
       o.parameters = args
     end
+    obj.signature = method_signature
 
     # delete any aliases referencing old method
     nobj.aliases.each do |aobj, name|

--- a/spec/handlers/examples/method_handler_001.rb.txt
+++ b/spec/handlers/examples/method_handler_001.rb.txt
@@ -50,6 +50,16 @@ end
   def %(o) end
   def ^(o) end
 
+  def multiline_params(x,
+    y, z, zz = 'zz',
+    *foo,
+    a: 'a', b: 'b',
+    c: 'c',
+    **bar,
+    &blk
+  )
+  end
+
   def optsmeth(x, opts = {}) end
   def blockmeth(x, &block) end
 

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHa
   it "handles parameters" do
     expect(P('Foo#[]').parameters).to eq [['key', "'default'"]]
     expect(P('Foo#/').parameters).to eq [['x', "File.new('x', 'w')"], ['y', '2']]
+    expect(P('Foo#multiline_params').signature).to eq "def multiline_params(x, y, z, zz = 'zz', *foo, a: 'a', b: 'b', c: 'c', **bar, &blk)"
   end
 
   it "handles opts = {} as parameter" do


### PR DESCRIPTION
# Description

Previously, the `signature` for a `MethodObject` would be cut-off when the parameters spanned multiple lines. Now, the signature will always be complete and fit on a single line.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
