### PR TITLE
Support nested structs of the form A::B = Struct.new(...)

### DIFF
--- a/lib/yard/handlers/ruby/constant_handler.rb
+++ b/lib/yard/handlers/ruby/constant_handler.rb
@@ -31,13 +31,13 @@ class YARD::Handlers::Ruby::ConstantHandler < YARD::Handlers::Ruby::Base
   end
 
   def process_structclass(statement)
-    lhs = statement[0][0]
-    if lhs.type == :const
-      klass = create_class(lhs[0], P(:Struct))
+    lhs = statement[0]
+    if (lhs.type == :var_field && lhs[0].type == :const) || lhs.type == :const_path_field
+      klass = create_class(lhs.source, P(:Struct))
       create_attributes(klass, extract_parameters(statement[1]))
       parse_block(statement[1].block[1], :namespace => klass) unless statement[1].block.nil?
     else
-      raise YARD::Parser::UndocumentableError, "Struct assignment to #{statement[0].source}"
+      raise YARD::Parser::UndocumentableError, "Struct assignment to #{lhs.source}"
     end
   end
 

--- a/spec/handlers/constant_handler_spec.rb
+++ b/spec/handlers/constant_handler_spec.rb
@@ -57,6 +57,18 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}Constant
     expect(obj.attributes[:instance]).to be_empty
   end
 
+  it "turns A::Const = Struct.new(:sym) into class A::Const with attr :sym" do
+    obj = Registry.at("A::NestedCompactStruct")
+    expect(obj).to be_kind_of(CodeObjects::ClassObject)
+    expect(obj.superclass).to eq P(:Struct)
+    attrs = obj.attributes[:instance]
+    [:b, :c].each do |key|
+      expect(attrs).to have_key(key)
+      expect(attrs[key][:read]).not_to be nil
+      expect(attrs[key][:write]).not_to be nil
+    end
+  end
+
   it "maintains docstrings on structs defined via constants" do
     obj = Registry.at("DocstringStruct")
     expect(obj).not_to be nil

--- a/spec/handlers/examples/constant_handler_001.rb.txt
+++ b/spec/handlers/examples/constant_handler_001.rb.txt
@@ -17,6 +17,7 @@ end
 MyClass = Struct.new(:a, :b, :c)
 NotMyClass = Struct.new("NotMyClass2", :b, :c)
 MyEmptyStruct = Struct.new
+A::NestedCompactStruct = Struct.new(:b, :c)
 
 MyStructWithConstant = Struct.new do
   # A constant.


### PR DESCRIPTION
# Description

On my codebase, yard fails when it happens to meet `Struct.new` assigned to a nested constant e.g. this code:

```ruby
A::B = Struct.new(:a, :b, :c)
```
fails with the following error:
```
[warn]: in YARD::Handlers::Ruby::ConstantHandler: Undocumentable Struct assignment to A::B
```

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
