### PR TITLE
fix: relative URL resolution for client-side docs navigation

### DIFF
--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -347,7 +347,8 @@ window.addEventListener(
   "message",
   async (e) => {
     if (e.data.action === "navigate") {
-      const response = await fetch(e.data.url);
+      const rel_url = relpath + e.data.url;
+      const response = await fetch(rel_url);
       const text = await response.text();
       const parser = new DOMParser();
       const doc = parser.parseFromString(text, "text/html");
@@ -383,12 +384,12 @@ window.addEventListener(
 
       document.getElementById("class_list_link").classList = classListLink;
 
-      const url = new URL(e.data.url, "https://localhost");
+      const url = new URL(rel_url, "https://localhost");
       const hash = decodeURIComponent(url.hash ?? "");
       if (hash) {
         document.getElementById(hash.substring(1)).scrollIntoView();
       }
-      history.pushState({}, document.title, e.data.url);
+      history.pushState({}, document.title, rel_url);
     }
   },
   false


### PR DESCRIPTION
## Summary
Sidebar navigation links are generated as relative URLs that work from the docs root, but they break when the current page is under a nested path.

This change uses the existing `relpath` value https://github.com/lsegal/yard/blob/eddd10c3948021c34a887db403824ce5a892708b/templates/default/layout/html/script_setup.erb#L3 to build a resolved URL (`rel_url = relpath + e.data.url`) and then uses that resolved URL consistently during navigation.

Please see the homebrew ruby docs as an example: https://docs.brew.sh/rubydoc/Formula/FormulaConflict.html. From this class try going to any other class. Also see https://github.com/Homebrew/brew/pull/21589
