### PR TITLE
Add support for duck types with multiple methods to TypesExplainer

### DIFF
--- a/lib/yard/tags/types_explainer.rb
+++ b/lib/yard/tags/types_explainer.rb
@@ -32,7 +32,7 @@ module YARD
 
         def to_s(singular = true)
           if name[0, 1] == "#"
-            singular ? "an object that responds to #{name}" : "objects that respond to #{name}"
+            (singular ? "an object that responds to " : "objects that respond to ") + list_join(name.split(/ *& */), with: "and")
           elsif name[0, 1] =~ /[A-Z]/
             singular ? "a#{name[0, 1] =~ /[aeiou]/i ? 'n' : ''} " + name : "#{name}#{name[-1, 1] =~ /[A-Z]/ ? "'" : ''}s"
           else
@@ -42,12 +42,12 @@ module YARD
 
         private
 
-        def list_join(list)
+        def list_join(list, with: "or")
           index = 0
           list.inject(String.new) do |acc, el|
             acc << el.to_s
             acc << ", " if index < list.size - 2
-            acc << " or " if index == list.size - 2
+            acc << " #{with} " if index == list.size - 2
             index += 1
             acc
           end

--- a/spec/tags/types_explainer_spec.rb
+++ b/spec/tags/types_explainer_spec.rb
@@ -38,6 +38,18 @@ RSpec.describe YARD::Tags::TypesExplainer do
       expect(@t.to_s(false)).to eq "objects that respond to #mymethod"
     end
 
+    it "works for multiple methods joined with '&' (ducktype)" do
+      @t.name = "#mymethod&#myothermethod&#mythirdmethod"
+      expect(@t.to_s).to eq "an object that responds to #mymethod, #myothermethod and #mythirdmethod"
+      expect(@t.to_s(false)).to eq "objects that respond to #mymethod, #myothermethod and #mythirdmethod"
+    end
+
+    it "works for multiple methods joined with ' & ' (ducktype)" do
+      @t.name = "#mymethod & #myothermethod & #mythirdmethod"
+      expect(@t.to_s).to eq "an object that responds to #mymethod, #myothermethod and #mythirdmethod"
+      expect(@t.to_s(false)).to eq "objects that respond to #mymethod, #myothermethod and #mythirdmethod"
+    end
+    
     it "works for a constant value" do
       ['false', 'true', 'nil', '4'].each do |name|
         @t.name = name


### PR DESCRIPTION
# Description

- Adds support for multiple-method duck types delimited with `&`, cf. @lsegal's suggestion in [this StackOverflow comment from 13+ years ago](https://stackoverflow.com/a/9127271/27358).

## Discussion

I agree with the sentiment expressed in that comment that doing this is not a great idea, and in general, it would be better to define an ad-hoc "interface" type. But there are times when you're dealing with an obnoxious third-party library, and you just need to document something in one place, and introducing a whole type for that feels like overkill.

This is a basic implementation that just covers this use case, but I could see an argument for instead supporting `&` for intersection types in general (and maybe `|` as well as `,` for union types while we're at it), which wouldn't be much more code.

# Completed Tasks

- [X] I have read the [Contributing Guide][contrib].
- [X] The pull request is complete (implemented / written).
- [X] Git commits have been cleaned up (squash WIP / revert commits).
- [X] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
