### PR TITLE
Update CI depending Ruby 3.0 from the rc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
   build_ruby3:
     name: "Ruby: 3.0 OS: Linux"
     runs-on: ubuntu-latest
-    container: ruby:3.0-rc-alpine
+    container: ruby:3.0-alpine
     steps:
       - uses: actions/checkout@v2
       - run: apk add -U build-base


### PR DESCRIPTION
# Description

Using rc version is applied in https://github.com/lsegal/yard/pull/1364, but already released `3.0` without rc

<img width="1362" alt="スクリーンショット 2021-02-20 13 40 42" src="https://user-images.githubusercontent.com/1180335/108584102-e54df900-7381-11eb-825c-48d8dfaa9384.png">
<img width="1450" alt="スクリーンショット 2021-02-20 13 41 00" src="https://user-images.githubusercontent.com/1180335/108584103-e7b05300-7381-11eb-91db-be97785d228c.png">

It might fix Segmentation fault as https://github.com/lsegal/yard/runs/1940341250 ? 🤔 
=> I think No... `docker container run --user=root --volume="$(pwd)/:/usr/src/" --workdir='/usr/src/' -it 'ruby:3.0' '/bin/bash'` reproduce it once.

# Completed Tasks

- [ ] I have read the [Contributing Guide][contrib].
- [ ] The pull request is complete (implemented / written).
- [ ] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
