### PR TITLE
Adds webp image support

### DIFF
--- a/lib/yard/server/commands/display_file_command.rb
+++ b/lib/yard/server/commands/display_file_command.rb
@@ -11,7 +11,7 @@ module YARD
         def run
           filename = File.cleanpath(File.join(library.source_path, path))
           raise NotFoundError unless File.file?(filename)
-          if filename =~ /\.(jpe?g|gif|png|bmp|svg)$/i
+          if filename =~ /\.(jpe?g|gif|png|bmp|svg|webp)$/i
             headers['Content-Type'] = StaticFileCommand::DefaultMimeTypes[$1.downcase] || 'text/html'
             render File.read_binary(filename)
           else

--- a/lib/yard/server/http_utils.rb
+++ b/lib/yard/server/http_utils.rb
@@ -97,6 +97,7 @@ module YARD::Server
       "tiff"  => "image/tiff",
       "txt"   => "text/plain",
       "wasm"  => "application/wasm",
+      "webp"   => "image/webp",
       "xbm"   => "image/x-xbitmap",
       "xhtml" => "text/html",
       "xls"   => "application/vnd.ms-excel",


### PR DESCRIPTION
# Description

Webp images render an image-missing icon.
This adds "webp" to the list of image extensions for DisplayFileCommand.

Gave a fair amount of time to trying to add a DisplayFileCommand spec and fell on my face - It goes a bit too deep for my surface-level knowledge. 
Existing tests pass and verified by hand that webp now renders using this update.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [o] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
