### PR TITLE
Prefer `coveralls-ruby-reborn` to fix coverage bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem 'json'
   gem 'simplecov'
   gem 'samus', '~> 3.0.9', :require => false
-  gem 'coveralls', :require => false
+  gem 'coveralls_reborn', '~> 0.20.0', require: false
   gem 'webrick'
 end
 

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,11 @@ group :development do
   gem 'json'
   gem 'simplecov'
   gem 'samus', '~> 3.0.9', :require => false
-  gem 'coveralls_reborn', '~> 0.20.0', require: false
+  if RUBY_VERSION < '2.4'
+    gem 'coveralls', :require => false
+  else
+    gem 'coveralls_reborn', '~> 0.20.0', require: false
+  end
   gem 'webrick'
 end
 


### PR DESCRIPTION
https://github.com/lsegal/yard/runs/1871056160 is passed, but coverage is fault

```
Coveralls encountered an exception:
NoMethodError
undefined method `coverage' for #<SimpleCov::SourceFile:0x000055b355942bc8 @filename="/__w/yard/yard/docs/templates/plugin.rb", @coverage_data={"lines"=>[nil, 1, 1, nil, 1, 1, 0, nil, nil, 1, 0, nil, nil, 1, 0, nil, nil, 1, 0, nil, nil, 1, 0, 0, nil, nil, nil, nil, 1, 2, 0, nil, nil, 0, 0, 0, 0, 0, nil, 0, nil, nil, nil, nil, 1, 90, 46, nil, 0, nil, 0, 0, 0, 0, 0, nil, nil, 0, 0, nil, 0, 0, nil, nil, 90, nil, nil, nil, 1, 1]}>
Did you mean?  coverage_data
/usr/local/bundle/gems/coveralls-0.7.2/lib/coveralls/simplecov.rb:50:in `block in format'
/usr/local/lib/ruby/3.0.0/forwardable.rb:238:in `each'
/usr/local/lib/ruby/3.0.0/forwardable.rb:238:in `each'
/usr/local/bundle/gems/coveralls-0.7.2/lib/coveralls/simplecov.rb:40:in `format'
/usr/local/bundle/gems/simplecov-0.21.2/lib/simplecov/result.rb:51:in `format!'
/usr/local/bundle/gems/simplecov-0.21.2/lib/simplecov/configuration.rb:197:in `block in at_exit'
/usr/local/bundle/gems/simplecov-0.21.2/lib/simplecov.rb:189:in `run_exit_tasks!'
/usr/local/bundle/gems/simplecov-0.21.2/lib/simplecov.rb:179:in `at_exit_behavior'
/usr/local/bundle/gems/simplecov-0.21.2/lib/simplecov/defaults.rb:30:in `block in <top (required)>'
```

And it *sometimes* makes segfault in ruby 3.0 🤔 

```sh
docker container run --user=root --volume="$(pwd)/:/usr/src/" --workdir='/usr/src/' -it 'ruby:3.0' '/bin/bash'
```

```
root@94086923f7e2:/usr/src# ruby -v; CI=true bundle exec rspec
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-linux]
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
....................................................................................................../usr/src/docs/templates/plugin.rb:45: [BUG] Segmentation fault at 0x0000000000000067
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-linux]
```

And result of https://github.com/lsegal/yard/runs/1940341250
But can not reproduce every time.

I saw https://github.com/lemurheavy/coveralls-ruby/issues/161, https://github.com/lemurheavy/coveralls-ruby/issues/130 and changed the gem. 
After this change, it passed.

```
root@94086923f7e2:/usr/src# ruby -v; CI=true bundle exec rspec
ruby 3.0.0p0 (2020-12-25 revision 95aff21468) [x86_64-linux]
[Coveralls] Set up the SimpleCov formatter.
[Coveralls] Using SimpleCov's default settings.
[Coveralls] Submitting to https://coveralls.io/api/v1
[Coveralls] Couldn't find a repository matching this job.
Coverage is at 93.38%.
Coverage report sent to Coveralls.
```

