### PR TITLE
Commonmarker 1.0 support

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -89,6 +89,8 @@ module YARD
                              :tables,
                              :with_toc_data,
                              :no_intraemphasis).to_html
+        when 'Commonmarker'
+          Commonmarker.to_html(text) # GFM configs are on by default
         when 'CommonMarker'
           CommonMarker.render_html(text, %i[DEFAULT GITHUB_PRE_LANG], %i[autolink table])
         else

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -90,7 +90,8 @@ module YARD
                              :with_toc_data,
                              :no_intraemphasis).to_html
         when 'Commonmarker'
-          Commonmarker.to_html(text) # GFM configs are on by default
+          # GFM configs are on by default; use YARD for syntax highlighting
+          Commonmarker.to_html(text, plugins: {syntax_highlighter: nil})
         when 'CommonMarker'
           CommonMarker.render_html(text, %i[DEFAULT GITHUB_PRE_LANG], %i[autolink table])
         else

--- a/lib/yard/templates/helpers/markup_helper.rb
+++ b/lib/yard/templates/helpers/markup_helper.rb
@@ -30,6 +30,7 @@ module YARD
           {:lib => :maruku, :const => 'Maruku'},
           {:lib => :'rpeg-markdown', :const => 'PEGMarkdown'},
           {:lib => :rdoc, :const => 'YARD::Templates::Helpers::Markup::RDocMarkdown'},
+          {:lib => :commonmarker, :const => 'Commonmarker'},
           {:lib => :commonmarker, :const => 'CommonMarker'}
         ],
         :textile => [

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
 
     it "creates tables (markdown specific)" do
       log.enter_level(Logger::FATAL) do
-        supports_table = %w(RedcarpetCompat Kramdown::Document CommonMarker)
+        supports_table = %w(RedcarpetCompat Kramdown::Document Commonmarker CommonMarker)
         unless supports_table.include?(markup_class(:markdown).to_s)
           pending "This test depends on a markdown engine that supports tables"
         end

--- a/spec/templates/markup_processor_integrations/integration_spec_helper.rb
+++ b/spec/templates/markup_processor_integrations/integration_spec_helper.rb
@@ -26,7 +26,7 @@ RSpec.shared_context 'shared helpers for markup processor integration specs' do
 
   before(:each) do
     if html_renderer.markup_class(markup).nil?
-      skip "Missing markup renderer #{markup}"
+      raise "Missing markup renderer #{markup}"
     end
   end
 

--- a/spec/templates/markup_processor_integrations/markdown_spec.rb
+++ b/spec/templates/markup_processor_integrations/markdown_spec.rb
@@ -82,7 +82,7 @@ MARKDOWN
     end
   end
 
-  describe 'CommonMarker', if:  RUBY_VERSION >= '2.3' do
+  describe 'Commonmarker', if:  RUBY_VERSION >= '2.3' do
     let(:markup) { :markdown }
     let(:markup_provider) { :commonmarker }
 


### PR DESCRIPTION
# Description

* Add `Commonmarker` (all lower-case `m`s) provider for `commonmarker ~> 1.0.0`
  * Fixes #1528
* Also changes “Missing markup renderer” from `skip` to `raise` to catch this sort of issues in the future

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [ ] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
