### PR TITLE
Respect Ruby semantics for bare visibility with singleton defs

### DIFF
--- a/lib/yard/handlers/base.rb
+++ b/lib/yard/handlers/base.rb
@@ -462,6 +462,18 @@ module YARD
           end
         end
 
+        if docstring.is_a?(String)
+          if (m = docstring.match(/^\s*@!?visibility\s+(public|private|protected)\b/m))
+            vis_sym = m[1].to_sym
+
+            if object.nil?
+              globals.visibility_origin = :directive
+            elsif object.is_a?(CodeObjects::MethodObject)
+              object.visibility = vis_sym
+            end
+          end
+        end
+
         register_transitive_tags(object)
       end
 
@@ -511,7 +523,17 @@ module YARD
       def register_visibility(object, visibility = self.visibility)
         return unless object.respond_to?(:visibility=)
         return if object.is_a?(NamespaceObject)
-        object.visibility = visibility
+
+        if object.is_a?(CodeObjects::MethodObject)
+          origin = globals.visibility_origin
+          if origin == :keyword
+            object.visibility = visibility if object.scope == scope
+          else
+            object.visibility = visibility
+          end
+        else
+          object.visibility = visibility
+        end
       end
 
       # Registers the same method information on the module function, if

--- a/lib/yard/handlers/ruby/legacy/visibility_handler.rb
+++ b/lib/yard/handlers/ruby/legacy/visibility_handler.rb
@@ -8,9 +8,10 @@ class YARD::Handlers::Ruby::Legacy::VisibilityHandler < YARD::Handlers::Ruby::Le
     vis = statement.tokens.first.text
     if statement.tokens.size == 1
       self.visibility = vis
+      globals.visibility_origin = :keyword
     else
       tokval_list(statement.tokens[2..-1], :attr).each do |name|
-        MethodObject.new(namespace, name, scope) {|o| o.visibility = vis }
+        MethodObject.new(namespace, name, scope) { |o| o.visibility = vis }
       end
     end
   end

--- a/lib/yard/handlers/ruby/visibility_handler.rb
+++ b/lib/yard/handlers/ruby/visibility_handler.rb
@@ -13,6 +13,7 @@ class YARD::Handlers::Ruby::VisibilityHandler < YARD::Handlers::Ruby::Base
     case statement.type
     when :var_ref, :vcall
       self.visibility = ident.first.to_sym
+      globals.visibility_origin = :keyword
     when :command
       if RUBY_VERSION >= '3.' && is_attribute_method?(statement.parameters.first)
         parse_block(statement.parameters.first, visibility: ident.first.to_sym)

--- a/spec/templates/helpers/shared_signature_examples.rb
+++ b/spec/templates/helpers/shared_signature_examples.rb
@@ -27,7 +27,7 @@ RSpec.shared_examples_for "signature" do
   end
 
   it "shows signature for private class method" do
-    YARD.parse_string "class A; private; def self.foo; end end"
+    YARD.parse_string "class A; private_class_method def self.foo; end end"
     expect(trim(signature(Registry.at('A.foo')))).to eq @results[:private_class]
   end
 


### PR DESCRIPTION
# Description

YARD incorrectly marked singleton method definitions (`def self.x`) as private when a bare private appeared earlier in the class body. This problem was originally described here (https://github.com/lsegal/yard/issues/1496). Ruby semantics say a bare access modifier affects only the current def-target:

- class body: affects instance methods only
- inside `class << self`: affects class methods only
- `def self.x` in a class body remains public unless:
  - `private_class_method` is used, or
  - `private` appears inside `class << self`

This PR brings YARD in line with Ruby.

Behavior change:
- Bare `private`/`public`/`protected` now only affect methods whose scope matches the current def-target.
- `@!visibility` directive continues to apply regardless of method scope (as before), since it’s a documentation control.
- Explicit statements `private :foo`/`public :foo` are unaffected.
- `private_class_method`/`public_class_method` handlers continue to set exact visibilities.

So, the code from the issue now outputs correctly:
```ruby
require 'yard'

code = <<~CODE
  class T
    def m1
      T.m2
    end

    private

    def self.m2
      print 123
    end

    class << self
      private

      def m3; end
    end
  end
CODE

def detect_private_methods(code)
  YARD.parse_string(code)
  YARD::Registry.all(:class).map do |class_obj|
    class_obj.meths(inherited: false).map do |method_obj|
      if method_obj.scope == :class && method_obj.visibility == :private
        puts "Method #{method_obj.name} is a #{method_obj.visibility} #{method_obj.scope} method!"
      end
    end
  end
end

detect_private_methods(code)
# Method m3 is a private class method!
# => [[nil, nil, nil]]
```

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
