### PR TITLE
Fix resolving mixins that mix themselves in

### DIFF
--- a/spec/handlers/examples/mixin_handler_001.rb.txt
+++ b/spec/handlers/examples/mixin_handler_001.rb.txt
@@ -38,3 +38,16 @@ end
 
 module FromConstant; end
 FromConstant.include A
+
+module Foo
+end
+
+module MixMySelfIn
+  Foo.include(self)
+end
+
+module Nested
+  module Foo
+    ::Foo.include(self)
+  end
+end

--- a/spec/handlers/mixin_handler_spec.rb
+++ b/spec/handlers/mixin_handler_spec.rb
@@ -69,4 +69,8 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MixinHan
     expect(YARD::Registry.root.instance_mixins).not_to eq [P('D1::E1::F1')]
     expect(P('A1::B1::C1').instance_mixins).to eq [P('D1::E1::F1')]
   end
+
+  it "resolves modules that mix themselves in" do
+    expect(Registry.at('Foo').mixins).to match_array [P('MixMySelfIn'), P('Nested::Foo')]
+  end
 end


### PR DESCRIPTION
# Description

```ruby
module A
  B.include(self)
end
```

Wasn't working properly

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).
