### PR TITLE
Support module_function decorator

### DIFF
--- a/lib/yard/handlers/ruby/module_function_handler.rb
+++ b/lib/yard/handlers/ruby/module_function_handler.rb
@@ -2,6 +2,8 @@
 # Handles module_function calls to turn methods into public class methods.
 # Also creates a private instance copy of the method.
 class YARD::Handlers::Ruby::ModuleFunctionHandler < YARD::Handlers::Ruby::Base
+  include YARD::Handlers::Ruby::DecoratorHandlerMethods
+
   handles method_call(:module_function)
   namespace_only
 
@@ -13,15 +15,25 @@ class YARD::Handlers::Ruby::ModuleFunctionHandler < YARD::Handlers::Ruby::Base
     when :fcall, :command
       statement[1].traverse do |node|
         case node.type
+        when :def
+          process_decorator do |instance_method|
+            make_module_function(instance_method, namespace)
+          end
+          break
         when :symbol; name = node.first.source
         when :string_content; name = node.source
         else next
         end
+
         instance_method = MethodObject.new(namespace, name)
-        class_method = MethodObject.new(namespace, name, :module)
-        instance_method.copy_to(class_method)
-        class_method.visibility = :public
+        make_module_function(instance_method, namespace)
       end
     end
+  end
+
+  def make_module_function(instance_method, namespace)
+    class_method = MethodObject.new(namespace, instance_method.name, :module)
+    instance_method.copy_to(class_method)
+    class_method.visibility = :public
   end
 end

--- a/spec/handlers/module_function_handler_spec.rb
+++ b/spec/handlers/module_function_handler_spec.rb
@@ -44,6 +44,21 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}Visibili
     assert_module_function('Foo', 'baz')
   end
 
+  it "can decorate a method definition" do
+    YARD.parse_string <<-eof
+      module Foo
+        def qux; end
+
+        module_function def bar; end
+
+        def baz; end
+      end
+    eof
+    expect(Registry.at('Foo.qux')).to be nil
+    assert_module_function('Foo', 'bar')
+    expect(Registry.at('Foo.baz')).to be nil
+  end
+
   # @bug gh-563
   it "copies tags to module function properly" do
     YARD.parse_string <<-eof


### PR DESCRIPTION
# Description

`module_function` can be used as a decorator likewise `private`.
This pull-request makes yard to support this feature.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
