### PR TITLE
fix: replace calls to toggle(fn, fn) with click(fn)

### DIFF
--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -7,44 +7,46 @@ try { sessionStorage = window.sessionStorage; } catch (e) { }
 function createSourceLinks() {
     $('.method_details_list .source_code').
         before("<span class='showSource'>[<a href='#' class='toggleSource'>View source</a>]</span>");
-    $('.toggleSource').toggle(function() {
-       $(this).parent().nextAll('.source_code').slideDown(100);
-       $(this).text("Hide source");
-    },
-    function() {
+    $('.toggleSource').click(function() {
+      if ($(this).text() === "View source") {
+        $(this).parent().nextAll('.source_code').slideDown(100);
+        $(this).text("Hide source");
+      } else {
         $(this).parent().nextAll('.source_code').slideUp(100);
         $(this).text("View source");
+      }
     });
 }
 
 function createDefineLinks() {
     var tHeight = 0;
     $('.defines').after(" <a href='#' class='toggleDefines'>more...</a>");
-    $('.toggleDefines').toggle(function() {
+    $('.toggleDefines').click(function() {
+      if ($(this).text() === "more...") {
         tHeight = $(this).parent().prev().height();
         $(this).prev().css('display', 'inline');
         $(this).parent().prev().height($(this).parent().height());
         $(this).text("(less)");
-    },
-    function() {
+      } else {
         $(this).prev().hide();
         $(this).parent().prev().height(tHeight);
         $(this).text("more...");
+      }
     });
 }
 
 function createFullTreeLinks() {
     var tHeight = 0;
-    $('.inheritanceTree').toggle(function() {
+    $('.inheritanceTree').click(function() {
+      if($(this).text() === "show all") {
         tHeight = $(this).parent().prev().height();
-        $(this).parent().toggleClass('showAll');
         $(this).text("(hide)");
         $(this).parent().prev().height($(this).parent().height());
-    },
-    function() {
-        $(this).parent().toggleClass('showAll');
+      } else {
         $(this).parent().prev().height(tHeight);
         $(this).text("show all");
+      }
+      $(this).parent().toggleClass('showAll');
     });
 }
 
@@ -216,14 +218,14 @@ function generateTOC() {
   html = '<div id="toc"><p class="title hide_toc"><a href="#"><strong>Table of Contents</strong></a></p></div>';
   $('#content').prepend(html);
   $('#toc').append(_toc);
-  $('#toc .hide_toc').toggle(function() {
-    $('#toc .top').slideUp('fast');
-    $('#toc').toggleClass('hidden');
-    $('#toc .title small').toggle();
-  }, function() {
-    $('#toc .top').slideDown('fast');
-    $('#toc').toggleClass('hidden');
-    $('#toc .title small').toggle();
+  $('#toc .title.hide_toc').click(function() {
+    if ($(this).parent().hasClass('hidden')) {
+      $(this).next().slideDown('fast');
+    } else {
+      $(this).next().slideUp('fast');
+    }
+    $(this).parent().toggleClass('hidden');
+    $(this).find('small').toggle();
   });
 }
 


### PR DESCRIPTION
# Background

The API `.toggle(fn, fn)` [was removed](https://jquery.com/upgrade-guide/1.9/#changes-of-note-in-jquery-1-9) in jQuery v1.9.x

While bumping jQuery to v3.6.0 in https://github.com/lsegal/yard/pull/1397, we noticed that jquery-migrate does not provide 100% wrapper for `.toggle(fn, fn)`
* API reference preview: https://lsegal-yard-jquery-bump-no-edits.netlify.app/
* <details>
  <summary>TOC hides on load</summary>

  https://user-images.githubusercontent.com/16024985/131713399-a4c58c17-ffcb-49ab-a5e9-5b2e8067a866.mov

  </details>

Discussion in comment: https://github.com/lsegal/yard/pull/1397#discussion_r700425695

# Description

This PR changes calls of `.toggle(fn, fn)` with `.click(fn)` so that the users who want to upgrade jQuery can replace `jquery.js` vendored by YARD.

# Testing
I verified that replacing toggle with click does not break existing functionality in jQuery 1.7.1

API reference preview: https://lsegal-yard-replace-toggle-with-click.netlify.app/
* The jQuery version is `"1.7.1"`, verified by running `$.fn.jquery` in Console.
* Screen recordings:
  * <details>
    <summary>Table of Contents on landing page</summary>

    https://user-images.githubusercontent.com/16024985/131574652-39808355-b4e5-43ba-918d-37459158e1de.mov

    </details>

  * <details>
    <summary>Inheritance tree on Array page.</summary>

    https://user-images.githubusercontent.com/16024985/131574907-bf3d318e-fa61-4201-95ea-020db86875a3.mov

    </details>
  * <details>
    <summary>Source above footer on Array page.</summary>

    https://user-images.githubusercontent.com/16024985/131574943-d3a06add-7ab9-4c24-be15-091e5b51aa59.mov

    </details>
  * <details>
    <summary>Defines on Module: YARD::Handlers::Ruby page.</summary>

    https://user-images.githubusercontent.com/16024985/131583803-f222164c-f1f5-452e-94b9-00f6114f798d.mov

    </details>

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
