### PR TITLE
Add support for Ruby v4.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         # 3.0 is interpreted as 3
-        ruby: ["3.0", 3.1, 3.2, 3.3, 3.4]
+        ruby: ["3.0", 3.1, 3.2, 3.3, 3.4, "4.0"]
         include:
           - os: ubuntu-latest
             container: ruby:2.2

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 
 group :development do
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4.0.0')
+    gem 'benchmark'
     gem 'irb'
     gem 'logger'
   end

--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 group :development do
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4.0.0')
     gem 'irb'
+    gem 'logger'
   end
   gem 'rspec', '>= 3.11.0'
   gem 'rake'

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,9 @@
 source 'https://rubygems.org'
 
 group :development do
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4.0.0')
+    gem 'irb'
+  end
   gem 'rspec', '>= 3.11.0'
   gem 'rake'
   gem 'rdoc', '= 6.1.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ group :development do
     gem 'benchmark'
     gem 'irb'
     gem 'logger'
+    gem 'ostruct'
   end
   gem 'rspec', '>= 3.11.0'
   gem 'rake'

--- a/lib/yard/rubygems/specification.rb
+++ b/lib/yard/rubygems/specification.rb
@@ -11,7 +11,7 @@ class Gem::Specification
     @has_rdoc == 'yard'
   end
 
-  undef has_rdoc?
+  undef has_rdoc? if method_defined?(:has_rdoc?)
   def has_rdoc?
     (@has_rdoc ||= true) && @has_rdoc != 'yard'
   end

--- a/spec/handlers/ruby/base_spec.rb
+++ b/spec/handlers/ruby/base_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe YARD::Handlers::Ruby::Base, '#valid_handler?' do
       handles "x"
     end
     allow(Handlers::Base).to receive(:subclasses).and_return [StringHandler]
-    ast = Parser::Ruby::RubyParser.parse("if x == 2 then true end").ast
+    ast = YARD::Parser::Ruby::RubyParser.parse("if x == 2 then true end").ast
     valid StringHandler, ast[0][0][0]
     invalid StringHandler, ast[0][1]
   end
@@ -56,7 +56,7 @@ RSpec.describe YARD::Handlers::Ruby::Base, '#valid_handler?' do
       handles(/^if x ==/)
     end
     allow(Handlers::Base).to receive(:subclasses).and_return [RegexHandler]
-    ast = Parser::Ruby::RubyParser.parse("if x == 2 then true end").ast
+    ast = YARD::Parser::Ruby::RubyParser.parse("if x == 2 then true end").ast
     valid RegexHandler, ast
     invalid RegexHandler, ast[0][1]
   end
@@ -75,7 +75,7 @@ RSpec.describe YARD::Handlers::Ruby::Base, '#valid_handler?' do
       handles method_call(:meth)
     end
     allow(Handlers::Base).to receive(:subclasses).and_return [MethCallHandler]
-    ast = Parser::Ruby::RubyParser.parse(<<-"eof").ast
+    ast = YARD::Parser::Ruby::RubyParser.parse(<<-"eof").ast
       meth                   # 0
       meth()                 # 1
       meth(1,2,3)            # 2

--- a/yard.gemspec
+++ b/yard.gemspec
@@ -20,4 +20,7 @@ Gem::Specification.new do |s|
   s.executables   = ['yard', 'yardoc', 'yri']
   s.license = 'MIT' if s.respond_to?(:license=)
   s.metadata['yard.run'] = 'yri'
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4.0.0')
+    s.add_dependency 'irb'
+  end
 end

--- a/yard.gemspec
+++ b/yard.gemspec
@@ -22,5 +22,6 @@ Gem::Specification.new do |s|
   s.metadata['yard.run'] = 'yri'
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4.0.0')
     s.add_dependency 'irb'
+    s.add_dependency 'logger'
   end
 end


### PR DESCRIPTION
# Description

Add support for Ruby v4.0.

I've added Ruby v4.0 to the CI build matrix and then worked through fixing various problems.

The main problems relate to default gems which [became "bundled" in Ruby v4.0][1]. In many cases I've had to add them to both the gemspec and the Gemfile, because as far as I can tell the former isn't used by the specs. There might be a better way to do this and avoid the duplication...?

I've also wrapped the declaration of these dependencies in an `if` condition on the Ruby version being at least v4.0.0. If you don't care about adding these extra dependencies in earlier versions of Ruby, you might be able to get away without these conditions.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md

Supersedes #1638. Fixes #1636.

[1]: https://rubyreferences.github.io/rubychanges/4.0.html#default-gems-that-became-bundled