### PR TITLE
Add doc for Tag#name if no tag name is supplied

### DIFF
--- a/lib/yard/tags/tag.rb
+++ b/lib/yard/tags/tag.rb
@@ -23,6 +23,7 @@ module YARD
       attr_accessor :types
 
       # @return [String] a name associated with the tag
+      # @return [nil] if no tag name is supplied
       attr_accessor :name
 
       # @return [CodeObjects::Base] the associated object


### PR DESCRIPTION
# Description

Added documentation for `YARD::Tags::Tag#name`, which could be `nil`.

The following is a typical example.

```rb
YARD::DocstringParser.new.parse("@return [void]").tags
#=> [#<YARD::Tags::Tag:0x0000000105294108 @name=nil, @tag_name="return", @text="", @types=["void"]>]
```

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
