### PR TITLE
Add `:with_toc_data` to redcarpet configs

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -81,9 +81,13 @@ module YARD
         if provider.to_s == 'RDiscount'
           provider.new(text, :autolink).to_html
         elsif provider.to_s == 'RedcarpetCompat'
-          provider.new(text, :no_intraemphasis, :gh_blockcode,
-                             :fenced_code, :autolink, :tables,
-                             :lax_spacing).to_html
+          provider.new(text, :autolink,
+                             :fenced_code,
+                             :gh_blockcode,
+                             :lax_spacing,
+                             :tables,
+                             :with_toc_data,
+                             :no_intraemphasis).to_html
         else
           provider.new(text).to_html
         end

--- a/spec/templates/markup_processor_integrations/redcarpet_spec.rb
+++ b/spec/templates/markup_processor_integrations/redcarpet_spec.rb
@@ -40,6 +40,10 @@ MARKDOWN
     expect(rendered_document).to match(header_regexp(2, 'Example code listings'))
   end
 
+  it 'generates anchor tags for level 2 header' do
+    expect(rendered_document).to include('<h2 id="example-code-listings">Example code listings</h2>')
+  end
+
   it 'renders indented block of code, and applies Ruby syntax highlight' do
     expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '1'))
   end


### PR DESCRIPTION
This will autogenerate id tags for headers. Without headers the javascript in the default template will generate ids, but uses a different algorithm that doesn't match what github does. The javascript will leave existing ids alone, so if the default redcarpet markdown renderer is used the ids will match what github does and it will be possible to reference anchor tags in a way that works both on github and when rendered via a yard server.

# Description

Describe your pull request and problem statement here.

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
