### PR TITLE
Fixing yard server parsing checksum containing filenames with spaces.

### DIFF
--- a/lib/yard/registry_store.rb
+++ b/lib/yard/registry_store.rb
@@ -291,7 +291,8 @@ module YARD
     def load_checksums
       return unless File.file?(checksums_path)
       lines = File.readlines(checksums_path).map do |line|
-        line.strip.split(/\s+/)
+        parts = line.strip.split(/\s+/)
+        parts.count > 2 ? [parts[0..-2].join(' '), parts[-1]] : parts
       end
       @checksums = Hash[lines]
     end

--- a/lib/yard/registry_store.rb
+++ b/lib/yard/registry_store.rb
@@ -291,8 +291,7 @@ module YARD
     def load_checksums
       return unless File.file?(checksums_path)
       lines = File.readlines(checksums_path).map do |line|
-        parts = line.strip.split(/\s+/)
-        parts.count > 2 ? [parts[0..-2].join(' '), parts[-1]] : parts
+        line.strip.rpartition(' ').tap { |p| p.delete_at(1) }
       end
       @checksums = Hash[lines]
     end


### PR DESCRIPTION
# Description

Running `yard server` it parses the checksums file. If any files scanned by yard contains space in their name, the parsing of the checksum file fails.

Similarly reported in:
https://stackoverflow.com/questions/27320253/yard-server-yields-invalid-number-of-elements-3-for-1-2

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
