### PR TITLE
Fix autoload path for RipperParser

### DIFF
--- a/lib/yard/autoload.rb
+++ b/lib/yard/autoload.rb
@@ -170,7 +170,6 @@ module YARD
 
     module Ruby # Ruby parsing components.
       module Legacy # Handles Ruby parsing in Ruby 1.8.
-        autoload :RipperParser,   __p('parser/ruby/legacy/ruby_parser')
         autoload :RubyParser,     __p('parser/ruby/legacy/ruby_parser')
         autoload :RubyToken,      __p('parser/ruby/legacy/ruby_lex')
         autoload :Statement,      __p('parser/ruby/legacy/statement')
@@ -180,6 +179,7 @@ module YARD
 
       autoload :AstNode,           __p('parser/ruby/ast_node')
       autoload :RubyParser,        __p('parser/ruby/ruby_parser')
+      autoload :RipperParser,      __p('parser/ruby/ruby_parser')
       autoload :TokenResolver,     __p('parser/ruby/token_resolver')
     end
 


### PR DESCRIPTION
# Description

The autoload specification is incorrect and should be corrected. The class `YARD::Parser::Ruby::Legacy::RipperParser` does not exist and is assumed to be `YARD::Parser::Ruby::RipperParser`.

```rb
YARD::Parser::Ruby::Legacy.constants
#=> [:Statement, :RipperParser, :RubyParser, :RubyToken, :StatementList, :TokenList]
YARD::Parser::Ruby::Legacy::RipperParser
#=> uninitialized constant YARD::Parser::Ruby::Legacy::RipperParser (NameError)
```

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
