### PR TITLE
Support endless method definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+- Add support for Ruby 3.0 endless method definitions. (#1376)
+
 # 0.9.26 - December 26th, 2020
 
 [0.9.26]: https://github.com/lsegal/yard/compare/v0.9.25...v0.9.26

--- a/lib/yard.rb
+++ b/lib/yard.rb
@@ -48,6 +48,9 @@ module YARD
 
   # @return [Boolean] whether YARD is being run in Ruby 2.0
   def self.ruby2?; @ruby2 ||= (RUBY_VERSION >= '2.0.0') end
+
+  # @return [Boolean] whether YARD is being run in Ruby 3.0
+  def self.ruby3?; @ruby3 ||= (RUBY_VERSION >= '3.0.0') end
 end
 
 # Keep track of Ruby version for compatibility code

--- a/lib/yard/handlers/ruby/method_handler.rb
+++ b/lib/yard/handlers/ruby/method_handler.rb
@@ -67,7 +67,7 @@ class YARD::Handlers::Ruby::MethodHandler < YARD::Handlers::Ruby::Base
   end
 
   def format_args
-    args = statement.parameters
+    return [] unless args = statement.parameters
 
     params = []
 

--- a/lib/yard/parser/ruby/ast_node.rb
+++ b/lib/yard/parser/ruby/ast_node.rb
@@ -480,7 +480,7 @@ module YARD
         end
 
         def parameters(include_block_param = true)
-          params = self[1 + index_adjust]
+          return unless params = self[1 + index_adjust]
           params = params[0] if params.type == :paren
           include_block_param ? params : params[0...-1]
         end
@@ -488,7 +488,7 @@ module YARD
         def signature
           params_src = ''
           params = self[1 + index_adjust]
-          if params.first
+          if params and params.first
             params_src = params.type == :paren ? '' : ' '
             params_src += params.source.gsub(/\s+(\s|\))/m, '\1')
           end

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -62,6 +62,26 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHa
     expect(P('Bar#multiline_params').signature).to eq sig
   end if YARD.ruby2?
 
+  it "handles endless method definitions without parameters" do
+    YARD.parse_string <<-EOF
+      class Bar
+        def endless = true
+      end
+    EOF
+
+    expect(P('Bar#endless').signature).to eq "def endless"
+  end if YARD.ruby3?
+
+  it "handles endless method definitions with parameters" do
+    YARD.parse_string <<-EOF
+      class Bar
+        def endless_with_arg(arg = true) = true
+      end
+    EOF
+
+    expect(P('Bar#endless_with_arg').signature).to eq "def endless_with_arg(arg = true)"
+  end if YARD.ruby3?
+
   it "handles method signature with no parameters" do
     YARD.parse_string "class Bar; def foo; end end"
     expect(P('Bar#foo').signature).to eq 'def foo'


### PR DESCRIPTION
# Description

Ruby 3.0 introduces endless method definitions:

``` ruby
def method = "return value"
```

This raises an exception in YARD, as the Ruby parser never calls `on_params`, thus there is no `ParameterNode` inside the method definition (see #1376). I've adjusted the code slightly to be able to handle this case.

I've added a test and have also confirmed on a real world project that with this change YARD correctly handles endless method definitions without parameters.

Endless method definitions with parameters were already supported. I've also added a test for them, as there was none.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
