### PR TITLE
Handle **nil with named block without errors

### DIFF
--- a/lib/yard/parser/ruby/ast_node.rb
+++ b/lib/yard/parser/ruby/ast_node.rb
@@ -431,7 +431,8 @@ module YARD
           # shape is (required, optional, rest, more, keyword, keyword_rest, block)
           # Ruby 3.1 moves :args_forward from rest to keyword_rest
           args_index = YARD.ruby31? ? -2 : 2
-          self[args_index].type == :args_forward if self[args_index]
+          node = self[args_index]
+          node.is_a?(AstNode) && node.type == :args_forward
         end
       end
 

--- a/spec/handlers/method_handler_spec.rb
+++ b/spec/handlers/method_handler_spec.rb
@@ -124,6 +124,16 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MethodHa
     expect(P('Foo#d_unnamed_splat').parameters).to eq []
   end
 
+  it "handles **nil with named block" do
+    YARD.parse_string <<-RUBY
+      class KwNilBlock
+        def no_kwargs_with_block(**nil, &block); end
+      end
+    RUBY
+
+    expect(P('KwNilBlock#no_kwargs_with_block').parameters).to eq [['&block', nil]]
+  end if YARD.ruby3?
+
   it "handles overloads" do
     meth = P('Foo#foo')
 


### PR DESCRIPTION
## Summary
- avoid `NoMethodError` when parsing methods using `**nil` and a named block
- test parsing `**nil` keyword rejection alongside a block

## Testing
- `bundle exec rake spec`

Fixes #1621

------
https://chatgpt.com/codex/tasks/task_e_68957569ebe4833095a123c8b3bf62d9