### PR TITLE
Fix double return tag.

### DIFF
--- a/lib/yard/autoload.rb
+++ b/lib/yard/autoload.rb
@@ -64,6 +64,11 @@ module YARD
   # parsing phase. This allows YARD as well as any custom extension to
   # analyze source and generate {CodeObjects} to be stored for later use.
   module Handlers
+    # Shared logic between C and Ruby handlers.
+    module Common
+      autoload :MethodHandler,            __p('handlers/common/method_handler')
+    end
+
     # CRuby Handlers
     # @since 0.8.0
     module C

--- a/lib/yard/handlers/c/handler_methods.rb
+++ b/lib/yard/handlers/c/handler_methods.rb
@@ -5,6 +5,7 @@ module YARD
       module HandlerMethods
         include Parser::C
         include CodeObjects
+        include Common::MethodHandler
 
         def handle_class(var_name, class_name, parent, in_module = nil)
           parent = nil if parent == "0"
@@ -67,7 +68,7 @@ module YARD
             register_visibility(obj, visibility)
             find_method_body(obj, func_name)
             obj.explicit = true
-            obj.add_tag(Tags::Tag.new(:return, '', 'Boolean')) if name =~ /\?$/
+            add_predicate_return_tag(obj) if name =~ /\?$/
           end
         end
 

--- a/lib/yard/handlers/common/method_handler.rb
+++ b/lib/yard/handlers/common/method_handler.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module YARD::Handlers
+  module Common
+    # Shared functionality between Ruby and C method handlers.
+    module MethodHandler
+      # @param [MethodObject] obj
+      def add_predicate_return_tag(obj)
+        if obj.tag(:return) && (obj.tag(:return).types || []).empty?
+          obj.tag(:return).types = ['Boolean']
+        elsif obj.tag(:return).nil?
+          unless obj.tags(:overload).any? {|overload| overload.tag(:return) }
+            obj.add_tag(YARD::Tags::Tag.new(:return, "", "Boolean"))
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/handlers/ruby/method_handler.rb
+++ b/lib/yard/handlers/ruby/method_handler.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 # Handles a method definition
 class YARD::Handlers::Ruby::MethodHandler < YARD::Handlers::Ruby::Base
+  include YARD::Handlers::Common::MethodHandler
+
   handles :def, :defs
 
   process do
@@ -39,13 +41,7 @@ class YARD::Handlers::Ruby::MethodHandler < YARD::Handlers::Ruby::Base
         extended method_added method_removed method_undefined).include?(meth)
       obj.add_tag(YARD::Tags::Tag.new(:private, nil))
     elsif meth.to_s =~ /\?$/
-      if obj.tag(:return) && (obj.tag(:return).types || []).empty?
-        obj.tag(:return).types = ['Boolean']
-      elsif obj.tag(:return).nil?
-        unless obj.tags(:overload).any? {|overload| overload.tag(:return) }
-          obj.add_tag(YARD::Tags::Tag.new(:return, "", "Boolean"))
-        end
-      end
+      add_predicate_return_tag(obj)
     end
 
     if obj.has_tag?(:option)

--- a/spec/handlers/c/method_handler_spec.rb
+++ b/spec/handlers/c/method_handler_spec.rb
@@ -213,6 +213,7 @@ RSpec.describe YARD::Handlers::C::MethodHandler do
     foo = Registry.at('Foo#foo?')
     expect(foo.docstring).to eq 'DOCSTRING'
     expect(foo.tag(:return).types).to eq ['Boolean']
+    expect(foo.tags(:return).size).to eq 1
   end
 
   it "does not add return tag if return tags exist" do
@@ -226,6 +227,7 @@ RSpec.describe YARD::Handlers::C::MethodHandler do
     eof
     foo = Registry.at('Foo#foo?')
     expect(foo.tag(:return).types).to eq ['String']
+    expect(foo.tags(:return).size).to eq 1
   end
 
   it "handles casted method names" do


### PR DESCRIPTION
# Description

In our C/C++ code base where we implement Ruby functions we some times have explicit `@return [Boolean]` tags for predicate methods.

YARD is adding an extra `@return [Boolean]` regardless if there already is one.

```cpp
/**
 * This method is used to determine if a bounding box contains a specific
 * Point3d or BoundingBox object.
 *
 * @example
 *   boundingbox = Geom::BoundingBox.new
 *   boundingbox.add([100, 200, -400], [200, 400, 100])
 *   # This will return false.
 *   boundingbox.contains?([300, 100, 400])
 *   # This will return true.
 *   boundingbox.contains?([150, 300, -200])
 *
 * @overload contains?(point_or_bb)
 *
 *   @param [Geom::Point3d, Geom::BoundingBox] point_or_bb
 *
 * @return [Boolean]
 *
 * @version SketchUp 6.0
 */
static VALUE _wrap_contains(VALUE self, VALUE arg) {
  // ...
}
```

![image](https://user-images.githubusercontent.com/192418/53362358-3fa25380-393a-11e9-8184-d16bfa237fba.png)

See output: http://ruby.sketchup.com/Geom/BoundingBox.html#contains%3F-instance_method

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
