### PR TITLE
Support both Commonmarker pre and post 1.0

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -89,7 +89,9 @@ module YARD
                              :tables,
                              :with_toc_data,
                              :no_intraemphasis).to_html
-        when 'CommonMarker'
+        when 'Commonmarker' # GFM configs are on by default; use YARD for syntax highlighting
+          Commonmarker.to_html(text, options: { extension: { header_ids: nil } }, plugins: {syntax_highlighter: nil})
+        when 'CommonMarker' # old, pre 1.0; downstream consumers should upgrade
           CommonMarker.render_html(text, %i[DEFAULT GITHUB_PRE_LANG], %i[autolink table])
         else
           provider.new(text).to_html

--- a/lib/yard/templates/helpers/markup_helper.rb
+++ b/lib/yard/templates/helpers/markup_helper.rb
@@ -30,7 +30,7 @@ module YARD
           {:lib => :maruku, :const => 'Maruku'},
           {:lib => :'rpeg-markdown', :const => 'PEGMarkdown'},
           {:lib => :rdoc, :const => 'YARD::Templates::Helpers::Markup::RDocMarkdown'},
-          {:lib => :commonmarker, :const => 'CommonMarker'}
+          {:lib => :commonmarker, :const => defined?(CommonMarker) ? 'CommonMarker' : "Commonmarker" }
         ],
         :textile => [
           {:lib => :redcloth, :const => 'RedCloth'}


### PR DESCRIPTION
# Description

Hello! I maintain [commonmarker](https://github.com/gjtorikian/commonmarker), a Ruby gem for converting CommonMark markup into HTML.

Recently, @noraj opened an issue asking me about https://github.com/lsegal/yard/pull/1540. I don't know the entire history of the PR, but my understanding is that there are two issues:

* YARD should support both pre- and post 1.0 versions of Commonmarker
* The `CommonMarker` const, which YARD uses, should not change, otherwise it's a breaking change
* [header tags need to be without IDs](https://github.com/lsegal/yard/pull/1540/files#r1731826662)

In this PR, I am proposing that YARD just keep using whatever configuration values it accepts to configure commonmarker processing; at the time of processing, if the old `CommonMarker` const is available, it's implied that that version of commonmarker is being used, so YARD should call the method that version expects; otherwise, the newer version will be used. 
 
The one case this doesn't cover is [this one](https://github.com/lsegal/yard/pull/1540/files#r1731826662): 

> we need to test both CommonMarker / Commonmarker implementations.

Note that the current test suite passes, because unlike #1540 I passed the options necessary to make a 1:1 match to the old behavior. But: I don't know how to configure the tests or more specifically CI to load two versions of the gem—nor am I interested in learning how! 

I think I've fulfilled my open source duties thus far. If I can help push this along in any way let me know. ✌️ 

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
