### PR TITLE
Allow literal symbols in types

### DIFF
--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -398,8 +398,10 @@ module YARD
 
         def on_aref_field(*args)
           @map[:lbracket].pop
-          AstNode.new(:aref_field, args,
-                      :listline => lineno..lineno, :listchar => charno...charno)
+          ll, lc = *@map[:aref].shift
+          sr = args.first.source_range.begin..lc
+          lr = args.first.line_range.begin..ll
+          AstNode.new(:aref_field, args, :char => sr, :line => lr)
         end
 
         def on_array(other)

--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -228,7 +228,7 @@ module YARD
       # @return [String] HTML with linkified references
       def resolve_links(text)
         code_tags = 0
-        text.gsub(%r{<(/)?(pre|code|tt)|(\\|!)?\{(?!\})(\S+?)(?:\s([^\}]*?\S))?\}(?=[\W<]|.+</|$)}m) do |str|
+        text.gsub(%r{<(/)?(pre|code|tt)|(\\|!)?\{(?!\})(\S+?)(?:\s([^\}]*?\S))?\}(?=\W|.+</|$)}m) do |str|
           closed = $1
           tag = $2
           escape = $3

--- a/yard.gemspec
+++ b/yard.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.executables   = ['yard', 'yardoc', 'yri']
   s.license = 'MIT' if s.respond_to?(:license=)
   s.metadata['yard.run'] = 'yri'
+  s.metadata['changelog_uri'] = 'https://rubydoc.info/gems/yard/file/CHANGELOG.md'
 end


### PR DESCRIPTION

# Description

This matches behavior of https://yardoc.org/types. Literal symbols are also supported by RBS, sord and recent versions of Solargraph, so this also reduces interoperability friction between tools.  

For instance, valid Solargraph annotations will cause errors in rubocop-yard, which uses YARD for parsing:

```
  lib/solargraph/complex_type/unique_type.rb:200:27: C: YARD/TagTypeSyntax: (SyntaxError) invalid character at :
```

# Completed Tasks

- [X] I have read the [Contributing Guide][contrib].
- [X] The pull request is complete (implemented / written).
- [X] Git commits have been cleaned up (squash WIP / revert commits).
- [X] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
