### PR TITLE
Add a version constraint on Asciidoctor (fixes tests)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,8 @@ group :development do
 end
 
 group :asciidoc do
-  gem 'asciidoctor'
+  # Asciidoctor 2.0 drops support for Ruby < 2.3.
+  gem 'asciidoctor', RUBY_VERSION < '2.3' ? '< 2' : '>= 0'
 end
 
 group :markdown do


### PR DESCRIPTION
# Description

Asciidoctor 2.0 drops support for Rubies < 2.3 (see [changelog](https://github.com/asciidoctor/asciidoctor/blob/master/CHANGELOG.adoc#200-2019-03-22---mojavelinux)). Attempt to run Yard's test suite on older Rubies may result in a build failure like https://travis-ci.org/lsegal/yard/jobs/512898313. Hence, a conditional version constraint has been added to Gemspec: on Ruby < 2.3 it requires Asciidoctor < 2, whereas on newer Rubies recent versions of Asciidoctor are allowed.

This pull request is expected to fix tests which are currently failing.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
