### PR TITLE
Handle empty string param in method helper

### DIFF
--- a/lib/yard/templates/helpers/method_helper.rb
+++ b/lib/yard/templates/helpers/method_helper.rb
@@ -66,7 +66,9 @@ module YARD
 
       # @return [String] formats source code of a constant value
       def format_constant(value)
-        sp = value.split("\n").last[/^(\s+)/, 1]
+        # last can return nil, so default to empty string
+        sp = value.split("\n").last || ""
+        sp = sp[/^(\s+)/, 1]
         num = sp ? sp.size : 0
         html_syntax_highlight value.gsub(/^\s{#{num}}/, '')
       end

--- a/spec/templates/helpers/method_helper_spec.rb
+++ b/spec/templates/helpers/method_helper_spec.rb
@@ -103,5 +103,17 @@ RSpec.describe YARD::Templates::Helpers::MethodHelper do
       expect(format_constant(bar)).to eq ':BAR'
       expect(format_constant(baz)).to eq ":&#39;B+z&#39;"
     end
+
+    context "when an empty string is passed as param" do
+      it "returns an empty string" do
+        # html_syntax_highlight will be called by format_constant
+        # and in turn will enquire for options.highlight
+        expect(self).to receive(:options).once.and_return(
+          Options.new.update(:highlight => false)
+        )
+
+        expect(format_constant("")).to eq ""
+      end
+    end
   end
 end


### PR DESCRIPTION
# Description

Hi, I'm using YARD in combination with yard-cucumber to document a company internal GEM.  When I ran YARD I got a nil pointer exception
```
1) YARD::Templates::Helpers::MethodHelper#format_constant when a empty string is passed as param
     Failure/Error: sp = value.split("\n").last[/^(\s+)/, 1]

     NoMethodError:
       undefined method `[]' for nil:NilClass
     # ./lib/yard/templates/helpers/method_helper.rb:70:in `format_constant'
     # ./spec/templates/helpers/method_helper_spec.rb:115:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:127:in `block (2 levels) in <top (required)>'
```

The problem is that somewhere an empty string is being passed to MethodHelper#format. 

This PR fixes that issue with the most simple solution I could think of. If Array#last returns nil, default to an empty string.
I've also extended the MethodHelper spec to cover this case.

# My current environment
* ruby 3.0.2
* OS X 12.0.1 Monterey

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
