### PR TITLE
Add --mask-directive option

### DIFF
--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -785,6 +785,12 @@ module YARD
         opts.on('--non-transitive-tag TAG', 'Marks a tag as not transitive') do |tag|
           Tags::Library.transitive_tags -= [tag.to_sym]
         end
+
+        opts.on('--mask-directive DIRECTIVE',
+                'Masks a directive to suppress any callback ' \
+                ' and the "unknown directive" warning') do |tag|
+          Tags::Library.define_directive(tag, Tags::NilDirective)
+        end
       end
     end
   end

--- a/lib/yard/tags/directives.rb
+++ b/lib/yard/tags/directives.rb
@@ -621,5 +621,11 @@ module YARD
         end
       end
     end
+
+    # Does nothing but suppresses "unknown directive" warnings, if
+    # a missing directive definition was masked with this class.
+    class NilDirective < Directive
+      def call; end
+    end
   end
 end

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -806,6 +806,11 @@ RSpec.describe YARD::CLI::Yardoc do
       @yardoc.parse_arguments('--non-transitive-tag', 'foo')
       expect(Tags::Library.transitive_tags).not_to include(:foo)
     end
+
+    it "accepts --mask-directive" do
+      @yardoc.parse_arguments('--mask-directive', 'foo')
+      expect(Tags::Library.factory_method_for_directive(:foo)).to eq Tags::NilDirective
+    end
   end
 
   describe "Safe mode" do

--- a/spec/tags/directives_spec.rb
+++ b/spec/tags/directives_spec.rb
@@ -461,3 +461,15 @@ RSpec.describe YARD::Tags::VisibilityDirective do
     end if YARD::Parser::SourceParser.parser_type == :ruby
   end
 end
+
+RSpec.describe YARD::Tags::NilDirective do
+  describe '#call' do
+    before { Tags::Library.define_directive(:unknown, YARD::Tags::NilDirective) }
+
+    after { Registry.clear }
+
+    it "does nothing if directive is unknown" do
+      tag_parse("@!unknown")
+    end
+  end
+end


### PR DESCRIPTION
# Description

This PR adds the `--mask-directive` option similar to `--hide-tag` but for directives.

The following example will mask `@!parse` directive with `YARD::Tags::NilDirective` class to suppress any callbacks:

```
yardoc --mask-directive parse
```

Also, the option allows to suppress warnings on unknown directives in different contexts.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
