### PR TITLE
Avoid regex allocations by checking arity condition first

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -144,7 +144,7 @@ module YARD
         PARSER_EVENT_TABLE.each do |event, arity|
           node_class = AstNode.node_class_for(event)
 
-          if /_new\z/ =~ event.to_s && arity == 0
+          if arity == 0 && /_new\z/ =~ event.to_s
             module_eval(<<-eof, __FILE__, __LINE__ + 1)
               def on_#{event}(*args)
                 #{node_class}.new(:list, args, :listchar => charno...charno, :listline => lineno..lineno)


### PR DESCRIPTION
# Description

Hi, I am trying to optimize YARD a bit to speed up documentation runs on a large codebase.

The codebase is private, so I am using https://github.com/watir/watir/ as a smaller stand-in to report benchmarking numbers from https://github.com/SamSaffron/memory_profiler.

# Test set-up
- Ruby 2.7.6 (installed via `rvm` on Linux)
- Watir version: 293bed2b57c
- MemoryProfiler version: 1.0.0
- YARD baseline: 0a550939f9b
- Test command:
  - `ruby-memory-profiler --no-color --retained-strings=500 --allocated-strings=500 --max=300 -o prof.log ./run-yard.rb stats`
    - `run-yard.rb` is a smaller version of `/bin/yard` (MemoryProfiler was not able to run `/bin/yard`)
    - I am using the `stats` command to avoid memory exhaustion

# Performance data
- Before
  - Total allocated: 187901758 bytes (1987572 objects)
  - Total retained:  4052113 bytes (53463 objects)
- After
  - Total allocated: 187895022 bytes (1987442 objects)
  - Total retained:  4052113 bytes (53463 objects)
- Savings
  - Total allocated: 6736 bytes (130 objects)
  - Total retained:  0 bytes (0 objects)

# Completed Tasks
- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
