### PR TITLE
Handle invalid option tag with name only

### DIFF
--- a/lib/yard/tags/default_factory.rb
+++ b/lib/yard/tags/default_factory.rb
@@ -73,6 +73,11 @@ module YARD
       end
 
       def parse_tag_with_types_name_and_default(tag_name, text)
+        if text.nil?
+          log.warn "Encountered #{tag_name} tag with no text"
+          return
+        end
+
         # Can't allow () in a default tag, otherwise the grammar is too ambiguous when types is omitted.
         open = TYPELIST_OPENING_CHARS.delete('(')
         close = TYPELIST_CLOSING_CHARS.delete(')')

--- a/spec/tags/default_factory_spec.rb
+++ b/spec/tags/default_factory_spec.rb
@@ -164,5 +164,11 @@ RSpec.describe YARD::Tags::DefaultFactory do
       expect(t.pair).to be_instance_of(Tags::DefaultTag)
       expect(t.pair.name).to eq "key"
     end
+
+    it "returns nil when only name is present" do
+      expect(log).to receive(:warn).with("Encountered option tag with no text")
+      t = parse_options("xyz")
+      expect(t.pair).to be(nil)
+    end
   end
 end


### PR DESCRIPTION
We have some of these in our codebase:

```
@option :foo
```

Handle them gracefully, even though they are invalid.

These were causing errors in VSCode, via Solargraph:

```
[WARN] Error processing request: [NoMethodError] undefined method `length' for nil:NilClass
[WARN] /Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/tags/default_factory.rb:148:in `extract_types_and_name_from_text_unstripped'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/tags/default_factory.rb:132:in `extract_types_and_name_from_text'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/tags/default_factory.rb:79:in `parse_tag_with_types_name_and_default'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/tags/default_factory.rb:93:in `parse_tag_with_options'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/tags/library.rb:237:in `send_to_factory'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/tags/library.rb:169:in `option_tag'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/tags/library.rb:274:in `tag_create'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/docstring_parser.rb:215:in `create_tag'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/docstring_parser.rb:156:in `block in parse_content'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/docstring_parser.rb:142:in `each'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/docstring_parser.rb:142:in `each_with_index'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/docstring_parser.rb:142:in `parse_content'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/yard-0.9.28/lib/yard/docstring_parser.rb:117:in `parse'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/source.rb:518:in `parse_docstring'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/pin/base.rb:246:in `parse_comments'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/pin/base.rb:99:in `docstring'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/pin/base.rb:129:in `deprecated?'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/language_server/message/workspace/workspace_symbol.rb:18:in `block in process'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/language_server/message/workspace/workspace_symbol.rb:8:in `map'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/language_server/message/workspace/workspace_symbol.rb:8:in `process'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/language_server/host.rb:112:in `receive'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/language_server/host/message_worker.rb:53:in `tick'
/Users/Evan.Goldenberg/.asdf/installs/ruby/2.7.3/lib/ruby/gems/2.7.0/gems/solargraph-0.48.0/lib/solargraph/language_server/host/message_worker.rb:44:in `block in start'
```

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
