### PR TITLE
Fix error when `@option` with non-method

### DIFF
--- a/spec/templates/tag_spec.rb
+++ b/spec/templates/tag_spec.rb
@@ -49,4 +49,16 @@ RSpec.describe YARD::Templates::Engine.template(:default, :tags) do
         .not_to raise_error
     end
   end
+
+  describe "option tags on non-methods" do
+    it "does not display @option tags on non-method objects" do
+      YARD.parse_string <<-'eof'
+        # @option opts name [#to_s] ('bar') the name
+        module Foo; end
+      eof
+
+      expect { Registry.at('Foo').format(html_options) }
+        .not_to raise_error
+    end
+  end
 end

--- a/templates/default/tags/html/option.erb
+++ b/templates/default/tags/html/option.erb
@@ -1,4 +1,4 @@
-<% if object.has_tag?(:option) %>
+<% if object.has_tag?(:option) && object.respond_to?(:parameters) %>
   <% object.parameters.each do |param, default| %>
     <% tags = object.tags(:option).select {|x| x.name.to_s == param.to_s.sub(/^\*+|:$/, '') } %>
     <% next if tags.empty? %>


### PR DESCRIPTION
# Description

Applying the `@option` tag to non-method code results in an error during documentation generation.

```
$ cat t.rb
# @option [String] foo bar
module Foo
end

$ bundle exec yardoc t.rb
[error]: Exception occurred while generating 'Foo.html'
[error]: NoMethodError: undefined method `parameters' for #<yardoc module Foo>
[error]: Stack trace:
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/code_objects/base.rb:379:in `method_missing'
	/Users/yuki.kurihara/src/github.com/ksss/yard/templates/default/tags/html/option.erb:4:in `_erb_cache_33'
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/templates/template.rb:289:in `erb'
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/templates/template.rb:371:in `render_section'
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/templates/template.rb:261:in `block (2 levels) in run'
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/templates/template.rb:258:in `each'

Files:           1
Modules:         1 (    0 undocumented)
Classes:         0 (    0 undocumented)
Constants:       0 (    0 undocumented)
Attributes:      0 (    0 undocumented)
Methods:         0 (    0 undocumented)
 100.00% documented
```

I have fixed it to prevent the error from occurring.

It might be acceptable to log a warning message, but for now, I've adjusted it to match the current behavior of the `@param` tag, which displays nothing.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
