### PR TITLE
use ensure_loaded! with mixin objects

### DIFF
--- a/lib/yard/handlers/ruby/mixin_handler.rb
+++ b/lib/yard/handlers/ruby/mixin_handler.rb
@@ -34,7 +34,10 @@ class YARD::Handlers::Ruby::MixinHandler < YARD::Handlers::Ruby::Base
     end
 
     rec = recipient(mixin)
-    return if rec.nil? || rec.mixins(scope).include?(obj)
+    return if rec.nil?
+
+    ensure_loaded!(rec)
+    return if rec.mixins(scope).include?(obj)
 
     shift = statement.method_name(true) == :include ? :unshift : :push
     rec.mixins(scope).send(shift, obj)

--- a/spec/handlers/examples/mixin_handler_002.rb.txt
+++ b/spec/handlers/examples/mixin_handler_002.rb.txt
@@ -1,0 +1,3 @@
+module B1; end
+
+A1.include(B1)

--- a/spec/handlers/examples/mixin_handler_003.rb.txt
+++ b/spec/handlers/examples/mixin_handler_003.rb.txt
@@ -1,0 +1,1 @@
+module A1; end

--- a/spec/handlers/mixin_handler_spec.rb
+++ b/spec/handlers/mixin_handler_spec.rb
@@ -62,11 +62,18 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MixinHan
   it "can mixin a const by complex path" do
     YARD.parse_string <<-eof
       class A1; class B1; class C1; end end end
-      class D1; class E1; class F1; end end end
+      class D1; class E1; module F1; end end end
       A1::B1::C1.include D1::E1::F1
     eof
 
     expect(YARD::Registry.root.instance_mixins).not_to eq [P('D1::E1::F1')]
     expect(P('A1::B1::C1').instance_mixins).to eq [P('D1::E1::F1')]
+  end
+
+  it "ensures the recipient is loaded from another file" do
+    # 002 includes a module into a module defined in 003
+    parse_file [:mixin_handler_002, :mixin_handler_003], __FILE__
+
+    expect(P('A1').instance_mixins).to eq [P('B1')]
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,10 +31,10 @@ end if ENV['CI'] && HAVE_RIPPER
 
 NAMED_OPTIONAL_ARGUMENTS = RUBY_VERSION >= '2.1.0'
 
-def parse_file(file, thisfile = __FILE__, log_level = log.level, ext = '.rb.txt')
+def parse_file(files, thisfile = __FILE__, log_level = log.level, ext = '.rb.txt')
   Registry.clear
-  path = File.join(File.dirname(thisfile), 'examples', file.to_s + ext)
-  YARD::Parser::SourceParser.parse(path, [], log_level)
+  paths = Array(files).map { |file| File.join(File.dirname(thisfile), 'examples', file.to_s + ext) }
+  YARD::Parser::SourceParser.parse(paths, [], log_level)
 end
 
 def described_in_docs(klass, meth, file = nil)


### PR DESCRIPTION
This handles the case of a module including itself into the recipient, defined a different file

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).
