### PR TITLE
Remove rackup server

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ end
 
 group :server do
   gem 'rack', '~> 2.0'
+  gem 'rackup', '~> 1.0'
 end
 
 group :i18n do


### PR DESCRIPTION
# Description

`Rackup::Server` was removed on 1.0.1. There's no much explanation on [their changelog](https://github.com/rack/rackup/blob/main/releases.md), and the git blame doesn't give up much information either. Fact is that this class doesn't exist.

The first commit simply adds this dependency, which breaks the specs. The second fixes it.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
