### PR TITLE
Fix Ruby 3.4 regex warning: remove duplicated range in character class

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -228,7 +228,7 @@ module YARD
       # @return [String] HTML with linkified references
       def resolve_links(text)
         code_tags = 0
-        text.gsub(%r{<(/)?(pre|code|tt)|(\\|!)?\{(?!\})(\S+?)(?:\s([^\}]*?\S))?\}(?=[\W<]|.+</|$)}m) do |str|
+        text.gsub(%r{<(/)?(pre|code|tt)|(\\|!)?\{(?!\})(\S+?)(?:\s([^\}]*?\S))?\}(?=\W|.+</|$)}m) do |str|
           closed = $1
           tag = $2
           escape = $3


### PR DESCRIPTION
# Description

Replace `[\W<]` with `\W` in regex lookahead since `<` is already [included](https://ruby-doc.org/3.4.1/Regexp.html#class-Regexp-label-Shorthand+Character+Classes) in `\W`. This resolves the 'character class has duplicated range' warning in Ruby 3.4.

Fixes #1609

Warnings are [disabled](https://github.com/lsegal/yard/blob/34796c5bfc0ce69a5fea1b38d96435fc4f5b7a75/spec/spec_helper.rb#L188) in specs, so I am unable to easily write an effective test.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [ ] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
