### PR TITLE
Links YARD::CLI::Yardoc to api reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ Note that the README file can be specified with its own `--readme` switch.
 You can also add a `.yardopts` file to your project directory which lists the
 switches separated by whitespace (newlines or space) to pass to yardoc whenever
 it is run. A full overview of the `.yardopts` file can be found in
-{YARD::CLI::Yardoc}.
+[YARD::CLI::Yardoc](https://rubydoc.info/gems/yard/YARD/CLI/Yardoc#label-Options+File+-28.yardopts-29).
 
 ### Queries
 


### PR DESCRIPTION
# Description

This PR updates the README to link `YARD::CLI::Yardoc` to  https://rubydoc.info/gems/yard/YARD/CLI/Yardoc#label-Options+File+-28.yardopts-29. I'm proposing this change to help others find how to create a valid .yardopts file quickly.

[rendered here](https://github.com/alvincrespo/yard/blob/docs--readme-link-to-api/README.md)

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
