### PR TITLE
Drop old RubyGems require from Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 require File.dirname(__FILE__) + '/lib/yard'
-require File.dirname(__FILE__) + '/lib/yard/rubygems/specification'
 require 'rbconfig'
 
 YARD::VERSION.replace(ENV['YARD_VERSION']) if ENV['YARD_VERSION']


### PR DESCRIPTION
# Description

`yard/rubygems/specification` is code targetted towards RubyGems < 2.0:

https://github.com/lsegal/yard/blob/eddd10c3948021c34a887db403824ce5a892708b/lib/rubygems_plugin.rb#L2-L9

It however was unconditionally required in the Rakefile. This code has finally broken in RubyGems 4.0.

Instead of updating 1.x legacy code to support all future versions (which would really be just making the file no-op on them anyway), it seems we can just drop the require in the Rakefile as it doesn't appear to be needed at all in the Rakefile unless it does something subtle I'm not aware of? It remains in the RubyGems plugin file as normal with the correct conditions.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
