### PR TITLE
GitHub Actions - misc updates, test Ruby 2.2 thru 3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: Unit Tests
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 jobs:
   build:
     name: "Ruby: ${{ matrix.ruby }} OS: ${{ matrix.os }}"
@@ -8,35 +8,23 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [macos-latest, windows-latest, ubuntu-latest]
-        ruby: ["2.4", "2.5", "2.6", "2.7"]
+        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        # 3.0 is interpreted as 3
+        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0"]
+        exclude:
+          - { os: windows-2019 , ruby: 2.2 }
+          - { os: windows-2019 , ruby: 2.3 }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Select Ruby Version
-        uses: eregon/use-ruby-action@master
+      - name: Install Ruby & 'bundle install'
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          base: update
-      - name: Update RubyGems & Bundler
-        run: gem update --system --no-document --conservative
-      - name: Install Dependencies
-        run: bundle install --jobs=3 --retry=3
+          bundler-cache: true
       - name: Run Test
         run: |
           ruby -v
           bundle exec rake
-        env:
-          CI: true
-  build_ruby3:
-    name: "Ruby: 3.0 OS: Linux"
-    runs-on: ubuntu-latest
-    container: ruby:3.0-alpine
-    steps:
-      - uses: actions/checkout@v2
-      - run: apk add -U build-base
-      - run: gem update --system --no-document --conservative
-      - run: bundle install --jobs=3 --retry=3
-      - run: ruby -v && bundle exec rake
         env:
           CI: true


### PR DESCRIPTION
# Description

1. eregon/use-ruby-action has been replaced with ruby/setup-ruby
2. Update to install bundler and cache 'bundle install' gems
3. Test Ruby 2.2 thru 3.0, exclude Windows 2.2 & 2.3 (old build tools)
4. Remove OS 'latest', replace with numeric
5. Add 'workflow_dispatch', which allows owners/maintainers to run CI on a specific branch.

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
