### PR TITLE
Update signature handling in @overload

### DIFF
--- a/lib/yard/tags/overload_tag.rb
+++ b/lib/yard/tags/overload_tag.rb
@@ -60,7 +60,8 @@ module YARD
           args = YARD::Handlers::Ruby::Legacy::Base.new(nil, nil).send(:tokval_list, toks, :all)
           args = args.map do |a|
             k, v = *a.split(/:|=/, 2)
-            [k.strip.to_s + (a[k.size, 1] == ':' ? ':' : ''), (v ? v.strip : nil)]
+            v.strip! if v
+            [k.strip.to_s + (a[k.size, 1] == ':' ? ':' : ''), (v && v.empty? ? nil : v)]
           end if args
           @name = meth.to_sym
           @parameters = args

--- a/spec/tags/overload_tag_spec.rb
+++ b/spec/tags/overload_tag_spec.rb
@@ -50,4 +50,19 @@ RSpec.describe YARD::Tags::OverloadTag do
     tag = Tags::OverloadTag.new(:overload, "default")
     expect(tag.signature).to eq "default"
   end
+
+  it "properly handles complex signatures" do
+    tag = Tags::OverloadTag.new(:overload, "foo(a, b = 1, *c, d, e:, f: 2, g:, **rest, &block)")
+    expect(tag.parameters).to eq [
+      ['a', nil],
+      ['b', "1"],
+      ['*c', nil],
+      ['d', nil],
+      ['e:', nil],
+      ['f:', "2"],
+      ['g:', nil],
+      ['**rest', nil],
+      ['&block', nil],
+    ]
+  end
 end


### PR DESCRIPTION
# Description

Previously, `@overload` tags that defined required keyword arguments would end up with an empty default value, to the delight of nobody. While this might *ideally* be handled by moving away from the legacy parsers, this is a stopgap that makes an already uncommon edge case go away.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
