### PR TITLE
Add tests to cover integration with various markup renderers

### DIFF
--- a/spec/templates/markup_processor_integrations/asciidoctor_spec.rb
+++ b/spec/templates/markup_processor_integrations/asciidoctor_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require File.dirname(__FILE__) + '/integration_spec_helper'
+
+RSpec.describe 'Asciidoctor integration' do
+  include_context 'shared helpers for markup processor integration specs'
+  let(:markup) { :asciidoc }
+  let(:markup_provider) { :asciidoctor }
+
+  let(:document) do
+    <<-ASCIIDOC
+== Example code listings
+
+Indented block of Ruby code:
+
+    x = 1
+
+Fenced block of Ruby code:
+
+-----
+x = 2
+-----
+
+Fenced and annotated block of Ruby code:
+
+[source,ruby]
+-----
+x = 3
+-----
+
+Fenced and annotated block of non-Ruby code:
+
+[source,bash]
+-----
+x = 4
+-----
+
+ASCIIDOC
+  end
+
+  it 'renders level 2 header' do
+    expect(rendered_document).to match(header_regexp(2, 'Example code listings'))
+  end
+
+  it 'renders indented block of code, and applies Ruby syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '1'))
+  end
+
+  it 'renders fenced block of code, and applies Ruby syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '2'))
+  end
+
+  it 'renders fenced and annotated block of Ruby code, and applies syntax highlight' do
+    pending "Fails due to https://github.com/lsegal/yard/issues/1239"
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '3'))
+  end
+
+  it 'renders fenced and annotated block of non-Ruby code, and does not apply syntax highlight' do
+    expect(rendered_document).to match('x = 4')
+  end
+end

--- a/spec/templates/markup_processor_integrations/integration_spec_helper.rb
+++ b/spec/templates/markup_processor_integrations/integration_spec_helper.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+RSpec.shared_context 'shared helpers for markup processor integration specs' do
+  let(:rendered_document) { html_renderer.htmlify document }
+
+  let(:template_options) do
+    Templates::TemplateOptions.new.tap do |o|
+      o.reset_defaults
+      o.default_return = nil
+      o.markup = markup
+      o.markup_provider = markup_provider
+    end
+  end
+
+  let(:html_renderer) do
+    obj = OpenStruct.new
+    obj.options = template_options
+    obj.object = Registry.root
+    obj.extend(Templates::Helpers::HtmlHelper)
+    obj
+  end
+
+  # Works only with one-liners.
+  def highlighted_ruby_regexp(*identifiers)
+    prefix = Regexp.escape '<pre class="code ruby"><code class="ruby">'
+    any_span_tag = '<span\b'
+    escaped_identifiers = identifiers.map {|a| Regexp.escape(a) }
+
+    regexp_parts = [prefix, any_span_tag, escaped_identifiers]
+    regexp_str = regexp_parts.flatten.join(".*")
+    Regexp.compile(regexp_str)
+  end
+
+  def header_regexp(level, text)
+    prefix = "<h#{level}[^>]*?>"
+    escaped_text = Regexp.escape text
+    regexp_str = [prefix, escaped_text].join(".*")
+    Regexp.compile(regexp_str)
+  end
+end

--- a/spec/templates/markup_processor_integrations/rdoc_markdown_spec.rb
+++ b/spec/templates/markup_processor_integrations/rdoc_markdown_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require File.dirname(__FILE__) + '/integration_spec_helper'
+
+RSpec.describe 'Markdown via RDoc integration' do
+  include_context 'shared helpers for markup processor integration specs'
+  let(:markup) { :markdown }
+  let(:markup_provider) { :rdoc }
+
+  let(:document) do
+    <<-MARKDOWN
+## Example code listings
+
+Indented block of Ruby code:
+
+    x = 1
+
+Fenced block of Ruby code:
+
+```
+x = 2
+```
+
+Fenced and annotated block of Ruby code:
+
+```ruby
+x = 3
+```
+
+Fenced and annotated block of non-Ruby code:
+
+```plain
+x = 4
+```
+
+MARKDOWN
+  end
+
+  it 'renders level 2 header' do
+    expect(rendered_document).to match(header_regexp(2, 'Example code listings'))
+  end
+
+  it 'renders indented block of code, and applies Ruby syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '1'))
+  end
+
+  it 'renders fenced block of code, and applies Ruby syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '2'))
+  end
+
+  it 'renders fenced and annotated block of Ruby code, and applies syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '3'))
+  end
+
+  it 'renders fenced and annotated block of non-Ruby code, and does not apply syntax highlight' do
+    pending 'This is actually highlighted, but it is not a big deal'
+    expect(rendered_document).to match('x = 4')
+  end
+end

--- a/spec/templates/markup_processor_integrations/rdoc_spec.rb
+++ b/spec/templates/markup_processor_integrations/rdoc_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require File.dirname(__FILE__) + '/integration_spec_helper'
+
+RSpec.describe 'RDoc integration' do
+  include_context 'shared helpers for markup processor integration specs'
+  let(:markup) { :rdoc }
+  # Must be nil as this is how this provider is defined.
+  # See: https://github.com/lsegal/yard/commit/6634ae25878cd4fcb79.
+  let(:markup_provider) { nil }
+
+  let(:document) do
+    <<-RDOC
+== Example code listings
+
+Verbatim block of Ruby code:
+
+  x = 1
+
+Verbatim non-Ruby block:
+
+  This has nothing to do with Ruby.
+
+RDOC
+  end
+
+  it 'renders level 2 header' do
+    expect(rendered_document).to match(header_regexp(2, 'Example code listings'))
+  end
+
+  it 'renders indented block of code, and applies Ruby syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '1'))
+  end
+
+  it 'renders indented block of text which is not a piece of Ruby code, ' \
+    'and does not apply syntax highlight' do
+    expect(rendered_document).to match('This has nothing to do with Ruby.')
+  end
+end

--- a/spec/templates/markup_processor_integrations/redcarpet_spec.rb
+++ b/spec/templates/markup_processor_integrations/redcarpet_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require File.dirname(__FILE__) + '/integration_spec_helper'
+
+RSpec.describe 'Redcarpet integration' do
+  include_context 'shared helpers for markup processor integration specs'
+  let(:markup) { :markdown }
+  let(:markup_provider) { :redcarpet }
+
+  let(:document) do
+    <<-MARKDOWN
+## Example code listings
+
+Indented block of Ruby code:
+
+    x = 1
+
+Fenced block of Ruby code:
+
+```
+x = 2
+```
+
+Fenced and annotated block of Ruby code:
+
+```ruby
+x = 3
+```
+
+Fenced and annotated block of non-Ruby code:
+
+```plain
+x = 4
+```
+
+MARKDOWN
+  end
+
+  it 'renders level 2 header' do
+    expect(rendered_document).to match(header_regexp(2, 'Example code listings'))
+  end
+
+  it 'renders indented block of code, and applies Ruby syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '1'))
+  end
+
+  it 'renders fenced block of code, and applies Ruby syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '2'))
+  end
+
+  it 'renders fenced and annotated block of Ruby code, and applies syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '3'))
+  end
+
+  it 'renders fenced and annotated block of non-Ruby code, and does not apply syntax highlight' do
+    pending 'This is actually highlighted, but it is not a big deal'
+    expect(rendered_document).to match('x = 4')
+  end
+end

--- a/spec/templates/markup_processor_integrations/redcloth_spec.rb
+++ b/spec/templates/markup_processor_integrations/redcloth_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require File.dirname(__FILE__) + '/integration_spec_helper'
+
+RSpec.describe 'RedCloth integration' do
+  include_context 'shared helpers for markup processor integration specs'
+  let(:markup) { :textile }
+  let(:markup_provider) { :redcloth }
+
+  let(:document) do
+    <<-TEXTILE
+h2. Example code listings
+
+Example paragraph.
+
+p. Example paragraph using 'p' tag.
+
+p. Block of Ruby code using 'bc' tag:
+
+bc. x = 1
+
+p. Block of Ruby code using 'pre' tag:
+
+pre. x = 2
+TEXTILE
+  end
+
+  it 'renders level 2 header' do
+    expect(rendered_document).to match(header_regexp(2, 'Example code listings'))
+  end
+
+  it 'renders paragraphs' do
+    expect(rendered_document).
+      to include('<p>Example paragraph.</p>')
+    # Textile may replace typewriter apostrophes here used as quotes with
+    # something typographically better
+    expect(rendered_document).
+      to match(%r{<p>Example paragraph using .*p.* tag.</p>})
+  end
+
+  it 'renders bc. block, and applies Ruby syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '1'))
+  end
+
+  it 'renders pre. block, and applies Ruby syntax highlight' do
+    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '2'))
+  end
+end


### PR DESCRIPTION
YARD supports several different markup languages, and plenty of markup processors.  However, their integration was hardly tested.  This is now being fixed.

### Description

There is one test suite per markup processor.  Every test suite contains an example document which is written in a respective markup language.  Test suites ensure that given markup processor correctly translates the document to HTML.  Furthermore, it is tested whether YARD's enhancements are applied correctly, most importantly syntax highlighting.

### Pending specs

Some tests are pending, what possibly reveals new bugs.

* Notably pending test for AsciiDoctor processor is a failing spec for #1239 bug.
* Pending specs related to Markdown should be discussed. IMO code blocks which are explicitly annotated as containing non-Ruby code should not be highlighted like they were in Ruby, but perhaps it's a correct behaviour.

### Further considerations

* As of this pull request, only a handful of markup processors are concerned, which is directly related to what is listed in Gemfile.  It is not difficult to add more though, and I can do that.
* Proposed location for these new tests is in `spec/templates/markup_processor_integrations` directory. Perhaps a better place could be found. Perhaps these tests should be separated from unit tests.
* Adding links to documentation for classes and methods referenced in document should be tested as well, but I don't know how to provide some sample `Registry` for this purpose.

### Relation to other issues

This pull request is probably a prerequisite for resolving #1239, #1157 and perhaps more.

### Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
