### PR TITLE
gemspec: Avoid including .rubocop.yml

### DIFF
--- a/yard.gemspec
+++ b/yard.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.email         = "lsegal@soen.ca"
   s.homepage      = "http://yardoc.org"
   s.platform      = Gem::Platform::RUBY
-  s.files         = `git ls-files`.strip.split(/\s+/).reject {|f| f.match(%r{^spec/}) }
+  s.files         = `git ls-files`.strip.split(/\s+/).reject {|f| f.match(%r{^spec/}) || f == '.rubocop.yml' }
   s.require_paths = ['lib']
   s.executables   = ['yard', 'yardoc', 'yri']
   s.license = 'MIT' if s.respond_to?(:license=)


### PR DESCRIPTION
# Description

This PR removes a (1) file from the gemspec's `files` directive.

With default settings, a consuming project could inadvertently end up including the directives set up for the Yard project.

Example: a setup where there's a temporary directory with gems inside the app.

```
Error: The `Style/MethodMissingSuper` cop has been removed since it has been superseded by `Lint/MissingSuper`. Please use `Lint/MissingSuper` instead.
(obsolete configuration found in app/views/jasmine/tmp/devbox/gems_inside_the_current_ruby_install/gems/yard-0.9.27/.rubocop.yml, please update it)
```

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
