### PR TITLE
Avoid unnecessary string allocation when calculating length

### DIFF
--- a/lib/yard/registry_resolver.rb
+++ b/lib/yard/registry_resolver.rb
@@ -132,7 +132,8 @@ module YARD
 
       path.scan(split_on_separators_match).each do |part, sep|
         cur_obj = nil
-        pos += "#{part}#{sep}".length
+        pos += part.length
+        pos += sep.length
         parsed_end = pos == path.length
 
         if !last_obj || (!parsed_end && !last_obj.is_a?(CodeObjects::NamespaceObject))


### PR DESCRIPTION
# Description

Hi, I am trying to optimize YARD a bit to speed up documentation runs on a large codebase.

The codebase is private, so I am using https://github.com/watir/watir/ as a smaller stand-in to report benchmarking numbers from https://github.com/SamSaffron/memory_profiler.

# Test set-up
- Ruby 2.7.6 (installed via `rvm` on Linux)
- Watir version: 293bed2b57c
- MemoryProfiler version: 1.0.0
- YARD baseline: 0a550939f9b
- Test command:
  - `ruby-memory-profiler --no-color --retained-strings=500 --allocated-strings=500 --max=300 -o prof.log ./run-yard.rb stats`
    - `run-yard.rb` is a smaller version of `/bin/yard` (MemoryProfiler was not able to run `/bin/yard`)
    - I am using the `stats` command to avoid memory exhaustion

# Performance data
- I don't have concrete performance data because the `stats` command doesn't seem to trigger this code path
- On the private codebase, the loop body was executed  ~375k times, so I think this optimization is worthwhile

# Completed Tasks
- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
