### PR TITLE
Add .gitattributes with line-ending rule

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Auto detect text files and perform LF normalization
+* text eol=lf


### PR DESCRIPTION
# Description

  - avoids "EOL issue, ie CRLF vs LF" by adding a .gitattributes file with a rule
  - see #1328

[GitHub article on line endings & git](https://help.github.com/en/github/using-git/configuring-git-to-handle-line-endings).

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] ~I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).~

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
