### PR TITLE
Remove deprecated RUBY19 and RUBY18 top level constants

### DIFF
--- a/lib/yard.rb
+++ b/lib/yard.rb
@@ -53,11 +53,6 @@ module YARD
   def self.ruby3?; @ruby3 ||= (RUBY_VERSION >= '3.0.0') end
 end
 
-# Keep track of Ruby version for compatibility code
-# @deprecated Use {YARD.ruby18?} or {YARD.ruby19?} instead.
-RUBY18 = YARD.ruby18?
-RUBY19 = YARD.ruby19?
-
 # Load Ruby core extension classes
 Dir.glob(File.join(YARD::ROOT, 'yard', 'core_ext', '*.rb')).each do |file|
   require file


### PR DESCRIPTION
They have been deprecated 9 years ago: https://github.com/lsegal/yard/commit/706c9f5f325f3f722f4c59db4e515da027499ea9
