### PR TITLE
Add Ruby 3.1 and ruby-head to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
         # 3.0 is interpreted as 3
-        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0"]
+        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, ruby-head]
         exclude:
           - { os: windows-2019 , ruby: 2.2 }
           - { os: windows-2019 , ruby: 2.3 }

--- a/spec/code_objects/base_spec.rb
+++ b/spec/code_objects/base_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe YARD::CodeObjects::Base do
   describe "#format" do
     it "sends object to Templates.render" do
       object = MethodObject.new(:root, :method)
-      expect(Templates::Engine).to receive(:render).with(:x => 1, :object => object, :type => object.type)
+      expect(Templates::Engine).to receive(:render).with({:x => 1, :object => object, :type => object.type})
       object.format :x => 1
     end
 

--- a/spec/templates/helpers/base_helper_spec.rb
+++ b/spec/templates/helpers/base_helper_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe YARD::Templates::Helpers::BaseHelper do
 
     it "passes off to #link_url if argument is recognized as a URL" do
       url = "http://yardoc.org/"
-      expect(self).to receive(:link_url).with(url, nil, :target => '_parent')
+      expect(self).to receive(:link_url).with(url, nil, {:target => '_parent'})
       linkify url
     end
 

--- a/spec/templates/template_spec.rb
+++ b/spec/templates/template_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe YARD::Templates::Template do
     it "renders all sections with options" do
       mod = template(:e).new
       allow(mod).to receive(:render_section) {|section| section.name.to_s }
-      expect(mod).to receive(:add_options).with(:a => 1).and_yield
+      expect(mod).to receive(:add_options).with({:a => 1}).and_yield
       mod.sections :a
       expect(mod.run(:a => 1)).to eq 'a'
     end


### PR DESCRIPTION
# Description

This PR adds Ruby 3.1 and ruby-head to CI.

As part of that change it fixes a few keyword argument issues in the specs - three specs were failing because the arguments passed to `with` were being intepreted as keyword arguments.  Wrapping them in explicit hashes resolved those failures.

I also observed a pre-existing failure to post to Coveralls (for all Rubies) that I did not address.

# Completed Tasks

- [X] I have read the [Contributing Guide][contrib].
- [X] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [X] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
