### PR TITLE
Support ruby 3.1 :args_forward shape change

### DIFF
--- a/lib/yard.rb
+++ b/lib/yard.rb
@@ -51,6 +51,9 @@ module YARD
 
   # @return [Boolean] whether YARD is being run in Ruby 3.0
   def self.ruby3?; @ruby3 ||= (RUBY_VERSION >= '3.0.0') end
+
+  # @return [Boolean] whether YARD is being run in Ruby 3.1
+  def self.ruby31?; @ruby31 ||= (RUBY_VERSION >= '3.1.0') end
 end
 
 # Keep track of Ruby version for compatibility code

--- a/lib/yard/handlers/ruby/method_handler.rb
+++ b/lib/yard/handlers/ruby/method_handler.rb
@@ -97,7 +97,7 @@ class YARD::Handlers::Ruby::MethodHandler < YARD::Handlers::Ruby::Base
       params << ['**' + args.double_splat_param.source, nil]
     end
 
-    params << ['&' + args.block_param.source, nil] if args.block_param
+    params << ['&' + args.block_param.source, nil] if args.block_param && !args.args_forward
 
     params
   end

--- a/lib/yard/parser/ruby/ast_node.rb
+++ b/lib/yard/parser/ruby/ast_node.rb
@@ -426,6 +426,13 @@ module YARD
         def block_param
           self[-1] ? self[-1][0] : nil
         end
+
+        def args_forward
+          # shape is (required, optional, rest, more, keyword, keyword_rest, block)
+          # Ruby 3.1 moves :args_forward from rest to keyword_rest
+          args_index = YARD.ruby31? ? -2 : 2
+          self[args_index].type == :args_forward if self[args_index]
+        end
       end
 
       class MethodCallNode < AstNode

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -72,6 +72,30 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHa
     expect(P('Bar#endless').signature).to eq "def endless"
   end if YARD.ruby3?
 
+  it "handles method with arguments forwarding" do
+    YARD.parse_string <<-EOF
+      class Bar
+        def method_with_forwarding(...)
+          forward_to(...)
+        end
+      end
+    EOF
+
+    expect(P('Bar#method_with_forwarding').signature).to eq "def method_with_forwarding(...)"
+  end
+
+  it "handles method with anonymous block" do
+    YARD.parse_string <<-EOF
+      class Bar
+        def anon_block_method(&)
+          baz(a, &)
+        end
+      end
+    EOF
+
+    expect(P('Bar#anon_block_method').signature).to eq "def anon_block_method(&)"
+  end if YARD.ruby31?
+
   it "handles endless method definitions with parameters" do
     YARD.parse_string <<-EOF
       class Bar


### PR DESCRIPTION
# Description

Currently yard errors when tries to parse method with args forwarding using Ruby 3.1:
```
[error]: NoMethodError: undefined method `source' for "&":String

params << ['&' + args.block_param.source, nil] if args.block_param
  | [error]: Stack trace:
  | /tmp/bundle/ruby/3.1.0/gems/yard-0.9.27/lib/yard/handlers/ruby/method_handler.rb:100:in `format_args'
```

This is happening because Ruby 3.1 changes `params` statement for a method with args forwarding from:
Reference:
https://kddnewton.com/2022/01/08/ripper-changelog-3.1.0.html#argument-forwarding

```ruby
[:params, nil, nil, [:args_forward], nil, nil, nil, nil]
```
to:
```ruby
 [:params, nil, nil, nil, nil, nil, [:args_forward], :&]
```

So the `block_param` wrongly assumes that `:&` is an explicit block argument.
I don't think there is an issue with `block_param` method, the "shape" of the statement stays the same and the last value in the array is references block param, it's just in this particular case the block param is "anonymous" or "implicit" if I may call it like that.

So I'm adding additional `args_forward`  check to avoid processing `:&` block.
`args_forward` method works for both Ruby 3.1 and older versions even though we don't necessarily need it for Ruby lower than 3.1


Also added test for the anonymous block forwarding. It's not related to the issue but I thought it can't hurt having it just in case

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
