### PR TITLE
Fix error when docsting is just only `@option`

### DIFF
--- a/lib/yard/tags/default_factory.rb
+++ b/lib/yard/tags/default_factory.rb
@@ -143,6 +143,7 @@ module YARD
         seen_space = false
         i = 0
         last_seen = ''
+        text ||= ''
         while i < text.length
           c = text[i, 1]
 

--- a/spec/tags/default_factory_spec.rb
+++ b/spec/tags/default_factory_spec.rb
@@ -68,6 +68,7 @@ RSpec.describe YARD::Tags::DefaultFactory do
     end
 
     it "returns text unparsed if there is no type list" do
+      expect(parse_types(nil)).to eq [nil, nil, '']
       expect(parse_types('')).to eq [nil, nil, '']
       expect(parse_types('[]')).to eq [nil, nil, '[]']
     end


### PR DESCRIPTION
# Description

Running `yardoc` on the following Ruby code will result in an error.

```rb
# t.rb
class Foo
  # @option
  def m
  end
end
```

```
$ bin/yardoc t.rb
[error]: Unhandled exception in YARD::Handlers::Ruby::MethodHandler:
  in `t.rb`:3:

	3: def m

[error]: NoMethodError: undefined method `length' for nil:NilClass
[error]: Stack trace:
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/tags/default_factory.rb:147:in `extract_types_and_name_from_text_unstripped'
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/tags/default_factory.rb:130:in `extract_types_and_name_from_text'
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/tags/default_factory.rb:79:in `parse_tag_with_types_name_and_default'
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/tags/default_factory.rb:91:in `parse_tag_with_options'
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/tags/library.rb:237:in `send_to_factory'
	/Users/yuki.kurihara/src/github.com/ksss/yard/lib/yard/tags/library.rb:169:in `option_tag'
```

This problem is seen only with `@option` and not with other major tags.

I presume that this is probably due to the fact that if `text` is `""` in the following code, the result will be `[]`, creating a `text == nil` condition when retrieved.

https://github.com/lsegal/yard/blob/2d197a381c5d4cc5c55b2c60fff992b31c986361/lib/yard/tags/default_factory.rb#L102

If the Docstring is only `"@param"`, `text` is still `""`.
To correct the problem, I now treat text as `""` when it is `nil`.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
