### PR TITLE
Update README section on how to use a Rake task (NameErrors)

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,8 @@ The second most obvious is to generate docs via a Rake task. You can do this by
 adding the following to your `Rakefile`:
 
 ```ruby
+require 'yard'
+
 YARD::Rake::YardocTask.new do |t|
  t.files   = ['lib/**/*.rb', OTHER_PATHS]   # optional
  t.options = ['--any', '--extra', '--opts'] # optional


### PR DESCRIPTION
Currently, README is incorrect about how to setup YARD's Rake task. And Rake task itself is also broken.

# Description

There is an example in README which explains how to add a Rake task. However, following it results with a `NameError` due to uninitialized constant `YARD`. This is not surprising, because Rake task definition should be loaded first, which is missing in that example. Unfortunately, adding `require 'yard/rake/yardoc_task'` does not help much — another `NameError` is raised, because the Rake task was unable to load YARD.

Changes included in this pull request:

1. Ensure that YARD is loaded when a Rake task is invoked.
2. Update README with a corrected example.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
