### PR TITLE
Add Ruby 3.1 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
         # 3.0 is interpreted as 3
-        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0"]
+        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1]
         exclude:
           - { os: windows-2019 , ruby: 2.2 }
           - { os: windows-2019 , ruby: 2.3 }


### PR DESCRIPTION
# Description

This PR adds Ruby 3.1 to CI matrix.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
