### PR TITLE
Add shell comments support in yardopts file

### DIFF
--- a/lib/yard/cli/yardopts_command.rb
+++ b/lib/yard/cli/yardopts_command.rb
@@ -69,7 +69,8 @@ module YARD
       # @return [Array<String>] an array of options parsed from .yardopts
       def yardopts(file = options_file)
         return [] unless use_yardopts_file
-        File.read_binary(file).shell_split
+
+        File.read_binary(file).lines.reject { |line| line.strip =~ /^#/ }.join.shell_split
       rescue Errno::ENOENT
         []
       end


### PR DESCRIPTION
# Description

Add shell comments support in ``.yardopts`` file.

For example you can write a ``.yardopts`` like this :

```sh
# vim: ft=sh

lib/**/*.rb                                   \
    --no-progress                             \
    --markup-provider 'redcarpet'             \
    --markup 'markdown'                       \
    --charset 'utf-8'                         \
    --protected --private --embed-mixins      \
    --tag type:'type' --hide-tag 'type'       \
    --readme README.md                        \
    --exclude '/\\.#'

# Local Variables:
# mode: sh
# End:
```

Before modifications, comments are split as arguments, for example in:
https://github.com/lsegal/yard/blob/84c983da9157ab7a6eccbc7a1740f2e22c05b679/lib/yard/cli/yardoc.rb#L296
They are seen as:

```ruby
["vim:", "ft=sh", "lib/**/*.rb", "#", "Local", "Variables:", "#", "mode:", "sh", "#", "End:"]
```

Instead of: 

```ruby
[ "lib/**/*.rb"]
```

# Completed Tasks

* [x] I have read the [Contributing Guide][contrib].
* [x] The pull request is complete (implemented / written).
* [x] Git commits have been cleaned up (squash WIP / revert commits).
* [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

ATM I don't know how to write a test (in this present context). Cuse there is no example IMHO : 

```sh 
grep -FRin 'yardopts(' spec/
```

[contrib]: https://github.com/lsegal/yard/blob/master/CONTRIBUTING.md
