### PR TITLE
Update Templates.md to fix incorrect path structure

### DIFF
--- a/docs/Templates.md
+++ b/docs/Templates.md
@@ -280,10 +280,11 @@ seen above by creating such a path in our '/path/to/mytemplates' custom template
 path:
 
     /path/to/mytemplates/:
-    |-- class
-    |   |-- html
-    |   |   |-- customsection.erb
-    |   |-- setup.rb
+    |--default
+    |   |-- class
+    |   |   |-- html
+    |   |   |   |-- customsection.erb
+    |   |   |-- setup.rb
 
 The `setup.rb` file would look like:
 


### PR DESCRIPTION
# Description

Fix incorrect path structure in "Overriding Templates by Registering a Template Path" section.

Because of the `YARD::Templates::Engine.register_template_path '/path/to/mytemplates'` code above, we need a `default` subdirectory to contain the `class/html/customsection.erb` and `class/setup.rb` files.

The paragraph immediately after this even mentions the `default/class` structure, but I missed it since it wasn't in the tree structure.

Tested with yard 0.9.36 to verify.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
