### PR TITLE
Fix duplicate terminal punctuation in summary

### DIFF
--- a/lib/yard/docstring.rb
+++ b/lib/yard/docstring.rb
@@ -192,7 +192,9 @@ module YARD
         end
       end
       @summary = stripped[0..idx]
-      if !@summary.empty? && @summary !~ /\A\s*\{include:.+\}\s*\Z/
+      if !@summary.empty? &&
+         @summary !~ /\A\s*\{include:.+\}\s*\Z/ && # Summary is copied using +{include:...}+
+         @summary !~ /[!?]\s*\Z/ # Summary ends in a terminal punctuation
         @summary += '.'
       end
       @summary

--- a/spec/docstring_spec.rb
+++ b/spec/docstring_spec.rb
@@ -94,6 +94,14 @@ RSpec.describe YARD::Docstring do
       Registry.clear
     end
 
+    it "does not attach period if summary ends with '?'" do
+      expect(Docstring.new("Is this object correctly configured?").summary).to eq "Is this object correctly configured?"
+    end
+
+    it "does not attach period if summary ends with '!'" do
+      expect(Docstring.new("Invoke this method first!").summary).to eq "Invoke this method first!"
+    end
+
     it "handles references embedded in summary" do
       expect(Docstring.new("Aliasing {Test.test}. Done.").summary).to eq "Aliasing {Test.test}."
     end

--- a/spec/templates/examples/class001.html
+++ b/spec/templates/examples/class001.html
@@ -150,7 +150,7 @@ Comments
   
 
   
-    <span class="summary_desc"><div class='inline'>constructor method!.</div></span>
+    <span class="summary_desc"><div class='inline'>constructor method!</div></span>
   
 </li>
 


### PR DESCRIPTION
# Description

This PR prevents YARD from adding a period (`.`) to the end of sentences that already end in a terminal punctuation character: `.`, `?`, or `!`.

This is specially helpful for methods in Ruby that end with a `?`, as they normally convey an interrogation:

```ruby
# Has this object been successfully configured for use?
def ready?
  # ...
end
```

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [ x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
