### PR TITLE
Prevent footer from being partially hidden on Firefox

### DIFF
--- a/templates/default/fulldoc/html/css/style.css
+++ b/templates/default/fulldoc/html/css/style.css
@@ -52,6 +52,7 @@ body {
   background: #fff;
   padding: 1.2em;
   padding-top: 0.2em;
+  box-sizing: border-box;
 }
 
 @media (max-width: 920px) {


### PR DESCRIPTION
# Description

I noticed that the footer is partially hidden in Firefox but not in Chrome. This patch make the footer fully visible.

![Jul-28-2020 14-41-14](https://user-images.githubusercontent.com/8417720/88666792-d7344480-d0e0-11ea-8a13-a2cccc8bdf0d.gif)


# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
