### PR TITLE
Process mixin calls to constants.

### DIFF
--- a/lib/yard/handlers/ruby/mixin_handler.rb
+++ b/lib/yard/handlers/ruby/mixin_handler.rb
@@ -32,6 +32,18 @@ class YARD::Handlers::Ruby::MixinHandler < YARD::Handlers::Ruby::Base
       obj = Proxy.new(namespace, mixin.source, :module)
     end
 
-    namespace.mixins(scope).unshift(obj) unless namespace.mixins(scope).include?(obj)
+    rec = recipient(mixin)
+    return if rec.nil? || rec.mixins(scope).include?(obj)
+    rec.mixins(scope).unshift(obj)
+  end
+
+  def recipient(mixin)
+    if statement[0].type == :var_ref && statement[0][0] != s(:kw, "self")
+      statement[0][0].type == :const ?
+        Proxy.new(namespace, statement.namespace.source) :
+        nil
+    else
+      namespace
+    end
   end
 end

--- a/spec/handlers/examples/extend_handler_001.rb.txt
+++ b/spec/handlers/examples/extend_handler_001.rb.txt
@@ -14,3 +14,6 @@ module Q
     end
   end
 end
+
+module FromConstant; end
+FromConstant.extend A

--- a/spec/handlers/examples/mixin_handler_001.rb.txt
+++ b/spec/handlers/examples/mixin_handler_001.rb.txt
@@ -35,3 +35,6 @@ module ABC
     end
   end
 end
+
+module FromConstant; end
+FromConstant.include A

--- a/spec/handlers/extend_handler_spec.rb
+++ b/spec/handlers/extend_handler_spec.rb
@@ -21,4 +21,8 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ExtendHa
   it "does not allow extending self if object is a class" do
     undoc_error "class Foo; extend self; end"
   end
+
+  it "adds mixins from extend calls to constants" do
+    expect(P('FromConstant').class_mixins).to eq [P('A')]
+  end
 end

--- a/spec/handlers/mixin_handler_spec.rb
+++ b/spec/handlers/mixin_handler_spec.rb
@@ -53,4 +53,8 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MixinHan
     undoc_error "module X; include invalid, Y; end"
     expect(Registry.at('X').mixins).to eq [P('Y')]
   end
+
+  it "adds mixins from include calls to constants" do
+    expect(P('FromConstant').instance_mixins).to eq [P('A')]
+  end
 end


### PR DESCRIPTION
Fixes #1272.

Process `include` and `extend` calls to constants. The following examples will generate the same documentation:

```ruby
class MyClass
  include MyModule
end

# or

MyClass.include MyModule
```

* [X] I have read the [Contributing Guide][contrib].
* [X] The pull request is complete (implemented / written).
* [X] Git commits have been cleaned up (squash WIP / revert commits).
* [X] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).
