### PR TITLE
Only load from `cgi` what is required for Ruby 3.5

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -1,5 +1,9 @@
 # frozen_string_literal: true
-require 'cgi'
+if RUBY_VERSION < '3.5'
+  require 'cgi/util'
+else
+  require 'cgi/escape'
+end
 
 module YARD
   module Templates::Helpers

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -103,7 +103,11 @@ def docspec(objname = self.class.description, klass = self.class.described_type)
 end
 
 module Kernel
-  require 'cgi'
+  if RUBY_VERSION < '3.5'
+    require 'cgi/util'
+  else
+    require 'cgi/escape'
+  end
 
   def p(*args)
     puts args.map {|arg| CGI.escapeHTML(arg.inspect) }.join("<br/>\n")


### PR DESCRIPTION
# Description

In Ruby 3.5 most of the cgi gem will be removed. Only the various escape/unescape methods will be retained by default.

But:
* On Ruby 3.5, `cgi/escape` is enough
* Earlier versions need `cgi/util` since the unescape methods don't work otherwise.

I tested this down to Ruby 2.0.

https://bugs.ruby-lang.org/issues/21258

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
