### PR TITLE
Add irb gem as dependency for Ruby v4.0

### DIFF
--- a/yard.gemspec
+++ b/yard.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |s|
   s.executables   = ['yard', 'yardoc', 'yri']
   s.license = 'MIT' if s.respond_to?(:license=)
   s.metadata['yard.run'] = 'yri'
+  s.add_dependency 'irb'
 end


### PR DESCRIPTION
# Description

Although the `irb` gem is still a default gem in Ruby v4.0, it is deprecated and will likely be removed in Ruby v4.1. At the moment, deprecation warnings like this are displayed:

    /usr/local/bundle/gems/yard-0.9.38/lib/yard/parser/ruby/legacy/irb/slex.rb:13:
    warning: irb/notifier is found in irb, which is not part of the default gems since Ruby 4.0.0.
    You can add irb to your Gemfile or gemspec to fix this error.

Currently library code in the `yard` gem depends on `irb` in at least 2 places:
* `lib/yard/parser/ruby/legacy/irb/slex.rb`
* `lib/yard/parser/ruby/legacy/ruby_lex.rb`

This suggests that the `irb` gem should be added as a dependency in the `yard` gemspec.

Fixes #1636.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
