### PR TITLE
Avoid string allocations when generating object name

### DIFF
--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -434,7 +434,10 @@ module YARD
       #
       # @return [Symbol] the type of code object this represents
       def type
-        self.class.name.split('::').last.gsub(/Object$/, '').downcase.to_sym
+        obj_name = self.class.name.split('::').last
+        obj_name.gsub!(/Object$/, '')
+        obj_name.downcase!
+        obj_name.to_sym
       end
 
       # Represents the unique path of the object. The default implementation


### PR DESCRIPTION
# Description

Hi, I am trying to optimize YARD a bit to speed up documentation runs on a large codebase.

The codebase is private, so I am using https://github.com/watir/watir/ as a smaller stand-in to report benchmarking numbers from https://github.com/SamSaffron/memory_profiler.

# Test set-up
- Ruby 2.7.6 (installed via `rvm` on Linux)
- Watir version: 293bed2b57c
- MemoryProfiler version: 1.0.0
- YARD baseline: 0a550939f9b
- Test command:
  - `ruby-memory-profiler --no-color --retained-strings=500 --allocated-strings=500 --max=300 -o prof.log ./run-yard.rb stats`
    - `run-yard.rb` is a smaller version of `/bin/yard` (MemoryProfiler was not able to run `/bin/yard`)
    - I am using the `stats` command to avoid memory exhaustion

# Performance data
- Before
  - Total allocated: 187901758 bytes (1987572 objects)
  - Total retained:  4052113 bytes (53463 objects)
- After
  - Total allocated: 187459865 bytes (1976523 objects)
  - Total retained:  4052153 bytes (53464 objects)
- Savings
  - Total allocated: 441893 bytes (11049 objects)
  - Total retained:  -40 bytes (-1 object)

# Completed Tasks
- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
