### PR TITLE
fix toc generation to properly nest

### DIFF
--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -422,8 +422,8 @@ li.r2 { background: #fafafa; }
 #toc ol { padding-left: 1.8em; }
 #toc li { font-size: 1.1em; line-height: 1.7em; }
 #toc > ol > li { font-size: 1.1em; font-weight: bold; }
-#toc ol > ol { font-size: 0.9em; }
-#toc ol ol > ol { padding-left: 2.3em; }
+#toc ol > li > ol { font-size: 0.9em; }
+#toc ol ol > li > ol { padding-left: 2.3em; }
 #toc ol + li { margin-top: 0.3em; }
 #toc.hidden { padding: 10px; background: #fefefe; box-shadow: none; }
 #toc.hidden:hover { background: #fafafa; }

--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -171,6 +171,7 @@ function generateTOC() {
   var counter = 0;
   var tags = ['h2', 'h3', 'h4', 'h5', 'h6'];
   var i;
+  var curli;
   if ($('#filecontents h1').length > 1) tags.unshift('h1');
   for (i = 0; i < tags.length; i++) { tags[i] = '#filecontents ' + tags[i]; }
   var lastTag = parseInt(tags[0][1], 10);
@@ -190,15 +191,25 @@ function generateTOC() {
     }
     if (thisTag > lastTag) {
       for (i = 0; i < thisTag - lastTag; i++) {
-        var tmp = $('<ol/>'); toc.append(tmp); toc = tmp;
+        if ( typeof(curli) == "undefined" ) {
+          curli = $('<li/>');
+          toc.append(curli);
+        }
+        toc = $('<ol/>');
+        curli.append(toc);
+        curli = undefined;
       }
     }
     if (thisTag < lastTag) {
-      for (i = 0; i < lastTag - thisTag; i++) toc = toc.parent();
+      for (i = 0; i < lastTag - thisTag; i++) {
+        toc = toc.parent();
+        toc = toc.parent();
+      }
     }
     var title = $(this).attr('toc-title');
     if (typeof(title) == "undefined") title = $(this).text();
-    toc.append('<li><a href="#' + this.id + '">' + title + '</a></li>');
+    curli =$('<li><a href="#' + this.id + '">' + title + '</a></li>'); 
+    toc.append(curli);
     lastTag = thisTag;
   });
   if (!show) return;


### PR DESCRIPTION
# Description

The js function the generates toc produces malformed html: `<ol>` elements occur within other `<ol>` elements directly. This change fixes it.

# Completed Tasks

* [x ] I have read the [Contributing Guide][contrib].
* [ x] The pull request is complete (implemented / written).
* [x ] Git commits have been cleaned up (squash WIP / revert commits).
* [x ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
