### PR TITLE
Add a yieldself tag

### DIFF
--- a/lib/yard/tags/library.rb
+++ b/lib/yard/tags/library.rb
@@ -593,6 +593,14 @@ module YARD
       # @see tag:return
       define_tag "Yield Returns",      :yieldreturn, :with_types
 
+      # Documents the type of context in which the block is expected
+      # to run.
+      #
+      # @example
+      #   # @yieldself [Array] An array will evaluate the block
+      #   def add5_block(&block) [].instance_eval(&block) end
+      define_tag "Yield Self",         :yieldself, :with_types
+
       # @yard.signature [r | w | rw] attribute_name
       #   Indented attribute docstring
       define_directive :attribute, :with_types_and_title, AttributeDirective


### PR DESCRIPTION
# Description

Add a `@yieldself` tag to document the context in which yielded blocks are expected to run. Example:

```ruby
class Foo; end

class Bar
  def initialize
    @foo = Foo.new
  end

  # @yieldself [Foo]
  def run_in_foo &proc
    @foo.instance_eval &proc
  end
end
```

Solargraph currently uses this tag to enhance autocompletion. I was planning to write an extension so gems could add it to their yardocs, but it seemed useful enough in documentation to check if it was worth adding to YARD itself.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
