### PR TITLE
Only call Object#taint when the taint method exists

### DIFF
--- a/lib/yard/cli/stats.rb
+++ b/lib/yard/cli/stats.rb
@@ -225,7 +225,8 @@ module YARD
         end
 
         opts.on('--query QUERY', "Only includes objects that match a specific query") do |query|
-          options[:verifier].add_expressions(query.taint)
+          query.taint if query.respond_to?(:taint)
+          options[:verifier].add_expressions(query)
         end
       end
     end

--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -650,7 +650,8 @@ module YARD
 
         opts.on('--query QUERY', "Only show objects that match a specific query") do |query|
           next if YARD::Config.options[:safe_mode]
-          options.verifier.add_expressions(query.taint)
+          query.taint if query.respond_to?(:taint)
+          options.verifier.add_expressions(query)
         end
 
         opts.on('--title TITLE', 'Add a specific title to HTML documents') do |title|

--- a/lib/yard/templates/template.rb
+++ b/lib/yard/templates/template.rb
@@ -176,7 +176,9 @@ module YARD
         def load_setup_rb
           setup_file = File.join(full_path, 'setup.rb')
           if File.file? setup_file
-            module_eval(File.read(setup_file).taint, setup_file, 1)
+            setup_code = File.read(setup_file)
+            setup_code.taint if setup_code.respond_to?(:taint)
+            module_eval(setup_code, setup_file, 1)
           end
         end
       end


### PR DESCRIPTION
# Description

Running YARD with Ruby 3.2 (current Ruby HEAD) results in the error:

```
$ rake yard
NoMethodError: undefined method `taint' for "# frozen_string_literal: true\n...":String

            module_eval(File.read(setup_file).taint, setup_file, 1)
                                             ^^^^^^

/home/runner/work/ruby-git/ruby-git/vendor/bundle/ruby/3.2.0/gems/yard-0.9.27/lib/yard/templates/template.rb:179:in `load_setup_rb'
```

This is because the `taint` mechanism, which was deprecated in Ruby 2.7 is to be removed from Ruby 3.2.  In Ruby 2.7, the taint checking functionality was removed and `Object#taint`, `Object#trust`, `Object#untaint`, `Object#untrust` and related methods have no-op implementations. This means all objects by default are deemed untainted.

In Ruby 3.2 (the current HEAD), `Object#taint`, `Object#trust`, `Object#untaint`, `Object#untrust` are completely removed.

See the article [Ruby 2.7 removes taint checking mechanism](https://blog.saeloun.com/2020/02/18/ruby-2-7-access-and-setting-of-safe-warned-will-become-global-variable.html) for a summary of the timeline for removal of the taint mechanism and links to Ruby core team discussions.

# Caveats

I ran tests locally after making these changes in Ruby 2.4.x so the CI matrix build will need to be completed to make sure that these changes do not impact tests on all supported versions of Ruby.

# Completed Tasks

- [X] I have read the [Contributing Guide][contrib].
- [X] The pull request is complete (implemented / written).
- [X] Git commits have been cleaned up (squash WIP / revert commits).
- [X] I ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md