### PR TITLE
Fix static HTML class list navigation path duplication (#1639)

### DIFF
--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -347,7 +347,12 @@ window.addEventListener(
   "message",
   async (e) => {
     if (e.data.action === "navigate") {
-      const response = await fetch(e.data.url);
+      // Resolve the URL against the iframe's location to handle relative paths correctly
+      const iframe = document.getElementById("nav");
+      const iframeUrl = iframe ? iframe.contentWindow.location.href : window.location.href;
+      const resolvedUrl = new URL(e.data.url, iframeUrl).href;
+
+      const response = await fetch(resolvedUrl);
       const text = await response.text();
       const parser = new DOMParser();
       const doc = parser.parseFromString(text, "text/html");
@@ -383,12 +388,12 @@ window.addEventListener(
 
       document.getElementById("class_list_link").classList = classListLink;
 
-      const url = new URL(e.data.url, "https://localhost");
+      const url = new URL(resolvedUrl);
       const hash = decodeURIComponent(url.hash ?? "");
       if (hash) {
         document.getElementById(hash.substring(1)).scrollIntoView();
       }
-      history.pushState({}, document.title, e.data.url);
+      history.pushState({}, document.title, resolvedUrl);
     }
   },
   false


### PR DESCRIPTION
 ## Summary
Fixes #1639

This fixes a breaking bug in v0.9.38 where clicking nested class links in the class list generates incorrect URLs when serving static HTML documentation, resulting in 404 errors.

## Root Cause
The fetch-based navigation system (commit e18b8440) resolves relative URLs from the class list iframe against the main frame's current URL instead of the iframe's base URL. When viewing `/Foo/Bar.html` and clicking a link to `Foo/Baz.html`, the browser incorrectly resolves it as `/Foo/Foo/Baz.html`.

## The Fix
* Resolve URLs against the iframe's `contentWindow.location` instead of the main frame location
* This ensures relative paths like `Foo/Baz.html` resolve correctly regardless of the current page

## Testing

Reproduced the issue with nested class structure:
```ruby
class Foo
    class Bar; end
    class Baz; end
end
```

- Before fix: Clicking Foo::Baz from /Foo/Bar.html → /Foo/Foo/Baz.html
- After fix: Clicking Foo::Baz from /Foo/Bar.html → /Foo/Baz.html

Related: https://github.com/block/elasticgraph/issues/1048