### PR TITLE
Fix RSpec deprecations

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -119,6 +119,8 @@ end if ENV['TM_APP_PATH']
 RSpec.configure do |config|
   config.before(:each) { log.io = StringIO.new }
 
+  config.raise_errors_for_deprecations!
+
   # isolate environment of each test
   # any other global settings which might be modified by a test should also
   # be saved and restored here

--- a/spec/tags/types_explainer_spec.rb
+++ b/spec/tags/types_explainer_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe YARD::Tags::TypesExplainer do
   end
 
   def parse_fail(types)
-    expect(lambda { parse(types) }).to raise_error(SyntaxError)
+    expect { parse(types) }.to raise_error(SyntaxError)
   end
 
   describe Type, '#to_s' do

--- a/spec/templates/tag_spec.rb
+++ b/spec/templates/tag_spec.rb
@@ -45,8 +45,8 @@ RSpec.describe YARD::Templates::Engine.template(:default, :tags) do
         module Foo; end
       eof
 
-      proc = lambda { Registry.at('Foo').format(html_options) }
-      expect(proc).not_to raise_error
+      expect { Registry.at('Foo').format(html_options) }
+        .not_to raise_error
     end
   end
 end


### PR DESCRIPTION
# Description

This fixes some RSpec deprecations (see [this](https://github.com/rspec/rspec-expectations/pull/1285) for more details) and switches RSpec to fail on deprecations.

```
  4) YARD::Tags::TypesExplainer YARD::Tags::TypesExplainer::Parser#parse fails on any unrecognized character
     Failure/Error: expect(lambda { parse(types) }).to raise_error(SyntaxError)
       The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports
_value_expectations?`. e.g  `expect { value }.to raise SyntaxError` not `expect(value).to raise SyntaxError`
     # ./spec/tags/types_explainer_spec.rb:15:in `parse_fail'
     # ./spec/tags/types_explainer_spec.rb:170:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:129:in `block (2 levels) in <top (required)>'

  5) YARD::Templates::Engine::Template__Users_pirj_source_yard_templates_default_tags param tags on non-methods does not display @param tags on non-method objects
     Failure/Error: expect(proc).not_to raise_error
       The implicit block expectation syntax is deprecated, you should pass a block rather than an argument to `expect` to use the provided block expectation matcher or the matcher must implement `supports
_value_expectations?`. e.g  `expect { value }.to raise Exception` not `expect(value).to raise Exception`
     # ./spec/templates/tag_spec.rb:49:in `block (3 levels) in <top (required)>'
     # ./spec/spec_helper.rb:129:in `block (2 levels) in <top (required)>'
```

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md