### PR TITLE
Fix rdoc generation for Ruby 1.9 variants

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -412,7 +412,7 @@ module YARD
         end
 
         def on_dyna_symbol(sym)
-          rng = if sym.source_range.size == 0 # rubocop:disable Style/ZeroLengthPredicate
+          rng = if sym.source_range.to_a.size == 0 # rubocop:disable Style/ZeroLengthPredicate
                   (sym.source_range.begin - 3)...sym.source_range.end
                 else
                   (sym.source_range.begin - 2)..(sym.source_range.end + 1)
@@ -612,7 +612,7 @@ module YARD
 
         def insert_comments
           root.traverse do |node|
-            next if %i{comment void_stmt list}.include?(node.type) || node.parent.type != :list
+            next if [:comment, :void_stmt, :list].include?(node.type) || node.parent.type != :list
 
             # never attach comments to if/unless mod nodes
             if node.type == :if_mod || node.type == :unless_mod


### PR DESCRIPTION
# Description

Yard supports Ruby > 0 but rdoc documentation generation fails for Ruby 1.9. `%i` symbols didn't exist in Ruby 1.9 so this change uses an array of symbols explicitly instead. Also, the `Range` class in Ruby 1.9 did not have a `#size` method, so where we are checking size on those, convert it to an array first. Unfortunately some hard to migrate Amazon internal tooling still uses old Ruby variants. For testing, I ran `bundle exec rake` for 2.6.5, and internally, I tested that documentation is generated for Ruby 1.9 packages.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
