### PR TITLE
Add `ostruct` to runtime dependency

### DIFF
--- a/yard.gemspec
+++ b/yard.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.executables   = ['yard', 'yardoc', 'yri']
   s.license = 'MIT' if s.respond_to?(:license=)
   s.metadata['yard.run'] = 'yri'
+  s.add_dependency 'ostruct'
 end


### PR DESCRIPTION
## Description

This PR adds `ostruct` to runtime dependency to suppress the following warning:

```console
$ ruby -v
ruby 3.4.0dev (2024-04-19T07:33:16Z master 7951b349ab) [x86_64-darwin23]
$ cd path/to/rubocop
$ bundle exec rake
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/yard-0.9.36/lib/yard/templates/template_options.rb:2:
warning: ostruct was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0. Add ostruct to your Gemfile or gemspec.
```

This change is aimed at Ruby 3.5 and will start showing warnings from Ruby 3.4: https://github.com/ruby/ruby/pull/10428

To maintain the following behavior, the dependency will be added in the gemspec to resolve this. https://github.com/lsegal/yard/blob/v0.9.36/lib/yard/templates/template_options.rb#L32-L34

## Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
