### PR TITLE
Don't update window location in frames with javascript

### DIFF
--- a/templates/default/fulldoc/html/frames.erb
+++ b/templates/default/fulldoc/html/frames.erb
@@ -8,10 +8,14 @@
   var match = unescape(window.location.hash).match(/^#!(.+)/);
   var name = match ? match[1] : '<%= url_for_main %>';
   name = name.replace(/^(\w+):\/\//, '').replace(/^\/\//, '');
-  window.top.location = name;
+  var url = new URL(name);
+  if (url.protocol !== 'javascript:') {
+    window.top.location = url;
+  }
 </script>
 <noscript>
   <h1>Oops!</h1>
   <h2>YARD requires JavaScript!</h2>
 </noscript>
 </html>
+


### PR DESCRIPTION
# Description

Don't update the window location in frames.erb when the input contains javascript.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
