### PR TITLE
load project-specific configuration as well as user-specific

### DIFF
--- a/lib/yard/cli/yri.rb
+++ b/lib/yard/cli/yri.rb
@@ -5,14 +5,14 @@ module YARD
   module CLI
     # A tool to view documentation in the console like `ri`
     class YRI < Command
-      # The location in {YARD::CONFIG_DIR} where the YRI cache file is loaded
+      # The location in {YARD::USER_CONFIG_DIR} where the YRI cache file is loaded
       # from.
-      CACHE_FILE = File.expand_path(File.join(YARD::Config::CONFIG_DIR, 'yri_cache'))
+      CACHE_FILE = File.expand_path(File.join(YARD::Config::USER_CONFIG_DIR, 'yri_cache'))
 
       # A file containing all paths, delimited by newlines, to search for
       # yardoc databases.
       # @since 0.5.1
-      SEARCH_PATHS_FILE = File.expand_path(File.join(YARD::Config::CONFIG_DIR, 'yri_search_paths'))
+      SEARCH_PATHS_FILE = File.expand_path(File.join(YARD::Config::USER_CONFIG_DIR, 'yri_search_paths'))
 
       # Default search paths that should be loaded dynamically into YRI. These paths
       # take precedence over all other paths ({SEARCH_PATHS_FILE} and RubyGems

--- a/lib/yard/registry.rb
+++ b/lib/yard/registry.rb
@@ -31,7 +31,7 @@ module YARD
   #   Registry.resolve(P('YARD::CodeObjects::Base'), '#docstring', true)
   module Registry
     DEFAULT_YARDOC_FILE = ".yardoc"
-    LOCAL_YARDOC_INDEX = File.expand_path(File.join(Config::CONFIG_DIR, 'gem_index'))
+    LOCAL_YARDOC_INDEX = File.expand_path(File.join(Config::USER_CONFIG_DIR, 'gem_index'))
     DEFAULT_PO_DIR = "po"
 
     extend Enumerable

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -2,6 +2,11 @@
 require 'yaml'
 
 RSpec.describe YARD::Config do
+  before do
+    allow(File).to receive(:file?).with(".yard/config").and_return(false)
+    allow(File).to receive(:file?).with(".yardopts").and_return(false)
+  end
+
   describe ".load" do
     before do
       expect(File).to receive(:file?).twice.with(CLI::Yardoc::DEFAULT_YARDOPTS_FILE).and_return(false)


### PR DESCRIPTION
so that you can configure a plugin per-project

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).
