### PR TITLE
ci.yml - add Ruby 2.2 & 2.3, update, split windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,22 +4,20 @@ on: [push, pull_request]
 jobs:
   build:
     name: "Ruby: ${{ matrix.ruby }} OS: ${{ matrix.os }}"
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        ruby: ["2.4", "2.5", "2.6", "2.7"]
+        os: [macos, windows, ubuntu]
+        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Select Ruby Version
-        uses: eregon/use-ruby-action@master
+        uses: MSP-Greg/setup-ruby-pkgs@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          base: update
-      - name: Update RubyGems & Bundler
-        run: gem update --system --no-document --conservative
+          mingw: _upgrade_
       - name: Install Dependencies
         run: bundle install --jobs=3 --retry=3
       - name: Run Test


### PR DESCRIPTION
# Description

Actions CI changes

1. Added Ruby 2.2 & 2.3
2. Updated macOS & Ubuntu action
3. Split Windows and use action for build tools activation
4. Removed RubyGems & Bundler update code. Actions code installs both

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
