### PR TITLE
Fix nested array parsing

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -370,7 +370,7 @@ module YARD
 
         def on_aref(*args)
           @map[:lbracket].pop
-          ll, lc = *@map[:aref].pop
+          ll, lc = *@map[:aref].shift
           sr = args.first.source_range.first..lc
           lr = args.first.line_range.first..ll
           AstNode.new(:aref, args, :char => sr, :line => lr)

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -213,6 +213,9 @@ eof
 
       ast = stmt('def x(a = S[1]) end').jump(:params)
       expect(ast.source).to eq 'a = S[1]'
+
+      ast = stmt('a[b[c]]')
+      expect(ast.source).to eq 'a[b[c]]'
     end
 
     it "ends source properly on if/unless mod" do


### PR DESCRIPTION
# Description

Prior to this change, nested arrays would be missing closing brackets when translating back to source code, e.g.:
```
[1] pry(main)> YARD::Parser::Ruby::RubyParser.new('a[b[c]]', nil).parse.root.first.source
=> "a[b[c]"
```

This in turn would print warnings in YARD output, and result in documentation errors. Example warnings:
```
[warn]: Syntax error in `(stdin)`:(1,96): syntax error, unexpected end-of-input, expecting ']'
[warn]: ParserSyntaxError: syntax error in `(stdin)`:(1,96): syntax error, unexpected end-of-input, expecting ']'
```

This change corrects this specific problem. All tests pass, but this is a naïve fix, and I'm not familiar enough with this code to contemplate other potential side effects.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
