### PR TITLE
Make inherited methods appear in groups if applicable

### DIFF
--- a/spec/templates/module_spec.rb
+++ b/spec/templates/module_spec.rb
@@ -200,4 +200,38 @@ RSpec.describe YARD::Templates::Engine.template(:default, :module) do
     eof
     html_equals(Registry.at('A').format(html_options), :module005)
   end
+
+  it "shows inherited methods from matching groups in the group section, not in flat inherited section" do
+    Registry.clear
+    YARD.parse_string <<-'eof'
+      class Parent
+        # @group DSL Methods
+        def parent_dsl; end
+
+        # @group Other
+        def parent_other; end
+      end
+
+      class Child < Parent
+        # @group DSL Methods
+        def child_dsl; end
+      end
+    eof
+
+    result = Registry.at('Child').format(html_options)
+
+    # The "DSL Methods" section should contain an "inherited from Parent" subsection with parent_dsl
+    dsl_section = result[/(<h2>\s*DSL Methods.*?)<h2>/m, 1]
+    expect(dsl_section).not_to be_nil
+    expect(dsl_section).to include('inherited')
+    expect(dsl_section).to include('parent_dsl')
+
+    # parent_dsl should NOT appear outside the "DSL Methods" section
+    # i.e. it should not appear in the flat inherited section
+    rest_of_page = result.sub(dsl_section, '')
+    expect(rest_of_page).not_to include('parent_dsl')
+
+    # parent_other (in "Other" group, not in Child) should still appear in the flat inherited section
+    expect(result).to include('parent_other')
+  end
 end

--- a/templates/default/module/html/inherited_methods.erb
+++ b/templates/default/module/html/inherited_methods.erb
@@ -5,6 +5,7 @@
   <% meths = prune_method_listing(superclass.meths(:included => false, :inherited => false)) %>
   <% meths.reject! {|m| object.child(:scope => m.scope, :name => m.name) != nil } %>
   <% meths.reject! {|m| m.is_alias? || m.is_attribute? } %>
+  <% meths.reject! {|m| m.group && object.groups && object.groups.include?(m.group) } %>
   <% next if meths.size == 0 %>
   <% if method_listing.size == 0 && !found_method %><h2>Method Summary</h2><% end %>
   <% found_method = true %>

--- a/templates/default/module/html/method_summary.erb
+++ b/templates/default/module/html/method_summary.erb
@@ -10,5 +10,13 @@
         <%= yieldall :item => meth %>
       <% end %>
     </ul>
+    <% (inherited_methods_by_group[name] || {}).each do |superclass, meths| %>
+      <h3 class="inherited">Methods <%= superclass.type == :class ? 'inherited' : 'included' %> from <%= linkify superclass %></h3>
+      <p class="inherited"><%= meths.sort_by {|o| o.name.to_s }.map {|m|
+        mname = m.name(true)
+        mname = mname.gsub(/^#/, '') if superclass.type == :module && object.class_mixins.include?(superclass)
+        linkify(m, mname)
+      }.join(", ") %></p>
+    <% end %>
   <% end %>
 <% end %>

--- a/templates/default/module/setup.rb
+++ b/templates/default/module/setup.rb
@@ -104,6 +104,26 @@ def inherited_constant_list
   end
 end
 
+def inherited_methods_by_group
+  return @inherited_meths_by_group if defined?(@inherited_meths_by_group)
+  @inherited_meths_by_group = {}
+  return @inherited_meths_by_group unless object.groups
+
+  object.inheritance_tree(true)[1..-1].each do |superclass|
+    next if superclass.is_a?(YARD::CodeObjects::Proxy)
+    next if options.embed_mixins.size > 0 && options.embed_mixins_match?(superclass) != false
+    meths = prune_method_listing(superclass.meths(:included => false, :inherited => false))
+    meths.reject! {|m| object.child(:scope => m.scope, :name => m.name) != nil }
+    meths.reject! {|m| m.is_alias? || m.is_attribute? }
+    meths.each do |m|
+      next unless m.group && object.groups.include?(m.group)
+      (@inherited_meths_by_group[m.group] ||= {})[superclass] ||= []
+      @inherited_meths_by_group[m.group][superclass] << m
+    end
+  end
+  @inherited_meths_by_group
+end
+
 def docstring_full(obj)
   docstring = obj.tags(:overload).size == 1 && obj.docstring.empty? ?
     obj.tag(:overload).docstring : obj.docstring


### PR DESCRIPTION
# Description

Make inherited methods appear in groups if applicable. Example:

```ruby
module Kat

	# @!group DSL Methods

	def eat
	end

	# @!endgroup

	def drink
	end
end

class Mar

	include Kat

	# @!group DSL Methods

	def sleep
	end

	# @!endgroup

	def rest
	end
end
```

<img width="587" height="460" alt="image" src="https://github.com/user-attachments/assets/890df205-be5b-4e38-a7c9-69300be5f69f" />


# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
