### PR TITLE
Fix array-within-word-array parsing

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -390,7 +390,7 @@ module YARD
 
         def on_array(other)
           node = AstNode.node_class_for(:array).new(:array, [other])
-          map = @map[MAPPINGS[node.type]]
+          map = @map[MAPPINGS[node.type]] if other.nil? || other.type == :list
           if map && !map.empty?
             lstart, sstart = *map.pop
             node.source_range = Range.new(sstart, @ns_charno - 1)


### PR DESCRIPTION
# Description

When yard saw a constant like:

```ruby
FOO = [%w[bar baz]]
```

it cut off the array at the first closing bracket in the resulting documentation:

```ruby
[%w[bar baz]
```

Fix by ensuring that these types of arrays, which don't have a
starting :lbracket, don't pop off :lbracket state in `@map`

Drop dead code and add a variety of related regression cases found in
my application using sord after trying different fixes.

# Completed Tasks

- [X] I have read the [Contributing Guide][contrib].
- [X] The pull request is complete (implemented / written).
- [X] Git commits have been cleaned up (squash WIP / revert commits).
- [X] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
