### PR TITLE
Handle rspec-mocks 3.10.3 change with "with" syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 source 'https://rubygems.org'
 
 group :development do
-  gem 'rspec'
+  gem 'rspec', '>= 3.11.0'
   gem 'rake'
   gem 'rdoc'
   gem 'json'

--- a/spec/code_objects/base_spec.rb
+++ b/spec/code_objects/base_spec.rb
@@ -249,7 +249,7 @@ RSpec.describe YARD::CodeObjects::Base do
   describe "#format" do
     it "sends object to Templates.render" do
       object = MethodObject.new(:root, :method)
-      expect(Templates::Engine).to receive(:render).with(:x => 1, :object => object, :type => object.type)
+      expect(Templates::Engine).to receive(:render).with({:x => 1, :object => object, :type => object.type})
       object.format :x => 1
     end
 

--- a/spec/templates/helpers/base_helper_spec.rb
+++ b/spec/templates/helpers/base_helper_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe YARD::Templates::Helpers::BaseHelper do
 
     it "passes off to #link_url if argument is recognized as a URL" do
       url = "http://yardoc.org/"
-      expect(self).to receive(:link_url).with(url, nil, :target => '_parent')
+      expect(self).to receive(:link_url).with(url, nil, {:target => '_parent'})
       linkify url
     end
 

--- a/spec/templates/template_spec.rb
+++ b/spec/templates/template_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe YARD::Templates::Template do
     it "renders all sections with options" do
       mod = template(:e).new
       allow(mod).to receive(:render_section) {|section| section.name.to_s }
-      expect(mod).to receive(:add_options).with(:a => 1).and_yield
+      expect(mod).to receive(:add_options).with({:a => 1}).and_yield
       mod.sections :a
       expect(mod.run(:a => 1)).to eq 'a'
     end


### PR DESCRIPTION
rspec-mocks 3.10.3 changed "with" syntax behavior to support
ruby 3 keyword arguments separation:

https://github.com/rspec/rspec-mocks/pull/1394
https://github.com/rspec/rspec-mocks/issues/1460

Fix yard testsuite accordingly.

Fixes #1432

# Description

Describe your pull request and problem statement here.

# Completed Tasks

- [ x] I have read the [Contributing Guide][contrib].
- [ x] The pull request is complete (implemented / written).
- [ x] Git commits have been cleaned up (squash WIP / revert commits).
- [ x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
