### PR TITLE
Support Ruby 3 inline attribute visibility

### DIFF
--- a/spec/handlers/examples/visibility_handler_002.rb.txt
+++ b/spec/handlers/examples/visibility_handler_002.rb.txt
@@ -1,0 +1,7 @@
+class Testing
+  private attr_accessor :inline_private_attr
+  protected attr_writer :inline_protected_writer
+
+  # This one should be public
+  attr_reader :inline_public_reader
+end

--- a/spec/handlers/visibility_handler_spec.rb
+++ b/spec/handlers/visibility_handler_spec.rb
@@ -41,4 +41,15 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}Visibili
   it "can decorate a method definition" do
     expect(Registry.at('Testing#decpriv').visibility).to eq :private
   end unless LEGACY_PARSER
+
+  describe 'ruby 3 specific features' do
+    before(:all) { parse_file :visibility_handler_002, __FILE__ }
+
+    it "handles attr_accessor when inlined" do
+      expect(Registry.at('Testing#inline_private_attr').visibility).to eq :private
+      expect(Registry.at('Testing#inline_private_attr=').visibility).to eq :private
+      expect(Registry.at('Testing#inline_protected_writer=').visibility).to eq :protected
+      expect(Registry.at('Testing#inline_public_reader').visibility).to eq :public
+    end
+  end if RUBY_VERSION >= "3."
 end


### PR DESCRIPTION
See https://redmine.ruby-lang.org/issues/17314

# Description

Currently attributes defined with:

```rb
private attr_accessor :foo
protected attr_accessor :bar
```

Will be displayed as public attributes in the documentation.

These should be considered private/protected and not be included in the documentation.

When generating documentation, this warning is show:

```
[warn]: in YARD::Handlers::Ruby::VisibilityHandler: Undocumentable statement, cannot determine method name
	in file ...:

	1: private attr_accessor :foo
```

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
