### PR TITLE
Parser::SourceParser#convert_encoding - fixup BOM encoding

### DIFF
--- a/lib/yard/parser/source_parser.rb
+++ b/lib/yard/parser/source_parser.rb
@@ -476,9 +476,8 @@ module YARD
           content.force_encoding('binary')
           ENCODING_BYTE_ORDER_MARKS.each do |encoding, bom|
             bom.force_encoding('binary')
-            if content[0, bom.size] == bom
-              content.force_encoding(encoding)
-              return content
+            if content.start_with?(bom)
+              return content.sub(bom, '').force_encoding(encoding)
             end
           end
           content.force_encoding('utf-8') # UTF-8 is default encoding


### PR DESCRIPTION
# Description

Ruby 3.3 may change handling of BOM encoded files.  Change code to work with 3.3 and earlier versions.

Closes #1509 

Note that Ruby 2.7 added [`IO##set_encoding_by_bom`](https://msp-greg.github.io/ruby_2_7/Core/IO.html#set_encoding_by_bom-instance_method)

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
