### PR TITLE
Fix heredoc-to-string conversion

### DIFF
--- a/spec/parser/ruby/legacy/statement_list_spec.rb
+++ b/spec/parser/ruby/legacy/statement_list_spec.rb
@@ -294,6 +294,12 @@ eof
   it "converts heredoc to string" do
     src = "<<-XML\n  foo\n\nXML"
     s = stmt(src)
-    expect(s.source).to eq '"foo\n\n"'
+    expect(s.source).to eq '"  foo\n\n"'
+  end
+
+  it "converts squiggly heredoc to string" do
+    src = "<<~XML\n  bar\n\nXML"
+    s = stmt(src)
+    expect(s.source).to eq '"bar\n\n"'
   end
 end


### PR DESCRIPTION
# Description

Resolves https://github.com/lsegal/yard/issues/1315, as well as adding support for squiggly heredocs

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
