### PR TITLE
Ensure YardocTask requires yard itself

### DIFF
--- a/lib/yard/rake/yardoc_task.rb
+++ b/lib/yard/rake/yardoc_task.rb
@@ -68,6 +68,9 @@ module YARD
       def define
         desc "Generate YARD Documentation" unless ::Rake.application.last_description
         task(name) do
+          # Lazy load yard so we don't impact the load time of the Rakefile
+          require_relative '../../yard'
+
           before.call if before.is_a?(Proc)
           yardoc = YARD::CLI::Yardoc.new
           yardoc.options[:verifier] = verifier if verifier


### PR DESCRIPTION
# Description

The yard task is not self contained at the moment and does not run without yard itself first being loaded.

It's preferable for rake tasks to be self-contained (the YardocTask should require its dependencies so users may require just the tasklib itself).

Fixes #1597 

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).
  - [x] `rake spec` passes locally. No tests added yet. Wanting feedback first before spending time deciphering test suite.

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
