### PR TITLE
Make the rake task depend only on rake

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ The second most obvious is to generate docs via a Rake task. You can do this by
 adding the following to your `Rakefile`:
 
 ```ruby
-require 'yard'
+require 'yard/rake/yardoc_task'
 
 YARD::Rake::YardocTask.new do |t|
  t.files   = ['lib/**/*.rb', OTHER_PATHS]   # optional

--- a/lib/yard/rake/yardoc_task.rb
+++ b/lib/yard/rake/yardoc_task.rb
@@ -68,6 +68,7 @@ module YARD
       def define
         desc "Generate YARD Documentation" unless ::Rake.application.last_description
         task(name) do
+          require 'yard'
           before.call if before.is_a?(Proc)
           yardoc = YARD::CLI::Yardoc.new
           yardoc.options[:verifier] = verifier if verifier


### PR DESCRIPTION
# Description

Without this it's necessary to require the whole library just to have
the task defined. With this change `yard` will be required before
executing the task code reducing the load time and memory footprint
of libraries defining the task.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
