### PR TITLE
github CI use macos-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-20.04, macos-10.15, windows-2019]
+        os: [ubuntu-20.04, macos-latest, windows-2019]
         # 3.0 is interpreted as 3
         ruby: [2.2, 2.3, 2.4, 2.5, 2.6, 2.7, "3.0", 3.1, 3.2]
         exclude:


### PR DESCRIPTION
macos-10.15 is unsupported, see https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/
This could be changed to macos-12 or macos-11 if there is reason to reference a particular version, but using -latest seemed to me like a good option.