### PR TITLE
resolves #1231 sort README files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,8 +13,7 @@ group :development do
 end
 
 group :asciidoc do
-  # Asciidoctor 2.0 drops support for Ruby < 2.3.
-  gem 'asciidoctor', RUBY_VERSION < '2.3' ? '< 2' : '>= 0'
+  gem 'asciidoctor'
 end
 
 group :markdown do

--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -294,8 +294,15 @@ module YARD
         # Last minute modifications
         self.files = Parser::SourceParser::DEFAULT_PATH_GLOB if files.empty?
         files.delete_if {|x| x =~ /\A\s*\Z/ } # remove empty ones
-        readme = Dir.glob('README{,*[^~]}').first
-        readme ||= Dir.glob(files.first).first if options.onefile
+        readmes = Dir.glob('README{,*[^~]}')
+        if readmes.empty?
+          readme = Dir.glob(files.first).first if options.onefile && !files.empty?
+        else
+          readme = readmes.
+            sort {|a, b| File.extname(a) <=> File.extname(b) }.
+            sort {|a, b| a.slice(0, a.rindex('.') || a.length) <=> b.slice(0, b.rindex('.') || b.length) }.
+            first
+        end
         options.readme ||= CodeObjects::ExtraFileObject.new(readme) if readme
         options.files.unshift(options.readme).uniq! if options.readme
 


### PR DESCRIPTION
# Description

The main reason for this change is to choose the README that users most expect to be chosen. Currently, there isn't really any rhyme or reason to which README is selected because the files aren't explicitly sorted. With this change, README will be selected over README.md, and README.md will be selected over README-zh_CN.md (or README.zh_CN.md).

The changes included are:

- sort README files, first by file extension, then by basename
- prefer README basename over all other files
- prefer file without extension over file with extension

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
