### PR TITLE
enable table support for CommonMarker

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -90,7 +90,7 @@ module YARD
                              :with_toc_data,
                              :no_intraemphasis).to_html
         when 'CommonMarker'
-          CommonMarker.render_html(text, %i[DEFAULT GITHUB_PRE_LANG], %i[autolink])
+          CommonMarker.render_html(text, %i[DEFAULT GITHUB_PRE_LANG], %i[autolink table])
         else
           provider.new(text).to_html
         end

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
 
     it "creates tables (markdown specific)" do
       log.enter_level(Logger::FATAL) do
-        supports_table = %w(RedcarpetCompat Kramdown::Document)
+        supports_table = %w(RedcarpetCompat Kramdown::Document CommonMarker)
         unless supports_table.include?(markup_class(:markdown).to_s)
           pending "This test depends on a markdown engine that supports tables"
         end


### PR DESCRIPTION
# Description

In switching from redcarpet to commonmarker, I found pipe-delimited tables did not render. commonmarker supports these and enabling them is a matter of merely adding `:table` to the `extensions` parameter of `CommonMarker.render_html`, and enabling existing tests for this markdown provider.

this was enabled by default for redcarpet long ago in https://github.com/lsegal/yard/pull/765 and I think it is good to do for commonmarker too.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).
  (sort of, I just turned on existing tests)

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
