### PR TITLE
Replace coveralls with coveralls_reborn

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ group :development do
   gem 'json'
   gem 'simplecov'
   gem 'samus', '~> 3.0.9', :require => false
-  gem 'coveralls', :require => false
+  gem 'coveralls_reborn', :require => false
   gem 'webrick'
 end
 


### PR DESCRIPTION
# Description

Submitting the coverage report to coveralls fails due to coveralls-ruby.
The following log is taken from https://github.com/lsegal/yard/runs/4694550961?check_suite_focus=true:

```
Coveralls encountered an exception:
NoMethodError
undefined method `coverage' for #<SimpleCov::SourceFile:0x000055a67b90ba88>
Did you mean?  coverage_data
/home/runner/work/yard/yard/vendor/bundle/ruby/2.7.0/gems/coveralls-0.7.2/lib/coveralls/simplecov.rb:50:in `block in format'
/home/runner/work/yard/yard/vendor/bundle/ruby/2.7.0/gems/forwardable-1.3.2/lib/forwardable.rb:238:in `each'
/home/runner/work/yard/yard/vendor/bundle/ruby/2.7.0/gems/forwardable-1.3.2/lib/forwardable.rb:238:in `each'
/home/runner/work/yard/yard/vendor/bundle/ruby/2.7.0/gems/coveralls-0.7.2/lib/coveralls/simplecov.rb:40:in `format'
/home/runner/work/yard/yard/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/simplecov/result.rb:51:in `format!'
/home/runner/work/yard/yard/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/simplecov/configuration.rb:197:in `block in at_exit'
/home/runner/work/yard/yard/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/simplecov.rb:189:in `run_exit_tasks!'
/home/runner/work/yard/yard/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/simplecov.rb:179:in `at_exit_behavior'
/home/runner/work/yard/yard/vendor/bundle/ruby/2.7.0/gems/simplecov-0.21.2/lib/simplecov/defaults.rb:30:in `block in <top (required)>'
```

This PR is based on https://github.com/lemurheavy/coveralls-ruby/issues/161 and replace coveralls-ruby with coveralls-ruby-reborn.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
