### PR TITLE
ruby_parser.rb - add void_stmt to insert_comments loop

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -612,7 +612,7 @@ module YARD
 
         def insert_comments
           root.traverse do |node|
-            next if node.type == :comment || node.type == :list || node.parent.type != :list
+            next if %i{comment void_stmt list}.include?(node.type) || node.parent.type != :list
 
             # never attach comments to if/unless mod nodes
             if node.type == :if_mod || node.type == :unless_mod


### PR DESCRIPTION
# Description

While running YARD with Ruby 2.7, the following comment is not added to class B:
```ruby
module A
  # comment
  # ...
  # end comment
  class B
```

but, if a blank line is added between `module A` and the comment, it parses fine.

Tests passed in my fork, but 2.7/trunk is not tested against.  I checked the issue locally.

I could add Actions testing on Windows (Ruby 2.4 thru trunk), which I assume would show the issue.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md