### PR TITLE
Config.read_config_file - use safe_load_file if available

### DIFF
--- a/lib/yard/config.rb
+++ b/lib/yard/config.rb
@@ -236,7 +236,11 @@ module YARD
     def self.read_config_file
       if File.file?(CONFIG_FILE)
         require 'yaml'
-        YAML.load_file(CONFIG_FILE)
+        if YAML.respond_to?(:safe_load_file)
+          YAML.safe_load_file(CONFIG_FILE, permitted_classes: [SymbolHash, Symbol])
+        else
+          YAML.load_file(CONFIG_FILE)
+        end
       else
         {}
       end

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -17,7 +17,13 @@ RSpec.describe YARD::Config do
     it "overwrites options with data in ~/.yard/config" do
       expect(File).to receive(:file?).with(YARD::Config::CONFIG_FILE).and_return(true)
       expect(File).to receive(:file?).with(YARD::Config::IGNORED_PLUGINS).and_return(false)
-      expect(YAML).to receive(:load_file).with(YARD::Config::CONFIG_FILE).and_return('test' => true)
+      if YAML.respond_to?(:safe_load_file)
+        expect(YAML).to receive(:safe_load_file)
+          .with(YARD::Config::CONFIG_FILE, permitted_classes: [SymbolHash, Symbol])
+          .and_return('test' => true)
+      else
+        expect(YAML).to receive(:load_file).with(YARD::Config::CONFIG_FILE).and_return('test' => true)
+      end
       YARD::Config.load
       expect(YARD::Config.options[:test]).to be true
     end


### PR DESCRIPTION
# Description

Psych 4+ may change load_file behavior. Noticed this issue running YARD with Ruby master/main/head build, as it recently crashed.

Also, using `Psych.safe_load_file` when available is probably better from a security standpoint...

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I ran `bundle exec rake` locally (if code is attached to PR) and ran CI in my fork.

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
