### PR TITLE
exclude `.rubocop.yml` from files list

### DIFF
--- a/yard.gemspec
+++ b/yard.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.email         = "lsegal@soen.ca"
   s.homepage      = "http://yardoc.org"
   s.platform      = Gem::Platform::RUBY
-  s.files         = `git ls-files`.strip.split(/\s+/).reject {|f| f.match(%r{^(spec/|.rubocop)}) }
+  s.files         = Dir['{lib}/**/*', 'LICENSE', 'LEGAL', 'README.md']
   s.require_paths = ['lib']
   s.executables   = ['yard', 'yardoc', 'yri']
   s.license = 'MIT' if s.respond_to?(:license=)

--- a/yard.gemspec
+++ b/yard.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.email         = "lsegal@soen.ca"
   s.homepage      = "http://yardoc.org"
   s.platform      = Gem::Platform::RUBY
-  s.files         = `git ls-files`.strip.split(/\s+/).reject {|f| f.match(%r{^spec/}) }
+  s.files         = `git ls-files`.strip.split(/\s+/).reject {|f| f.match(%r{^(spec/|.rubocop)}) }
   s.require_paths = ['lib']
   s.executables   = ['yard', 'yardoc', 'yri']
   s.license = 'MIT' if s.respond_to?(:license=)


### PR DESCRIPTION
When yard is installed/used in a project which also uses rubocop, rubocop ends up using yard's `.rubocop.yml` file when run with `bundle exec rubocop`.

# Description

Describe your pull request and problem statement here.

# Completed Tasks

- [ ] I have read the [Contributing Guide][contrib].
- [ ] The pull request is complete (implemented / written).
- [ ] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
