### PR TITLE
Make asciidoctor gem optional in tests

### DIFF
--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -189,6 +189,8 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
     end
 
     it "sets env and env-yard attributes (AsciiDoc specific)" do
+      skip "Missing asciidoctor gem" if markup_class(:asciidoc).nil?
+
       adoc = <<-EOF.strip.gsub(/^ +/, "") # strip and unindent
         ifdef::env[]
         Attribute "env" is set, and its value is "{env}".
@@ -204,6 +206,8 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
     end
 
     it "should not include the document title from the AsciiDoc header" do
+      skip "Missing asciidoctor gem" if markup_class(:asciidoc).nil?
+
       adoc = <<-EOF.strip.gsub(/^ +/, "") # strip and unindent
         = Project Name
 


### PR DESCRIPTION
# Description

Everything not in the `development` group in the Gemfile appears to be optional. There is code elsewhere to skip these gems when they are not installed:

https://github.com/lsegal/yard/blob/eddd10c3948021c34a887db403824ce5a892708b/spec/templates/markup_processor_integrations/integration_spec_helper.rb#L27-L31

https://github.com/lsegal/yard/blob/eddd10c3948021c34a887db403824ce5a892708b/spec/i18n/locale_spec.rb#L24-L43

This wasn't however the case for `asciidoctor`, which is currently required to be installed for the tests to pass.

This fixes the affected tests on Ruby 4.0 as `asciidoctor` doesn't support Ruby 4.0 upstream yet.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
