### PR TITLE
Fix typo in markdown_spec.rb

### DIFF
--- a/spec/templates/markup_processor_integrations/markdown_spec.rb
+++ b/spec/templates/markup_processor_integrations/markdown_spec.rb
@@ -2,7 +2,7 @@
 
 require File.dirname(__FILE__) + '/integration_spec_helper'
 
-RSpec.describe 'Markdown processrors integration' do
+RSpec.describe 'Markdown processors integration' do
   include_context 'shared helpers for markup processor integration specs'
 
   shared_examples 'shared examples for markdown processors' do


### PR DESCRIPTION

# Description

Was trying to figure out some markdown things, and came across this typo in the spec.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
