### PR TITLE
Make sure deleted object's entries are removed from object_types

### DIFF
--- a/lib/yard/registry_store.rb
+++ b/lib/yard/registry_store.rb
@@ -72,7 +72,12 @@ module YARD
     # Deletes an object at a given path
     # @param [#to_sym] key the key to delete
     # @return [void]
-    def delete(key) @store.delete(key.to_sym) end
+    def delete(key)
+      if @store[key.to_sym]
+        @object_types[@store[key.to_sym].type].delete(key.to_s)
+        @store.delete(key.to_sym)
+      end
+    end
 
     # Gets all path names from the store. Loads the entire database
     # if +reload+ is +true+

--- a/spec/registry_store_spec.rb
+++ b/spec/registry_store_spec.rb
@@ -304,6 +304,17 @@ RSpec.describe YARD::RegistryStore do
     end
   end
 
+  describe "#delete" do
+    pending "deletes the given object from store" do
+      @store.put(:YARD, @foo)
+      expect(@store.get(:YARD)).to be @foo
+      expect(@store.paths_for_type(:method)).to eq ["YARD"]
+      @store.delete(:YARD)
+      expect(@store.get(:YARD)).to be nil
+      expect(@store.paths_for_type(:method)).to eq []
+    end
+  end
+
   describe "#locale" do
     it "loads ./po/LOCALE_NAME.po" do
       fr_locale = I18n::Locale.new("fr")

--- a/spec/registry_store_spec.rb
+++ b/spec/registry_store_spec.rb
@@ -305,7 +305,7 @@ RSpec.describe YARD::RegistryStore do
   end
 
   describe "#delete" do
-    pending "deletes the given object from store" do
+    it "deletes the given object from store" do
       @store.put(:YARD, @foo)
       expect(@store.get(:YARD)).to be @foo
       expect(@store.paths_for_type(:method)).to eq ["YARD"]


### PR DESCRIPTION
# Description

Previously, `YARD::RegistryStore#delete` removes an object entry from `@store` but does not remove its entry from `@object_types`.
Therefore, some elements of `YARD::Registry.all` may be `nil` after an object deletion such as the following code.

```console
$ pry
[1] pry(main)> require 'yard'
=> true
[2] pry(main)> YARD::Registry.register(foo = YARD::CodeObjects::ModuleObject.new(nil, :Foo))
=> #<yardoc module Foo>
[3] pry(main)> YARD::Registry.register(bar = YARD::CodeObjects::ModuleObject.new(nil, :Bar))
=> #<yardoc module Bar>
[4] pry(main)> YARD::Registry.all(:module)
=> [#<yardoc module Foo>, #<yardoc module Bar>]
[5] pry(main)> YARD::Registry.delete(foo)
=> #<yardoc module Foo>
[6] pry(main)> YARD::Registry.all(:module)
=> [nil, #<yardoc module Bar>]
```

This PR makes sure that `YARD::RegistryStore#delete` remove the deleted object's entry from `@object_types` to fix this behavior.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
