### PR TITLE
Fix Asciidoc syntax highlight

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -65,7 +65,7 @@ module YARD
           html = html.encode(:invalid => :replace, :replace => '?')
         end
         html = resolve_links(html)
-        unless [:text, :none, :pre].include?(markup)
+        unless [:text, :none, :pre, :ruby].include?(markup)
           html = parse_codeblocks(html)
         end
         html

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -653,6 +653,7 @@ module YARD
       # @return [String, nil] detected programming language
       def detect_lang_in_codeblock_attributes(pre_html_attrs, code_html_attrs)
         detected = nil
+        detected ||= (/\bdata-lang="(.+?)"/ =~ code_html_attrs && $1)
         detected ||= (/\blang="(.+?)"/ =~ pre_html_attrs && $1)
         detected ||= (/\bclass="(.+?)"/ =~ code_html_attrs && $1)
         detected

--- a/spec/templates/markup_processor_integrations/asciidoctor_spec.rb
+++ b/spec/templates/markup_processor_integrations/asciidoctor_spec.rb
@@ -51,7 +51,6 @@ ASCIIDOC
   end
 
   it 'renders fenced and annotated block of Ruby code, and applies syntax highlight' do
-    pending "Fails due to https://github.com/lsegal/yard/issues/1239"
     expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '3'))
   end
 


### PR DESCRIPTION
# Description

This pull request improves the way in which code listing blocks in extra file objects are matched.
In the result, listings in extra file objects written in AsciiDoc are now properly enriched with YARD: the syntax is highlighted, and the identifiers are linked with their respective documentation.

Fixes #1239 (went with option 2).

# Details

The regular expression used for code blocks detection has been significantly relaxed. The updated one makes no assumptions on what HTML attributes can be set on `<pre>` or `<code>` element, allowing everything. It still requires that the listing's outermost element is `<pre>`, but this seems to be a reasonable limitation.

The programming language detection still considers the values of `class` and `lang` HTML attributes. Moreover, `data-lang` attribute, which is produced by AsciiDoctor markup processor, is also supported now.

Finally, this pull request properly ensures that code blocks produced from Ruby source files are not highlighted twice. It wasn't a problem before only because of a very lucky situation that code blocks produced by `html_markup_ruby` have a slightly different attributes, and that was preventing them from being erroneously double-highlighted.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
