### PR TITLE
Add webrick as runtime dependency

### DIFF
--- a/yard.gemspec
+++ b/yard.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |s|
   s.executables   = ['yard', 'yardoc', 'yri']
   s.license = 'MIT' if s.respond_to?(:license=)
   s.metadata['yard.run'] = 'yri'
+
+  s.add_runtime_dependency 'webrick', '~> 1.7.0'
 end


### PR DESCRIPTION
# Description

WEBrick was removed as a core library in Ruby 3.0

Fixes #1387

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
