### PR TITLE
Add existence check for readme

### DIFF
--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -295,9 +295,10 @@ module YARD
         self.files = Parser::SourceParser::DEFAULT_PATH_GLOB if files.empty?
         files.delete_if {|x| x =~ /\A\s*\Z/ } # remove empty ones
         readme = Dir.glob('README{,*[^~]}').
+          select {|f| extra_file_valid?(f)}.
           sort_by {|r| [r.count('.'), r.index('.'), r] }.first
         readme ||= Dir.glob(files.first).first if options.onefile && !files.empty?
-        options.readme ||= CodeObjects::ExtraFileObject.new(readme) if readme
+        options.readme ||= CodeObjects::ExtraFileObject.new(readme) if readme && extra_file_valid?(readme)
         options.files.unshift(options.readme).uniq! if options.readme
 
         Tags::Library.visible_tags -= hidden_tags


### PR DESCRIPTION
# Description

This PR fixes #1366, YARD failing to parse missing symlinked file in gem.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
