### PR TITLE
CI against Ruby 2.7.0-dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ rvm:
   - "2.4"
   - "2.5"
   - "2.6"
-  # - ruby-head
+  - ruby-head
   # - jruby
 
 # Define how to run your tests (defaults to `bundle exec rake` or `rake` depending on whether you have a `Gemfile`)
@@ -49,3 +49,7 @@ env:
 #   webhooks:
 #     urls:
 #       - https://webhooks.gitter.im/e/c6dbb9323007dfcf81df
+
+matrix:
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
### Summary

CI fails as follows when using Ruby 2.7.0-dev.

```console
% ruby 2.7.0dev (2019-10-31T08:11:23Z master 5f6fbf8725) [x86_64-darwin17]
% bundle exec rake
(snip)

Finished in 6.71 seconds (files took 1.19 seconds to load)
1910 examples, 29 failures, 3 pending
```

The cause of failures has not been identified, but changes in Ripper or something may have affected it.

First of all, it is opened as a PR so that CI failure can be shown.

## Other Information

I noticed this issue because RuboCop documentation generation failed when using Ruby 2.7.0-dev.

e.g. https://circleci.com/gh/rubocop-hq/rubocop-performance/855
