### PR TITLE
Fix false self-referential mixin when bare name matches ancestor namespace

### DIFF
--- a/lib/yard/registry_resolver.rb
+++ b/lib/yard/registry_resolver.rb
@@ -75,6 +75,13 @@ module YARD
       lexical_lookup = 0
       while namespace && !resolved
         resolved = lookup_path_direct(namespace, path, type)
+        # Prevent a bare name from resolving back to the namespace we started
+        # from when searching through a parent namespace. For example,
+        # `include Enumerable` inside `A::Enumerable` would walk up to namespace
+        # `A` and match `A::Enumerable`, creating a false self-referential mixin.
+        # Only skip when we have already moved to a parent (namespace != orignamespace).
+        # See https://github.com/lsegal/yard/issues/1116
+        resolved = nil if resolved.equal?(orignamespace) && !namespace.equal?(orignamespace)
         resolved ||= lookup_path_inherited(namespace, path, type) if inheritance
         break if resolved
         namespace = namespace.parent

--- a/spec/handlers/examples/mixin_handler_001.rb.txt
+++ b/spec/handlers/examples/mixin_handler_001.rb.txt
@@ -39,6 +39,13 @@ end
 module FromConstant; end
 FromConstant.include A
 
+module Outer1
+end
+
+module Outer1::Inner
+  include Inner
+end
+
 module Foo
 end
 

--- a/spec/handlers/mixin_handler_spec.rb
+++ b/spec/handlers/mixin_handler_spec.rb
@@ -45,6 +45,20 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}MixinHan
     expect(P("ABC::DEF::BAR").mixins).to eq [P("ABC::BAR")]
   end
 
+  it "does not create self-referential mixin when bare name matches an ancestor namespace" do
+    # `include Inner` inside `Outer1::Inner` should not resolve to `Outer1::Inner` itself.
+    # Previously YARD would walk up to namespace `Outer1` and find `Outer1::Inner`,
+    # producing a false cyclic mixin. See https://github.com/lsegal/yard/issues/1116
+    mod = P("Outer1::Inner")
+    expect(mod.mixins.map(&:path)).not_to include("Outer1::Inner")
+    expect(mod.mixins.map(&:path)).to eq ["Inner"]
+    # inheritance_tree(true) should not recurse infinitely and should not
+    # include Outer1::Inner as a *mixin* (it appears only as self at index 0)
+    tree = mod.inheritance_tree(true)
+    expect(tree.first).to eq mod
+    expect(tree.drop(1).map(&:path)).not_to include("Outer1::Inner")
+  end
+
   it "raises undocumentable error if argument is variable" do
     undoc_error "module X; include invalid; end"
     expect(Registry.at('X').mixins).to eq []


### PR DESCRIPTION
# Description

When a module like `A::Enumerable` contains `include Enumerable`, YARD's lexical resolver walks up the namespace tree, reaches parent namespace `A`, and finds `A::Enumerable` as the match for the bare name `Enumerable`. This records the module as including itself — producing incorrect documentation and potential infinite recursion in `inheritance_tree`.

This is the valid-Ruby case reported in #1116 (comment): https://github.com/lsegal/yard/issues/1116#issuecomment-353475432

```ruby
module A
end

module A::Enumerable
  include Enumerable  # YARD incorrectly resolved this to A::Enumerable itself
end
```

**Fix:** In `RegistryResolver#lookup_by_path`, after a direct-path lookup returns a result while searching in a *parent* namespace, skip that result if it equals the original starting namespace. This breaks the false cycle while leaving all other lookups unaffected (e.g., root-level lookups, qualified references).

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md