### PR TITLE
Update type notation for MethodObject#aliases

### DIFF
--- a/lib/yard/code_objects/method_object.rb
+++ b/lib/yard/code_objects/method_object.rb
@@ -145,7 +145,7 @@ module YARD::CodeObjects
     end
 
     # Returns all alias names of the object
-    # @return [Array<Symbol>] the alias names
+    # @return [Array<MethodObject>] the alias names
     def aliases
       list = []
       return list unless namespace.is_a?(NamespaceObject)


### PR DESCRIPTION
# Description

I was generating some stubs from the Yard database, and doing by the docs I thought `MethodObject#aliases` returned an array of `Symbol`, but the output included the fully qualified name. Upon inspection I found that the method actually returns an array of `MethodObject`.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
