### PR TITLE
Warns abount type parsing failures

### DIFF
--- a/lib/yard/tags/types_explainer.rb
+++ b/lib/yard/tags/types_explainer.rb
@@ -8,7 +8,8 @@ module YARD
       # @param types [Array<String>] a list of types to parse and summarize
       def self.explain(*types)
         explain!(*types)
-      rescue SyntaxError
+      rescue SyntaxError => e
+        log.warn "Cannot parse `#{types.join(", ")}`:#{e.message}"
         nil
       end
 

--- a/spec/tags/types_explainer_spec.rb
+++ b/spec/tags/types_explainer_spec.rb
@@ -199,5 +199,11 @@ RSpec.describe YARD::Tags::TypesExplainer do
         expect(explain).to eq expected.delete("\n").squeeze(' ')
       end
     end
+
+    it "warns about parsing failures" do
+      expect(log).to receive(:warn).with(/\ACannot parse.+String or Proc/)
+      explain = YARD::Tags::TypesExplainer.explain("String or Proc")
+      expect(explain).to be_nil
+    end
   end
 end


### PR DESCRIPTION
# Description

I found a type syntax bug in rspec documentation as https://github.com/rspec/rspec-expectations/pull/1292.
Then I checked the behavior in https://yardoc.org/types.html, but that did not report anything. So created PR as  https://github.com/lsegal/yardoc.org/pull/11.
And I think, if running `yard` reports warnings, it helps these accidents.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
