### PR TITLE
Avoid repeated allocations of node-type array

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -133,6 +133,12 @@ module YARD
         AST_TOKENS = [:CHAR, :backref, :const, :cvar, :gvar, :heredoc_end, :ident,
           :int, :float, :ivar, :label, :period, :regexp_end, :tstring_content, :backtick]
 
+        COMMENT_SKIP_NODE_TYPES = [
+          :comment,
+          :void_stmt,
+          :list
+        ].freeze
+
         MAPPINGS.each do |k, v|
           if Array === v
             v.each {|vv| (REV_MAPPINGS[vv] ||= []) << k }
@@ -613,7 +619,7 @@ module YARD
 
         def insert_comments
           root.traverse do |node|
-            next if [:comment, :void_stmt, :list].include?(node.type) || node.parent.type != :list
+            next if COMMENT_SKIP_NODE_TYPES.include?(node.type) || node.parent.type != :list
 
             # never attach comments to if/unless mod nodes
             if node.type == :if_mod || node.type == :unless_mod


### PR DESCRIPTION
# Description

Hi, I am trying to optimize YARD a bit to speed up documentation runs on a large codebase.

The codebase is private, so I am using https://github.com/watir/watir/ as a smaller stand-in to report benchmarking numbers from https://github.com/SamSaffron/memory_profiler.

# Test set-up
- Ruby 2.7.6 (installed via `rvm` on Linux)
- Watir version: 293bed2b57c
- MemoryProfiler version: 1.0.0
- YARD baseline: 0a550939f9b
- Test command:
  - `ruby-memory-profiler --no-color --retained-strings=500 --allocated-strings=500 --max=300 -o prof.log ./run-yard.rb stats`
    - `run-yard.rb` is a smaller version of `/bin/yard` (MemoryProfiler was not able to run `/bin/yard`)
    - I am using the `stats` command to avoid memory exhaustion

# Performance data
- Before
  - Total allocated: 187901758 bytes (1987572 objects)
  - Total retained:  4052113 bytes (53463 objects)
- After
  - Total allocated: 186038173 bytes (1940980 objects)
  - Total retained:  4052257 bytes (53465 objects)
- Savings
  - Total allocated: 1863585 bytes (46592 objects)
  - Total retained:  -144 bytes (-2 objects)

# Completed Tasks
- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
