### PR TITLE
TEST: remove invalid yield usage from spec example

### DIFF
--- a/spec/handlers/examples/yield_handler_001.rb.txt
+++ b/spec/handlers/examples/yield_handler_001.rb.txt
@@ -1,7 +1,4 @@
 class Testing
-  # Ignore yields outside methods
-  yield x, y, z
-
   # Should document this
   def mymethod
     yield


### PR DESCRIPTION
Using yield outside method definition is invalid, and with ruby3.3.0dev, this usage in spec example file causes spec testsuite failure.

So to make test pass also on ruby3.3, remove this usage.

Fixes #1514 .

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

