### PR TITLE
Improve a few type annotations

### DIFF
--- a/lib/yard/code_objects/base.rb
+++ b/lib/yard/code_objects/base.rb
@@ -228,7 +228,7 @@ module YARD
       # @example Create class Z inside namespace X::Y
       #   CodeObjects::Base.new(P("X::Y"), :Z) # or
       #   CodeObjects::Base.new(Registry.root, "X::Y")
-      # @param [NamespaceObject] namespace the namespace the object belongs in,
+      # @param [NamespaceObject, :root, nil] namespace the namespace the object belongs in,
       #   {Registry.root} or :root should be provided if it is associated with
       #   the top level namespace.
       # @param [Symbol, String] name the name (or complex path) of the object.

--- a/lib/yard/tags/tag.rb
+++ b/lib/yard/tags/tag.rb
@@ -38,7 +38,7 @@ module YARD
       # +raise+, etc.
       #
       # @param [#to_s] tag_name        the tag name to create the tag for
-      # @param [String] text           the descriptive text for this tag
+      # @param [String, nil] text      the descriptive text for this tag, or nil if none provided
       # @param [Array<String>] types   optional type list of formally declared types
       #                                for the tag
       # @param [String] name           optional key name which the tag refers to

--- a/lib/yard/templates/helpers/markup/rdoc_markup.rb
+++ b/lib/yard/templates/helpers/markup/rdoc_markup.rb
@@ -38,6 +38,7 @@ module YARD
           @@formatter = nil
           @@markup = nil
 
+          # @param text [String]
           def initialize(text)
             @text = text
 
@@ -47,6 +48,7 @@ module YARD
             end
           end
 
+          # @return [String]
           def to_html
             html = nil
             @@mutex.synchronize do


### PR DESCRIPTION
# Description

This is just a few type annotations that a typecheck of the Solargraph codebase found were missing.  The relevant parts of Solargraph typechecked correctly after these were added.

# Completed Tasks

- [X] I have read the [Contributing Guide][contrib].
- [ X The pull request is complete (implemented / written).
- [X] Git commits have been cleaned up (squash WIP / revert commits).
- [X] I <s>wrote tests</s><b>Re-typechecked dependent project</b> and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
