### PR TITLE
Store extra files in their own directory

### DIFF
--- a/lib/yard/code_objects/extra_file_object.rb
+++ b/lib/yard/code_objects/extra_file_object.rb
@@ -61,6 +61,10 @@ module YARD::CodeObjects
 
     def type; :extra_file end
 
+    def source_type; :ruby end
+
+    def parent; YARD::Registry.root end
+
     def ==(other)
       return false unless self.class === other
       other.filename == filename

--- a/lib/yard/serializers/file_system_serializer.rb
+++ b/lib/yard/serializers/file_system_serializer.rb
@@ -51,7 +51,7 @@ module YARD
         return object if object.is_a?(String)
 
         if object.is_a?(CodeObjects::ExtraFileObject)
-          fspath = ['file.' + object.name + (extension.empty? ? '' : ".#{extension}")]
+          fspath = ['_file', object.name + (extension.empty? ? '' : ".#{extension}")]
         else
           objname = object != YARD::Registry.root ? mapped_name(object) : "top-level-namespace"
           objname += '_' + object.scope.to_s[0, 1] if object.is_a?(CodeObjects::MethodObject)

--- a/lib/yard/server/doc_server_serializer.rb
+++ b/lib/yard/server/doc_server_serializer.rb
@@ -20,7 +20,7 @@ module YARD
         when CodeObjects::ConstantObject, CodeObjects::ClassVariableObject
           serialized_path(object.namespace) + "##{object.name}-#{object.type}"
         when CodeObjects::ExtraFileObject
-          super(object).gsub(/^file\./, 'file/')
+          super(object).gsub(/^_file\//, 'file/')
         else
           super(object)
         end

--- a/spec/serializers/file_system_serializer_spec.rb
+++ b/spec/serializers/file_system_serializer_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe YARD::Serializers::FileSystemSerializer do
     it "handles ExtraFileObject's" do
       s = Serializers::FileSystemSerializer.new
       e = CodeObjects::ExtraFileObject.new('filename.txt', '')
-      expect(s.serialized_path(e)).to eq 'file.filename.html'
+      expect(s.serialized_path(e)).to eq '_file/filename.html'
     end
 
     it "differentiates instance and class methods from serialized path" do

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -415,12 +415,12 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
       expect(parse_link(resolve_links("{file:TEST.txt#abc}"))).to eq(
         :inner_text => "TEST",
         :title => "TEST",
-        :href => "file.TEST.html#abc"
+        :href => "_file/TEST.html#abc"
       )
       expect(parse_link(resolve_links("{file:TEST.txt title}"))).to eq(
         :inner_text => "title",
         :title => "title",
-        :href => "file.TEST.html"
+        :href => "_file/TEST.html"
       )
     end
 

--- a/templates/default/fulldoc/html/setup.rb
+++ b/templates/default/fulldoc/html/setup.rb
@@ -8,7 +8,7 @@ def init
   generate_assets
   serialize('_index.html')
   options.files.each_with_index do |file, _i|
-    serialize_file(file, file.title)
+    serialize_file(file)
   end
 
   options.delete(:objects)
@@ -48,6 +48,7 @@ end
 # Generate the index document for the output
 # @params [Hash] options contains data and flags that influence the output
 def serialize_index(options)
+  options.object = Registry.root
   Templates::Engine.with_serializer('index.html', options.serializer) do
     T('layout').run(options.merge(:index => true))
   end
@@ -57,18 +58,12 @@ end
 # the README file or files specified on the command-line.
 #
 # @param [File] file object to be saved to the output
-# @param [String] title currently unused
 #
 # @see layout#diskfile
-def serialize_file(file, title = nil) # rubocop:disable Lint/UnusedMethodArgument
-  options.object = Registry.root
+def serialize_file(file)
   options.file = file
-  outfile = 'file.' + file.name + '.html'
-
   serialize_index(options) if file == options.readme
-  Templates::Engine.with_serializer(outfile, options.serializer) do
-    T('layout').run(options)
-  end
+  serialize(file)
   options.delete(:file)
 end
 

--- a/templates/guide/fulldoc/html/setup.rb
+++ b/templates/guide/fulldoc/html/setup.rb
@@ -23,7 +23,7 @@ def init
   class << options.serializer
     define_method(:serialized_path) do |object|
       if CodeObjects::ExtraFileObject === object
-        super(object).sub(/^file\./, '').downcase
+        super(object).sub(/^_file\//, '').downcase
       else
         super(object)
       end


### PR DESCRIPTION
# Description

Currently when creating HTML documentation, extra files are stored at the web root with "file." prefixed to their name. This PR changes this practice to instead store them in their own directory (named "_file" to prevent conflicts with Ruby objects). 

This brings the output more inline with the server which hosts the files under `/file/` path. In fact, the server keeps the relative path to the extra file as part of the URL path. (For example, while yard's changelog is found at `/file/CHANGELOG.md` the getting started guide is at `/file/docs/GettingStarted.md`.) If this PR is accepted, I would like to work on doing something similar for HTML creation. (This might fix #1277 as all the READMEs would be listed there, and it's easy enough to set custom title attributes to help distinguish.) If all of that is successful, I would like to have a setting that allows for showing the extra file hierarchically similar to how nested Ruby objects are presented with disclosure triangles.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
