### PR TITLE
Fix frozen string literal mutation

### DIFF
--- a/lib/yard/parser/ruby/legacy/ruby_lex.rb
+++ b/lib/yard/parser/ruby/legacy/ruby_lex.rb
@@ -978,7 +978,7 @@ module YARD
       end
 
       def identify_identifier
-        token = ""
+        token = String.new(encoding: Encoding::UTF_8)
         token.concat getc if peek(0) =~ /[$@]/
         token.concat getc if peek(0) == "@"
 


### PR DESCRIPTION
There's a warning

```shell
ruby_lex.rb:987: warning: literal string will be frozen in the future (run with --debug-frozen-string-literal for more information
```

which will lead to an error when frozen strings literals (MRI 3.5?) will be frozen by default.

# Description

Describe your pull request and problem statement here.

# Completed Tasks

- [X] I have read the [Contributing Guide][contrib].
- [X] The pull request is complete (implemented / written).
- [X] Git commits have been cleaned up (squash WIP / revert commits).
- [X] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
