### PR TITLE
Add `logger` to runtime dependency

### DIFF
--- a/yard.gemspec
+++ b/yard.gemspec
@@ -21,4 +21,5 @@ Gem::Specification.new do |s|
   s.executables   = ['yard', 'yardoc', 'yri']
   s.license = 'MIT' if s.respond_to?(:license=)
   s.metadata['yard.run'] = 'yri'
+  s.add_dependency 'logger'
 end


### PR DESCRIPTION
This PR adds `logger` to runtime dependency to suppress the following warning:

```console
$ ruby -v
ruby 3.4.0dev (2024-06-14T03:14:32Z master 2677ab1607) [x86_64-darwin23]
$ cd path/to/rubocop
$ bundle exec rake
/Users/koic/.rbenv/versions/3.4-dev/lib/ruby/gems/3.4.0+0/gems/yard-0.9.36/lib/yard/logging.rb:3:
warning: logger was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.5.0.
Add logger to your Gemfile or gemspec.
```

This change is aimed at Ruby 3.5 and will start showing warnings from Ruby 3.4: https://github.com/ruby/ruby/commit/d7e558e

To maintain the following behavior, the dependency will be added in the gemspec to resolve this. https://github.com/lsegal/yard/blob/v0.9.36/lib/yard/logging.rb#L3-L9

# Description

Describe your pull request and problem statement here.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
