### PR TITLE
Remove charset attr from link and script tags (if no src attr)

### DIFF
--- a/templates/default/fulldoc/html/frames.erb
+++ b/templates/default/fulldoc/html/frames.erb
@@ -4,7 +4,7 @@
   <meta charset="<%= charset %>">
 	<title><%= options.title %></title>
 </head>
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   var match = unescape(window.location.hash).match(/^#!(.+)/);
   var name = match ? match[1] : '<%= url_for_main %>';
   name = name.replace(/^(\w+):\/\//, '').replace(/^\/\//, '');

--- a/templates/default/fulldoc/html/full_list.erb
+++ b/templates/default/fulldoc/html/full_list.erb
@@ -4,7 +4,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta charset="<%= charset %>" />
     <% stylesheets_full_list.each do |stylesheet| %>
-      <link rel="stylesheet" href="<%= mtime_url(stylesheet) %>" type="text/css" media="screen" charset="utf-8" />
+      <link rel="stylesheet" href="<%= mtime_url(stylesheet) %>" type="text/css" media="screen" />
     <% end %>
 
     <% javascripts_full_list.each do |javascript| %>

--- a/templates/default/layout/html/headers.erb
+++ b/templates/default/layout/html/headers.erb
@@ -7,7 +7,7 @@
   <% end %>
 </title>
 <% stylesheets.each do |stylesheet| %>
-  <link rel="stylesheet" href="<%= mtime_url(stylesheet) %>" type="text/css" charset="utf-8" />
+  <link rel="stylesheet" href="<%= mtime_url(stylesheet) %>" type="text/css" />
 <% end %>
 <%= erb :script_setup %>
 <% javascripts.each do |javascript| %>

--- a/templates/default/layout/html/script_setup.erb
+++ b/templates/default/layout/html/script_setup.erb
@@ -1,4 +1,4 @@
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   pathId = <%= @path ? @path.inspect : 'null' %>;
   relpath = '<%= u = url_for(''); u + (u != '' ? '/' : '') %>';
 </script>

--- a/templates/default/onefile/html/headers.erb
+++ b/templates/default/onefile/html/headers.erb
@@ -1,6 +1,6 @@
 <style type="text/css">
   <%= @css_data %>
 </style>
-<script type="text/javascript" charset="utf-8">
+<script type="text/javascript">
   <%= @js_data %>
 </script>

--- a/templates/guide/layout/html/layout.erb
+++ b/templates/guide/layout/html/layout.erb
@@ -3,7 +3,7 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
   <head>
     <%= erb(:headers) %>
-		<script type="text/javascript" charset="utf-8">
+		<script type="text/javascript">
 			$(function() {
 				$('.object_link').each(function() {
 					$(this).html($(this).find('a').html())


### PR DESCRIPTION
# Description

Issue #1259

According to the new HTML 5 standards, link tags should never use the charset attribute (charset should be specified in the CSS files) and script tags should only specify it if there is a src attribute.

In the [W3C validator](https://validator.w3.org/), it outputs them as errors, instead of warnings, for some reason.

https://www.w3schools.com/tags/att_link_charset.asp
https://www.w3schools.com/tags/att_script_charset.asp

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
