### PR TITLE
Revert "Disable Ruby 2.5 from CI due to bundler crashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-20.04, macos-10.15, windows-2019]
-        # 3.0 is interpreted as 3. also disable 2.5 due to bundler crashes
-        ruby: [2.2, 2.3, 2.4, 2.6, 2.7, "3.0", 3.1]
+        # 3.0 is interpreted as 3
+        ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1]
         exclude:
-          - { os: windows-2019, ruby: 2.2 }
-          - { os: windows-2019, ruby: 2.3 }
+          - { os: windows-2019 , ruby: 2.2 }
+          - { os: windows-2019 , ruby: 2.3 }
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
# Description

This reverts commit a80a728af430b9b316e20221d69a21db4780af75.

'revisit when fixed'

Fixed by PR #1385

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
