### PR TITLE
Implement hybrid rdoc/markdown markup renderer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # main
 
 - Add support for Ruby .rbs files (docstrings included)
+- Add built-in hybrid RDoc/Markdown renderer (`HybridMarkdown`) requiring no external gems
 - Add support for `#-` as a comment-block separator. See Getting Started Guide.
 - Fix false self-referential mixin when bare name matches ancestor namespace (#1672)
 - Fix bracket/brace map corruption from Ruby 3.0+ pattern matching deconstruction (#1671)

--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ summary of some of YARD's notable features.
 
 ## Feature List
 
-**1. RDoc/SimpleMarkup Formatting Compatibility**: YARD is made to be compatible
-with RDoc formatting. In fact, YARD does no processing on RDoc documentation
-strings, and leaves this up to the output generation tool to decide how to
-render the documentation.
+**1. Builtin RDoc/Markdown Hybrid Support**: YARD ships with a builtin markup
+renderer that supports both RDoc and Markdown formatting out of the box—no
+external gem required. You can freely mix RDoc-style and Markdown-style
+documentation without installing any additional libraries.
 
 **2. Yardoc Meta-tag Formatting Like Python, Java, Objective-C and other
 languages**: YARD uses a '@tag' style definition syntax for meta tags alongside
@@ -114,20 +114,17 @@ $ gem install yard
 Alternatively, if you've checked the source out directly, you can call
 `rake install` from the root project directory.
 
-**Important Note for Debian/Ubuntu users:** there's a possible chance your Ruby
-install lacks RDoc, which is occasionally used by YARD to convert markup to
-HTML. If running `which rdoc` turns up empty, install RDoc by issuing:
+### Markup rendering
 
-```sh
-$ sudo apt-get install rdoc
-```
+YARD includes a builtin renderer that handles both RDoc and Markdown markup
+types without any external dependencies. To switch the default markup type,
+pass `-m markdown` (or `-m rdoc`) to `yard doc`, or add it to your `.yardopts`
+file.
 
-### Markdown parser
-
-When rendering markdown, yard will use one of several possible markdown providers,
-[in order of priority](https://github.com/lsegal/yard/blob/e833aac7a01510245dd4ae1d1d18b046c8293c2d/lib/yard/templates/helpers/markup_helper.rb#L26-L33).
-If you are experiencing rendering bugs (example [1](https://github.com/lsegal/yard/issues/1410) [2](https://github.com/lsegal/yard/issues/1543)), try adding one of the
-gems further up in the list to your Gemfile.
+For optional extra rendering features (e.g. GitHub-Flavoured Markdown fenced
+code blocks, tables, or specific Markdown extensions), you can install an
+additional provider gem such as `redcarpet`, `commonmarker`, or `kramdown` and
+select it explicitly with `-M PROVIDER` (e.g. `yard doc -m markdown -M redcarpet`).
 
 ## Usage
 

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -85,13 +85,17 @@ YARD treats it as a normal comment line and it remains part of the docstring.
 
 ## Which Markup Format?
 
-YARD does not impose a specific markup. The above example uses standard RDoc
-markup formatting, but YARD also supports textile and markdown via the
-command-line switch or `.yardopts` file (see below). This means that you are
-free to use whatever formatting you like. This guide is actually written
-using markdown. YARD, however, does add a few important syntaxes that are
-processed no matter which markup formatting you use, such as tag support
-and inter-document linking. These syntaxes are discussed below.
+YARD does not impose a specific markup format. YARD ships with a builtin
+renderer that supports both RDoc and Markdown out of the box—no external gem
+required. You can use either format (or switch between them) without installing
+anything extra. YARD also supports textile, asciidoc, and other formats via
+optional gems.
+
+To select a markup format, use the command-line switch `-m FORMAT` or add
+`--markup FORMAT` to your `.yardopts` file. This guide is written in Markdown.
+YARD adds a few important syntaxes that are processed regardless of which
+markup format you choose, such as tag support and inter-document linking.
+These syntaxes are discussed below.
 
 ## Adding Tags to Documentation
 

--- a/docs/WhatsNew.md
+++ b/docs/WhatsNew.md
@@ -6,6 +6,24 @@
 
 YARD now supports parsing Ruby signature files (.rbs) with full docstring support. This means you can write your documentation in `.rbs` files and have it show up in generated documentation, and use `.rbs` files alongside `.rb` sources to supplement type and API information.
 
+## New built-in Markdown renderer (0.9.40)
+
+YARD now ships with a built-in Markdown renderer (`YARD::Templates::Helpers::Markup::HybridMarkdown`)
+that requires **no external gems**. It supports a practical subset of GitHub Flavored Markdown (GFM)
+as well as common RDoc markup forms, including:
+
+- ATX and setext headings (`#`, `=`)
+- Fenced code blocks (`` ``` `` and `~~~`) as well as RDoc formatted `+text+` blocks.
+- Tables, blockquotes, and thematic breaks
+- Ordered and unordered lists (including RDoc-style)
+- Inline emphasis, code, links, and images
+- HTML passthrough blocks
+
+This renderer is the **default** for both the `rdoc` and `markdown` markup types—no gem
+installation required. If an optional provider gem (e.g. `redcarpet`, `kramdown`,
+`commonmarker`) is installed and selected, YARD will use it instead for extra features such
+as custom extensions or stricter spec compliance.
+
 ## `#-` comment block separators (0.9.40)
 
 YARD now recognizes a trailing `#-` line as a separator between comment

--- a/docs/WhatsNew.md
+++ b/docs/WhatsNew.md
@@ -12,7 +12,7 @@ YARD now ships with a built-in Markdown renderer (`YARD::Templates::Helpers::Mar
 that requires **no external gems**. It supports a practical subset of GitHub Flavored Markdown (GFM)
 as well as common RDoc markup forms, including:
 
-- ATX and setext headings (`#`, `=`)
+- Headings (`#`, `=`)
 - Fenced code blocks (`` ``` `` and `~~~`) as well as RDoc formatted `+text+` blocks.
 - Tables, blockquotes, and thematic breaks
 - Ordered and unordered lists (including RDoc-style)

--- a/lib/yard/autoload.rb
+++ b/lib/yard/autoload.rb
@@ -287,6 +287,7 @@ module YARD
   module Templates
     module Helpers # Namespace for template helpers
       module Markup # Namespace for markup providers
+        autoload :HybridMarkdown,           __p('templates/helpers/markup/hybrid_markdown')
         autoload :RDocMarkup,               __p('templates/helpers/markup/rdoc_markup')
         autoload :RDocMarkdown,             __p('templates/helpers/markup/rdoc_markdown')
       end

--- a/lib/yard/templates/helpers/markup/hybrid_markdown.rb
+++ b/lib/yard/templates/helpers/markup/hybrid_markdown.rb
@@ -76,6 +76,7 @@ module YARD
           PLACEHOLDER_RE = /\0(\d+)\0/.freeze
           ESCAPABLE_CHARS_RE = /\\([!"#$%&'()*+,\-.\/:;<=>?@\[\\\]^_`{|}~])/.freeze
           AUTOLINK_RE = /<([A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\s]*|[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~-]+@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)>/.freeze
+          TAB_WIDTH = 4
 
           def initialize(text)
             @references = {}
@@ -231,7 +232,7 @@ module YARD
 
             while index < lines.length
               line = lines[index]
-              break unless blank_line?(line) || line =~ /^(?: {2,}|\t)/
+              break unless blank_line?(line) || indented_code_start?(line)
               body << line
               index += 1
             end
@@ -280,7 +281,7 @@ module YARD
             list_indent = marker[:indent]
 
             while index < lines.length
-              break if items.any? && thematic_break?(lines[index]) && leading_spaces(lines[index]) <= list_indent + 3
+              break if items.any? && thematic_break?(lines[index]) && leading_columns(lines[index]) <= list_indent + 3
 
               item_marker = parse_list_marker(lines[index])
               break unless item_marker && same_list_type?(marker, item_marker)
@@ -318,13 +319,14 @@ module YARD
                 if blank_line?(line)
                   item_lines << "\n"
                   blank_seen = true
-                elsif blank_seen && (line.start_with?("\t") || leading_spaces(line) >= content_indent)
-                  break if first_line.empty? && item_lines.all? { |item_line| item_line == "\n" } && !line.start_with?("\t") && leading_spaces(line) == content_indent
+                elsif blank_seen && indented_to?(line, content_indent)
+                  break if first_line.empty? && item_lines.all? { |item_line| item_line == "\n" } &&
+                    leading_columns(line) == content_indent
                   item_loose = true if loose_list_item_continuation?(item_lines)
                   stripped = strip_list_item_indent(line, content_indent)
                   item_lines << stripped
                   blank_seen = false
-                elsif !blank_seen && (line.start_with?("\t") || leading_spaces(line) >= content_indent)
+                elsif !blank_seen && indented_to?(line, content_indent)
                   stripped = strip_list_item_indent(line, content_indent)
                   item_lines << stripped
                   blank_seen = false
@@ -432,9 +434,8 @@ module YARD
               if blank_line?(line)
                 quoted_lines << "\n"
                 previous_blank = true
-              elsif blockquote_start?(line)
-                line =~ BLOCKQUOTE_RE
-                quoted_lines << "#{$1}\n"
+              elsif (stripped = strip_blockquote_marker(line))
+                quoted_lines << stripped
                 saw_quote = true
                 previous_blank = false
               else
@@ -809,25 +810,25 @@ module YARD
           end
 
           def indented_code_start?(line)
-            line =~ /^(?: {2,}|\t)/
+            leading_columns(line) >= 2
           end
 
           def indented_code_block_start?(lines, index)
             return false unless indented_code_start?(lines[index])
-            return true if lines[index] =~ /^(?: {4,}|\t)/
+            return true if leading_columns(lines[index]) >= 4
 
             !index.zero? && blank_line?(lines[index - 1])
           end
 
           def yard_indented_code_start?(lines, index)
-            return false unless lines[index] =~ /^(?: {2,}|\t)!!!([\w.+-]+)[ \t]*$/
+            return false unless leading_columns(lines[index]) >= 2
+            return false unless consume_columns(lines[index], 2) =~ /^!!!([\w.+-]+)[ \t]*$/
             return false if index + 1 >= lines.length
 
-            indented_code_block_start?(lines, index) && lines[index + 1] =~ /^(?: {2,}|\t)/
+            indented_code_block_start?(lines, index) && indented_code_start?(lines[index + 1])
           end
 
           def list_start?(line, interrupt_paragraph = false)
-            return true if line =~ UNORDERED_LIST_RE || line =~ RDOC_ORDERED_LIST_RE
             return false unless (marker = parse_list_marker(line))
             return true unless interrupt_paragraph
 
@@ -843,7 +844,7 @@ module YARD
           end
 
           def blockquote_start?(line)
-            line =~ BLOCKQUOTE_RE
+            !strip_blockquote_marker(line).nil?
           end
 
           def html_block_start?(line, interrupt_paragraph = false)
@@ -875,26 +876,14 @@ module YARD
 
           def unindent(lines)
             indent = lines.reject { |line| blank_line?(line) }.map do |line|
-              line.start_with?("\t") ? 4 : line[/\A +/, 0].to_s.length
+              leading_columns(line)
             end.min || 4
 
-            lines.map do |line|
-              if line.start_with?("\t")
-                line.sub(/^\t/, '')
-              else
-                line.sub(/\A {0,#{indent}}/, '')
-              end
-            end.join
+            lines.map { |line| consume_columns(line, indent) }.join
           end
 
           def unindent_indented_code(lines)
-            lines.map do |line|
-              if line.start_with?("\t")
-                line.sub(/^\t/, '')
-              else
-                line.sub(/^ {0,4}/, '')
-              end
-            end.join
+            lines.map { |line| consume_columns(line, 4) }.join
           end
 
           def code_block(text, lang = nil)
@@ -961,29 +950,58 @@ module YARD
           end
 
           def parse_list_marker(line)
-            if line =~ /^(\s{0,3})([*+-])([ \t]*)(.*)$/
-              match = Regexp.last_match
-              return nil if match[3].empty? && !match[4].empty?
+            source = line.to_s.sub(/\n\z/, '')
+            indent, index = scan_leading_columns(source)
+            return nil if indent > 3
+            return nil if index >= source.length
 
-              return {:ordered => false, :bullet => match[2], :indent => match[1].length,
-                      :marker_length => 1, :padding => match[3].length, :content => match[4]}
+            char = source[index, 1]
+            current_column = indent
+
+            if '*+-'.include?(char)
+              marker_length = 1
+              marker_end = index + 1
+              current_column += 1
+              padding, marker_end = scan_padding_columns(source, marker_end, current_column)
+              content = source[marker_end..-1].to_s
+              return nil if padding.zero? && !content.empty?
+
+              return {:ordered => false, :bullet => char, :indent => indent,
+                      :marker_length => marker_length, :padding => padding, :content => content}
             end
 
-            if line =~ /^(\s{0,3})(\d{1,9})([.)])([ \t]*)(.*)$/
-              match = Regexp.last_match
-              return nil if match[4].empty? && !match[5].empty?
+            number = source[index..-1][/^\d{1,9}/]
+            if number
+              marker_end = index + number.length
+              delimiter = source[marker_end, 1]
+              if delimiter == '.' || delimiter == ')'
+                marker_length = number.length + 1
+                current_column += marker_length
+                marker_end += 1
+                padding, marker_end = scan_padding_columns(source, marker_end, current_column)
+                content = source[marker_end..-1].to_s
+                return nil if padding.zero? && !content.empty?
 
-              return {:ordered => true, :delimiter => match[3], :start => match[2].to_i,
-                      :indent => match[1].length, :marker_length => match[2].length + 1,
-                      :padding => match[4].length, :content => match[5]}
+                return {:ordered => true, :delimiter => delimiter, :start => number.to_i,
+                        :indent => indent, :marker_length => marker_length,
+                        :padding => padding, :content => content}
+              end
             end
 
-            return nil unless line =~ /^\s{0,3}([A-Za-z])\.(?:[ \t]+(.*))$/
+            if source[index, 2] =~ /\A[A-Za-z]\.\z/
+              marker_length = 2
+              marker_end = index + marker_length
+              current_column += marker_length
+              padding, marker_end = scan_padding_columns(source, marker_end, current_column)
+              content = source[marker_end..-1].to_s
+              return nil if padding.zero? && !content.empty?
 
-            match = Regexp.last_match
-            {:ordered => true, :delimiter => '.', :start => 1,
-             :indent => line[/\A */].to_s.length, :marker_length => 2, :padding => 1,
-             :content => (match[2] || '')}
+              return {:ordered => true, :delimiter => '.', :start => 1,
+                      :indent => indent, :marker_length => marker_length,
+                      :padding => padding, :content => content}
+            end
+
+            nil
           end
 
           def list_item_padding(marker)
@@ -1403,7 +1421,7 @@ module YARD
           def punctuation_char?(char)
             return false if char.nil?
 
-            char =~ /[[:punct:]]/ || unicode_symbol_char?(char)
+            ascii_punctuation_char?(char) || unicode_symbol_char?(char)
           end
 
           def unicode_symbol_char?(char)
@@ -1420,20 +1438,28 @@ module YARD
               (0x20A0..0x20CF).include?(codepoint)
           end
 
-          def leading_spaces(line)
-            line[/\A */, 0].to_s.length
+          def ascii_punctuation_char?(char)
+            return false unless ascii_only_compat?(char)
+
+            byte = char.to_s.unpack('C').first
+            return false unless byte
+
+            (0x21..0x2F).include?(byte) ||
+              (0x3A..0x40).include?(byte) ||
+              (0x5B..0x60).include?(byte) ||
+              (0x7B..0x7E).include?(byte)
+          end
+
+          def leading_columns(line)
+            scan_leading_columns(line.to_s).first
           end
 
           def indented_to?(line, indent)
-            line.start_with?("\t") || leading_spaces(line) >= indent
+            leading_columns(line) >= indent
           end
 
           def strip_list_item_indent(line, content_indent)
-            if line.start_with?("\t")
-              line.sub(/^\t/, '')
-            else
-              line.sub(/\A {0,#{content_indent}}/, '')
-            end
+            consume_columns(line, content_indent, 0, true)
           end
 
           def escape_url(url)
@@ -1525,9 +1551,9 @@ module YARD
             prefix = ''
             content = line.chomp
 
-            while content =~ /\A(\s{0,3}> ?)(.*)\z/
-              prefix << $1
-              content = $2
+            while (split = split_blockquote_prefix(content))
+              prefix << split[0]
+              content = split[1].chomp
             end
 
             [prefix, content]
@@ -1681,6 +1707,102 @@ module YARD
             text.to_s.split(/^/, -1)
           end
 
+          def scan_leading_columns(text)
+            index = 0
+            column = 0
+            source = text.to_s
+
+            while index < source.length
+              char = source[index, 1]
+              if char == ' '
+                column += 1
+              elsif char == "\t"
+                column += TAB_WIDTH - (column % TAB_WIDTH)
+              else
+                break
+              end
+              index += 1
+            end
+
+            [column, index]
+          end
+
+          def scan_padding_columns(text, index, start_column)
+            column = start_column
+            padding = 0
+            source = text.to_s
+
+            while index < source.length
+              char = source[index, 1]
+              if char == ' '
+                column += 1
+                padding += 1
+              elsif char == "\t"
+                advance = TAB_WIDTH - (column % TAB_WIDTH)
+                column += advance
+                padding += advance
+              else
+                break
+              end
+              index += 1
+            end
+
+            [padding, index]
+          end
+
+          def consume_columns(text, columns, start_column = 0, normalize_remaining = false)
+            index = 0
+            column = start_column
+            remaining = columns
+            prefix_width = 0
+            source = text.to_s
+
+            while index < source.length && remaining > 0
+              char = source[index, 1]
+              if char == ' '
+                column += 1
+                remaining -= 1
+                index += 1
+              elsif char == "\t"
+                advance = TAB_WIDTH - (column % TAB_WIDTH)
+                if advance <= remaining
+                  column += advance
+                  remaining -= advance
+                  index += 1
+                else
+                  prefix_width += advance - remaining if normalize_remaining
+                  column += advance
+                  remaining = 0
+                  index += 1
+                end
+              else
+                break
+              end
+            end
+
+            if normalize_remaining
+              while index < source.length
+                char = source[index, 1]
+                if char == ' '
+                  prefix_width += 1
+                  column += 1
+                  index += 1
+                elsif char == "\t"
+                  advance = TAB_WIDTH - (column % TAB_WIDTH)
+                  prefix_width += advance
+                  column += advance
+                  index += 1
+                else
+                  break
+                end
+              end
+
+              (' ' * prefix_width) + source[index..-1].to_s
+            else
+              source[index..-1].to_s
+            end
+          end
+
           def lazy_blockquote_continuation?(quoted_lines, line)
             return false if block_boundary?(line)
             return false if indented_code_start?(line) && !blockquote_paragraph_context?(quoted_lines)
@@ -1724,6 +1846,27 @@ module YARD
 
           def normalize_heading_line(line)
             normalize_paragraph_line(line).rstrip
+          end
+
+          def split_blockquote_prefix(line)
+            source = line.to_s
+            indent, index = scan_leading_columns(source)
+            return nil if indent > 3
+            return nil unless source[index, 1] == '>'
+
+            prefix = source[0..index]
+            rest = source[(index + 1)..-1].to_s
+            if rest.start_with?(' ') || rest.start_with?("\t")
+              prefix << rest[0, 1]
+              rest = consume_columns(rest, 1, indent + 1, true)
+            end
+
+            [prefix, rest.end_with?("\n") ? rest : "#{rest}\n"]
+          end
+
+          def strip_blockquote_marker(line)
+            split = split_blockquote_prefix(line)
+            split && split[1]
           end
 
           def loose_list_item_continuation?(item_lines)

--- a/lib/yard/templates/helpers/markup/hybrid_markdown.rb
+++ b/lib/yard/templates/helpers/markup/hybrid_markdown.rb
@@ -143,10 +143,15 @@ module YARD
               return heading
             end
 
-            return unless line =~ RDOC_HEADING_RE
+            match = RDOC_HEADING_RE.match(line)
+            return unless match
 
-            level = [$1.length, 6].min
-            "<h#{level}>#{format_inline($2.strip)}</h#{level}>"
+            heading_marks = match[1]
+            heading_text = match[2].strip
+            return nil if heading_text =~ /\A[=\-]+\z/
+
+            level = [heading_marks.length, 6].min
+            "<h#{level}>#{format_inline(heading_text)}</h#{level}>"
           end
 
           def parse_setext_heading(lines, index)
@@ -246,7 +251,7 @@ module YARD
               index += 1
             end
 
-            html = "<table>\n<thead>\n<tr>\n".dup
+            html = "<table>\n<thead>\n<tr>\n"
             header.each_with_index do |cell, i|
               attrs = alignments[i] ? %( align="#{alignments[i]}") : ""
               html << "<th#{attrs}>#{format_inline(cell)}</th>\n"
@@ -315,9 +320,9 @@ module YARD
                   blank_seen = true
                 elsif blank_seen && (line.start_with?("\t") || leading_spaces(line) >= content_indent)
                   break if first_line.empty? && item_lines.all? { |item_line| item_line == "\n" } && !line.start_with?("\t") && leading_spaces(line) == content_indent
+                  item_loose = true if loose_list_item_continuation?(item_lines)
                   stripped = strip_list_item_indent(line, content_indent)
                   item_lines << stripped
-                  item_loose = true
                   blank_seen = false
                 elsif !blank_seen && (line.start_with?("\t") || leading_spaces(line) >= content_indent)
                   stripped = strip_list_item_indent(line, content_indent)
@@ -1003,19 +1008,19 @@ module YARD
               return nil if normalize_reference_label(label).empty?
 
             index = 0
-            index += 1 while index < definition.length && definition[index] =~ /[ \t\n]/
+            index += 1 while index < definition.length && definition[index, 1] =~ /[ \t\n]/
             return nil if index >= definition.length
 
-            if definition[index] == '<'
+            if definition[index, 1] == '<'
               close = definition.index('>', index + 1)
               return nil unless close
               url = definition[(index + 1)...close]
               return nil if url.include?("\n")
               index = close + 1
-                return nil if index < definition.length && definition[index] !~ /[ \t\n]/
+                return nil if index < definition.length && definition[index, 1] !~ /[ \t\n]/
             else
               start = index
-              while index < definition.length && definition[index] !~ /[ \t\n]/
+              while index < definition.length && definition[index, 1] !~ /[ \t\n]/
                 index += 1
               end
               url = definition[start...index]
@@ -1023,18 +1028,18 @@ module YARD
 
               return nil if url.nil? || url.include?('<') || url.include?('>')
 
-            index += 1 while index < definition.length && definition[index] =~ /[ \t\n]/
+            index += 1 while index < definition.length && definition[index, 1] =~ /[ \t\n]/
             title = nil
 
             if index < definition.length
-              delimiter = definition[index]
+              delimiter = definition[index, 1]
               close_delimiter = delimiter == '(' ? ')' : delimiter
               if delimiter == '"' || delimiter == "'" || delimiter == '('
                 index += 1
                 start = index
                 buffer = ''
                 while index < definition.length
-                  char = definition[index]
+                  char = definition[index, 1]
                   if char == '\\' && index + 1 < definition.length
                     buffer << definition[index, 2]
                     index += 2
@@ -1044,10 +1049,10 @@ module YARD
                   buffer << char
                   index += 1
                 end
-                return nil if index >= definition.length || definition[index] != close_delimiter
+                return nil if index >= definition.length || definition[index, 1] != close_delimiter
                 title = buffer
                 index += 1
-                index += 1 while index < definition.length && definition[index] =~ /[ \t\n]/
+                index += 1 while index < definition.length && definition[index, 1] =~ /[ \t\n]/
                 return nil unless index == definition.length
               else
                 return nil
@@ -1066,15 +1071,15 @@ module YARD
 
             while index < text.length
               if prefix
-                if text[index, 2] != '![' || (index > 0 && text[index - 1] == '\\')
-                  output << text[index]
+                if text[index, 2] != '![' || (index > 0 && text[index - 1, 1] == '\\')
+                  output << text[index, 1]
                   index += 1
                   next
                 end
                 label_start = index + 2
               else
-                if text[index] != '[' || (index > 0 && text[index - 1] == '\\')
-                  output << text[index]
+                if text[index, 1] != '[' || (index > 0 && text[index - 1, 1] == '\\')
+                  output << text[index, 1]
                   index += 1
                   next
                 end
@@ -1082,22 +1087,22 @@ module YARD
               end
 
               label_end = find_closing_bracket(text, label_start - 1)
-              unless label_end && text[label_end + 1] == '('
-                output << text[index]
+              unless label_end && text[label_end + 1, 1] == '('
+                output << text[index, 1]
                 index += 1
                 next
               end
 
               dest, title, consumed = parse_inline_destination(text, label_end + 2, placeholders)
               unless consumed
-                output << text[index]
+                output << text[index, 1]
                 index += 1
                 next
               end
 
               label = text[label_start...label_end]
               if !prefix && contains_nested_link?(label, placeholders)
-                output << text[index]
+                output << text[index, 1]
                 index += 1
                 next
               end
@@ -1115,15 +1120,15 @@ module YARD
             while index < text.length
               image = kind == :image
               if image
-                if text[index, 2] != '![' || (index > 0 && text[index - 1] == '\\')
-                  output << text[index]
+                if text[index, 2] != '![' || (index > 0 && text[index - 1, 1] == '\\')
+                  output << text[index, 1]
                   index += 1
                   next
                 end
                 label_open = index + 1
               else
-                if text[index] != '[' || (index > 0 && text[index - 1] == '\\')
-                  output << text[index]
+                if text[index, 1] != '[' || (index > 0 && text[index - 1, 1] == '\\')
+                  output << text[index, 1]
                   index += 1
                   next
                 end
@@ -1132,12 +1137,12 @@ module YARD
 
               label_close = find_closing_bracket(text, label_open)
               unless label_close
-                output << text[index]
+                output << text[index, 1]
                 index += 1
                 next
               end
 
-              next_char = text[label_close + 1]
+              next_char = text[label_close + 1, 1]
               label = restore_placeholders(text[(label_open + 1)...label_close], placeholders)
               html = nil
               consumed = nil
@@ -1157,7 +1162,7 @@ module YARD
                 end
               else
                 if kind == :link && contains_nested_link?(label, placeholders)
-                  output << text[index]
+                  output << text[index, 1]
                   index += 1
                   next
                 end
@@ -1169,7 +1174,7 @@ module YARD
                 output << store_placeholder(placeholders, html)
                 index = consumed
               else
-                output << text[index]
+                output << text[index, 1]
                 index += 1
               end
             end
@@ -1181,7 +1186,7 @@ module YARD
             depth = 0
             index = open_index
             while index < text.length
-              char = text[index]
+              char = text[index, 1]
               if char == '['
                 depth += 1
               elsif char == ']'
@@ -1197,9 +1202,9 @@ module YARD
 
           def find_matching_backtick_run(text, index, length)
             while index < text.length
-              if text[index] == '`'
+              if text[index, 1] == '`'
                 run_length = 1
-                run_length += 1 while index + run_length < text.length && text[index + run_length] == '`'
+                run_length += 1 while index + run_length < text.length && text[index + run_length, 1] == '`'
                 return index if run_length == length
 
                 index += run_length
@@ -1212,11 +1217,11 @@ module YARD
           end
 
           def parse_inline_destination(text, index, placeholders = nil)
-            while index < text.length && text[index] =~ /[ \t\n]/
+            while index < text.length && text[index, 1] =~ /[ \t\n]/
               index += 1
             end
 
-            if text[index] == '<'
+            if text[index, 1] == '<'
               close = text.index('>', index + 1)
               return [nil, nil, nil] unless close
               dest = text[(index + 1)...close]
@@ -1227,7 +1232,7 @@ module YARD
               close = index
               parens = 0
               while close < text.length
-                char = text[close]
+                char = text[close, 1]
                 if char == '\\' && close + 1 < text.length
                   close += 2
                   next
@@ -1251,17 +1256,17 @@ module YARD
               end
             end
 
-            while index < text.length && text[index] =~ /[ \t\n]/
+            while index < text.length && text[index, 1] =~ /[ \t\n]/
               index += 1
             end
 
             title = nil
-            if text[index] == '"' || text[index] == "'"
-              delimiter = text[index]
+            if text[index, 1] == '"' || text[index, 1] == "'"
+              delimiter = text[index, 1]
               index += 1
               buffer = ''
               while index < text.length
-                char = text[index]
+                char = text[index, 1]
                 if char == '\\' && index + 1 < text.length
                   buffer << text[index, 2]
                   index += 2
@@ -1271,15 +1276,15 @@ module YARD
                 buffer << char
                 index += 1
               end
-              return [nil, nil, nil] unless index < text.length && text[index] == delimiter
+              return [nil, nil, nil] unless index < text.length && text[index, 1] == delimiter
               title = buffer
               index += 1
-            elsif text[index] == '('
+            elsif text[index, 1] == '('
               index += 1
               buffer = ''
               depth = 1
               while index < text.length
-                char = text[index]
+                char = text[index, 1]
                 if char == '\\' && index + 1 < text.length
                   buffer << text[index, 2]
                   index += 2
@@ -1294,15 +1299,15 @@ module YARD
                 buffer << char
                 index += 1
               end
-              return [nil, nil, nil] unless index < text.length && text[index] == ')'
+              return [nil, nil, nil] unless index < text.length && text[index, 1] == ')'
               title = buffer
               index += 1
             end
 
-            while index < text.length && text[index] =~ /[ \t\n]/
+            while index < text.length && text[index, 1] =~ /[ \t\n]/
               index += 1
             end
-            return [nil, nil, nil] unless text[index] == ')'
+            return [nil, nil, nil] unless text[index, 1] == ')'
 
             [dest.to_s, title, index + 1]
           end
@@ -1371,8 +1376,8 @@ module YARD
           end
 
           def delimiter_flags(text, run_start, run_end, char)
-            before = run_start.zero? ? nil : text[run_start - 1]
-            after = run_end >= text.length ? nil : text[run_end]
+            before = run_start.zero? ? nil : text[run_start - 1, 1]
+            after = run_end >= text.length ? nil : text[run_end, 1]
             before_whitespace = whitespace_char?(before)
             after_whitespace = whitespace_char?(after)
             before_punctuation = punctuation_char?(before)
@@ -1396,7 +1401,23 @@ module YARD
           end
 
           def punctuation_char?(char)
-            !char.nil? && char =~ /[[:punct:]]/
+            return false if char.nil?
+
+            char =~ /[[:punct:]]/ || unicode_symbol_char?(char)
+          end
+
+          def unicode_symbol_char?(char)
+            codepoint = char.to_s.unpack('U*').first
+            return false unless codepoint
+
+            (0x00A2..0x00A9).include?(codepoint) ||
+              (0x00AC..0x00AE).include?(codepoint) ||
+              (0x00B0..0x00B4).include?(codepoint) ||
+              codepoint == 0x00B6 ||
+              codepoint == 0x00B7 ||
+              codepoint == 0x00D7 ||
+              codepoint == 0x00F7 ||
+              (0x20A0..0x20CF).include?(codepoint)
           end
 
           def leading_spaces(line)
@@ -1523,13 +1544,13 @@ module YARD
 
             index = 1
             while index < text.length
-              char = text[index]
+              char = text[index, 1]
               if char == '\\'
                 index += 2
                 next
               end
               return nil if char == '['
-              return index if char == ']' && text[index + 1] == ':'
+              return index if char == ']' && text[index + 1, 1] == ':'
 
               index += 1
             end
@@ -1544,9 +1565,9 @@ module YARD
             index = 0
 
             while index < text.length
-              if text[index, 2] == '![' && (index.zero? || text[index - 1] != '\\')
+              if text[index, 2] == '![' && (index.zero? || text[index - 1, 1] != '\\')
                 label_open = index + 1
-              elsif text[index] == '[' && (index.zero? || text[index - 1] != '\\')
+              elsif text[index, 1] == '[' && (index.zero? || text[index - 1, 1] != '\\')
                 label_open = index
               else
                 index += 1
@@ -1555,7 +1576,7 @@ module YARD
 
               label_close = find_closing_bracket(text, label_open)
               if label_close
-                next_char = text[label_close + 1]
+                next_char = text[label_close + 1, 1]
                 return true if next_char == '(' || next_char == '['
               end
 
@@ -1703,6 +1724,31 @@ module YARD
 
           def normalize_heading_line(line)
             normalize_paragraph_line(line).rstrip
+          end
+
+          def loose_list_item_continuation?(item_lines)
+            return false if open_fence_in_lines?(item_lines)
+
+            previous = item_lines.reverse.find { |item_line| item_line != "\n" }
+            return true unless previous
+
+            !parse_list_marker(previous.chomp)
+          end
+
+          def open_fence_in_lines?(lines)
+            opener = nil
+
+            lines.each do |line|
+              next if blank_line?(line)
+
+              if opener
+                opener = nil if fence_closer?(line, opener[:char], opener[:length])
+              else
+                opener = parse_fence_opener(line)
+              end
+            end
+
+            !opener.nil?
           end
 
           def each_char_compat(text)

--- a/lib/yard/templates/helpers/markup/hybrid_markdown.rb
+++ b/lib/yard/templates/helpers/markup/hybrid_markdown.rb
@@ -1,0 +1,1684 @@
+# frozen_string_literal: true
+
+if RUBY_VERSION < '3.5'
+  require 'cgi/util'
+else
+  require 'cgi/escape'
+end
+require 'uri'
+
+module YARD
+  module Templates
+    module Helpers
+      module Markup
+        # A built-in formatter that implements a practical subset of GitHub
+        # flavored Markdown plus common RDoc markup forms.
+        class HybridMarkdown
+          attr_accessor :from_path
+
+          NAMED_ENTITIES = {
+            'nbsp' => [0x00A0].pack('U'),
+            'copy' => [0x00A9].pack('U'),
+            'AElig' => [0x00C6].pack('U'),
+            'Dcaron' => [0x010E].pack('U'),
+            'frac34' => [0x00BE].pack('U'),
+            'HilbertSpace' => [0x210B].pack('U'),
+            'DifferentialD' => [0x2146].pack('U'),
+            'ClockwiseContourIntegral' => [0x2232].pack('U'),
+            'ngE' => [0x2267, 0x0338].pack('U*'),
+            'ouml' => [0x00F6].pack('U'),
+            'quot' => '"',
+            'amp' => '&'
+          }.freeze
+
+          ATX_HEADING_RE = /^\s{0,3}#{Regexp.escape('#')}{1,6}(?=[ \t]|$)/.freeze
+          RDOC_HEADING_RE = /^\s*(=+)[ \t]+(.+?)\s*$/.freeze
+          SETEXT_HEADING_RE = /^\s*(=+|-+)\s*$/.freeze
+          FENCE_RE = /^(\s{0,3})(`{3,}|~{3,})([^\n]*)$/.freeze
+          THEMATIC_BREAK_RE = /^\s{0,3}(?:(?:-\s*){3,}|(?:\*\s*){3,}|(?:_\s*){3,})\s*$/.freeze
+          TABLE_SEPARATOR_RE = /^\s*\|?(?:\s*:?-+:?\s*\|)+(?:\s*:?-+:?\s*)\|?\s*$/.freeze
+          UNORDERED_LIST_RE = /^\s{0,3}([*+-])[ \t]+(.+?)\s*$/.freeze
+          ORDERED_LIST_RE = /^\s{0,3}(\d+)([.)])[ \t]+(.+?)\s*$/.freeze
+          RDOC_ORDERED_LIST_RE = /^\s{0,3}([A-Za-z])\.[ \t]+(.+?)\s*$/.freeze
+          LABEL_LIST_BRACKET_RE = /^\s*\[([^\]]+)\](?:[ \t]+(.+))?\s*$/.freeze
+          LABEL_LIST_COLON_RE = /^\s*([^\s:][^:]*)::(?:[ \t]+(.*))?\s*$/.freeze
+          BLOCKQUOTE_RE = /^\s{0,3}>\s?(.*)$/.freeze
+          HTML_BLOCK_RE = %r{
+            ^\s*(?:
+              <!--|
+              <\?|
+              <![A-Z]|
+              <!\[CDATA\[|
+              </?(?:address|article|aside|base|basefont|blockquote|body|caption|center|col|colgroup|dd|details|dialog|dir|div|dl|dt|fieldset|figcaption|figure|footer|form|frame|frameset|h[1-6]|head|header|hr|html|iframe|legend|li|link|main|menu|menuitem|nav|noframes|ol|optgroup|option|p|param|search|section|summary|table|tbody|td|tfoot|th|thead|title|tr|track|ul)\b|
+              <(?:script|pre|style|textarea)\b|
+              </(?:script|pre|style|textarea)\b|
+              </?[A-Za-z][A-Za-z0-9-]*(?:\s+[A-Za-z_:][\w:.-]*(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))?)*\s*/?>\s*$
+            )
+          }mx.freeze
+          HTML_BLOCK_TAGS = %w[
+            address article aside base basefont blockquote body caption center col
+            colgroup dd details dialog dir div dl dt fieldset figcaption figure
+            footer form frame frameset h1 h2 h3 h4 h5 h6 head header hr html iframe
+            legend li link main menu menuitem nav noframes ol optgroup option p param
+            search section summary table tbody td tfoot th thead title tr track ul
+          ].freeze
+          HTML_TAG_RE = %r{
+              <!--(?:>|->)|
+              <!--(?:.*?)-->|
+            <\?.*?\?>|
+            <![A-Z][^>]*>|
+            <!\[CDATA\[.*?\]\]>|
+            </[A-Za-z][A-Za-z0-9-]*\s*>|
+            <[A-Za-z][A-Za-z0-9-]*
+              (?:\s+[A-Za-z_:][\w:.-]*
+                (?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))?
+              )*
+              \s*/?>
+          }mx.freeze
+          ENTITY_RE = /&(?:[A-Za-z][A-Za-z0-9]+|#\d+|#[xX][0-9A-Fa-f]+);/.freeze
+          YARD_LINK_RE = /(?<!\\)\{(?!\})(\S+?)(?:\s([^\}]*?\S))?\}(?=\W|.+<\/|$)/m.freeze
+          CODE_LANG_RE = /\A(?:[ \t]*\n)?[ \t]*!!!([\w.+-]+)[ \t]*\n/.freeze
+          REFERENCE_DEF_START_RE = /^\s{0,3}\[([^\]]+)\]:\s*(.*)$/.freeze
+          PLACEHOLDER_RE = /\0(\d+)\0/.freeze
+          ESCAPABLE_CHARS_RE = /\\([!"#$%&'()*+,\-.\/:;<=>?@\[\\\]^_`{|}~])/.freeze
+          AUTOLINK_RE = /<([A-Za-z][A-Za-z0-9.+-]{1,31}:[^<>\s]*|[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~-]+@[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?(?:\.[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?)+)>/.freeze
+
+          def initialize(text)
+            @references = {}
+            @text = extract_reference_definitions(text.to_s.gsub(/\r\n?/, "\n"))
+          end
+
+          def to_html
+            parse_blocks(split_lines(@text), 0).join("\n")
+          end
+
+          private
+
+          def parse_blocks(lines, index)
+            blocks = []
+
+            while index < lines.length
+              line = lines[index]
+
+              if blank_line?(line)
+                index += 1
+              elsif yard_indented_code_start?(lines, index)
+                block, index = parse_yard_indented_code(lines, index)
+                blocks << block
+              elsif thematic_break?(line)
+                blocks << '<hr />'
+                index += 1
+              elsif (heading = parse_setext_heading(lines, index))
+                blocks << heading
+                index += 2
+              elsif (heading = parse_heading(line))
+                blocks << heading
+                index += 1
+              elsif fenced_code_start?(line)
+                block, index = parse_fenced_code(lines, index)
+                blocks << block
+              elsif table_start?(lines, index)
+                block, index = parse_table(lines, index)
+                blocks << block
+              elsif labeled_list_start?(lines, index)
+                block, index = parse_labeled_list(lines, index)
+                blocks << block
+              elsif blockquote_start?(line)
+                block, index = parse_blockquote(lines, index)
+                blocks << block
+              elsif list_start?(line)
+                block, index = parse_list(lines, index)
+                blocks << block
+              elsif html_block_start?(line)
+                block, index = parse_html_block(lines, index)
+                blocks << block
+              elsif indented_code_block_start?(lines, index)
+                block, index = parse_indented_code(lines, index)
+                blocks << block
+              else
+                block, index = parse_paragraph(lines, index)
+                blocks << block unless block.empty?
+              end
+            end
+
+            blocks
+          end
+
+          def parse_heading(line)
+            if (heading = parse_atx_heading(line))
+              return heading
+            end
+
+            return unless line =~ RDOC_HEADING_RE
+
+            level = [$1.length, 6].min
+            "<h#{level}>#{format_inline($2.strip)}</h#{level}>"
+          end
+
+          def parse_setext_heading(lines, index)
+            return nil if index + 1 >= lines.length
+            return nil if lines[index].strip.empty?
+            return nil if lines[index] =~ /^\s{0,3}>/
+            return nil if parse_list_marker(lines[index])
+            return nil unless lines[index + 1] =~ SETEXT_HEADING_RE
+
+            level = $1.start_with?('=') ? 1 : 2
+            "<h#{level}>#{format_inline(lines[index].strip)}</h#{level}>"
+          end
+
+          def parse_fenced_code(lines, index)
+            opener = parse_fence_opener(lines[index])
+            fence_char = opener[:char]
+            fence_length = opener[:length]
+            indent = opener[:indent]
+            lang = opener[:lang]
+            index += 1
+            body = []
+
+            while index < lines.length
+              break if fence_closer?(lines[index], fence_char, fence_length)
+
+              body << strip_fenced_indent(lines[index], indent)
+              index += 1
+            end
+
+            index += 1 if index < lines.length
+            [code_block(body.join, lang), index]
+          end
+
+          def parse_indented_code(lines, index)
+            body = []
+            previous_blank = false
+
+            while index < lines.length
+              line = lines[index]
+              break if previous_blank && html_block_start?(line)
+              break unless blank_line?(line) || indented_code_start?(line)
+              body << line
+              previous_blank = blank_line?(line)
+              index += 1
+            end
+
+            body.pop while body.any? && blank_line?(body.last)
+            [code_block(unindent_indented_code(body)), index]
+          end
+
+          def parse_yard_indented_code(lines, index)
+            body = []
+
+            while index < lines.length
+              line = lines[index]
+              break unless blank_line?(line) || line =~ /^(?: {2,}|\t)/
+              body << line
+              index += 1
+            end
+
+            body.pop while body.any? && blank_line?(body.last)
+            [code_block(unindent(body)), index]
+          end
+
+          def parse_table(lines, index)
+            header = split_table_row(lines[index])
+            alignments = split_table_row(lines[index + 1]).map { |cell| table_alignment(cell) }
+            rows = []
+            index += 2
+
+            while index < lines.length && table_row?(lines[index])
+              rows << split_table_row(lines[index])
+              index += 1
+            end
+
+            html = "<table>\n<thead>\n<tr>\n".dup
+            header.each_with_index do |cell, i|
+              attrs = alignments[i] ? %( align="#{alignments[i]}") : ""
+              html << "<th#{attrs}>#{format_inline(cell)}</th>\n"
+            end
+            html << "</tr>\n</thead>\n<tbody>\n"
+            rows.each do |row|
+              html << "<tr>\n"
+              row.each_with_index do |cell, i|
+                attrs = alignments[i] ? %( align="#{alignments[i]}") : ""
+                html << "<td#{attrs}>#{format_inline(cell)}</td>\n"
+              end
+              html << "</tr>\n"
+            end
+            html << "</tbody>\n</table>"
+            [html, index]
+          end
+
+          def parse_list(lines, index)
+            marker = parse_list_marker(lines[index])
+            ordered = marker[:ordered]
+            tag = ordered ? 'ol' : 'ul'
+            start_attr = ordered && marker[:start] != 1 ? %( start="#{marker[:start]}") : ''
+            items = []
+            tight = true
+            list_indent = marker[:indent]
+
+            while index < lines.length
+              item_marker = parse_list_marker(lines[index])
+              break unless item_marker && same_list_type?(marker, item_marker)
+
+              effective_padding = list_item_padding(item_marker)
+              content_indent = item_marker[:indent] + item_marker[:marker_length] + effective_padding
+              lazy_indent = item_marker[:indent] + effective_padding
+              item_lines = []
+              first_line = item_marker[:content]
+              unless first_line.empty?
+                leading = [item_marker[:padding] - effective_padding, 0].max
+                item_lines << "#{' ' * leading}#{first_line}\n"
+              end
+              index += 1
+              blank_seen = false
+              item_loose = false
+
+              while index < lines.length
+                line = lines[index]
+                next_marker = parse_list_marker(line)
+                if next_marker && same_list_type?(marker, next_marker) &&
+                    (next_marker[:indent] == item_marker[:indent] || (blank_seen && next_marker[:indent] <= list_indent + 3))
+                  tight = false if blank_seen
+                  break
+                end
+                break if next_marker && next_marker[:indent] < content_indent
+                break if !blank_seen && line !~ /^(?: {0,#{content_indent}}|\t)/ && block_boundary?(line)
+
+                if blank_line?(line)
+                  item_lines << "\n"
+                  blank_seen = true
+                elsif blank_seen && (line.start_with?("\t") || leading_spaces(line) >= content_indent)
+                  break if first_line.empty? && item_lines.all? { |item_line| item_line == "\n" } && !line.start_with?("\t") && leading_spaces(line) == content_indent
+                  stripped = strip_list_item_indent(line, content_indent)
+                  item_lines << stripped
+                  item_loose = true
+                  blank_seen = false
+                elsif !blank_seen && (line.start_with?("\t") || leading_spaces(line) >= content_indent)
+                  stripped = strip_list_item_indent(line, content_indent)
+                  item_lines << stripped
+                  blank_seen = false
+                elsif !blank_seen
+                  item_lines << strip_list_item_indent(line, lazy_indent)
+                  blank_seen = false
+                else
+                  break
+                end
+
+                index += 1
+              end
+
+              item_blocks = parse_blocks(item_lines, 0)
+              item_html = item_blocks.join("\n")
+              item_html = format_inline(first_line) if item_html.empty? && !first_line.empty?
+
+              simple_item = !item_loose &&
+                item_blocks.length == 1 &&
+                item_html =~ /\A<p>(.*?)<\/p>\z/m &&
+                item_html !~ /<(?:pre|blockquote|ul|ol|dl|table|h\d|hr)/m
+
+              if item_html.empty?
+                item_html = ''
+              else
+                item_loose ||= item_blocks.count { |block| block.start_with?('<p>') } > 1
+              end
+
+              tight &&= !item_loose
+              items << {:html => item_html, :simple => simple_item}
+            end
+
+            items.map! do |item|
+              item_html = item[:html]
+              if tight
+                item_html = item_html.sub(/\A<p>(.*?)<\/p>\z/m, '\1')
+                item_html = item_html.sub(/\A<p>(.*?)<\/p>(?=\n<(?:ul|ol|blockquote|pre|h\d|table|hr))/m, '\1')
+                item_html = item_html.sub(/\n<p>(.*?)<\/p>\z/m, "\n\\1")
+              end
+              if item_html.empty?
+                '<li></li>'
+              elsif tight && item[:simple]
+                "<li>#{item_html}</li>"
+              elsif tight && item_html !~ /\A</m
+                suffix = item_html.include?("\n") ? "\n" : ''
+                "<li>#{item_html}#{suffix}</li>"
+              else
+                "<li>\n#{item_html}\n</li>"
+              end
+            end
+
+            ["<#{tag}#{start_attr}>\n#{items.join("\n")}\n</#{tag}>", index]
+          end
+
+          def parse_labeled_list(lines, index)
+            items = []
+
+            while index < lines.length
+              label, body = parse_labeled_list_line(lines[index])
+              break unless label
+
+              index += 1
+              body_lines = []
+              body_lines << body if body && !body.empty?
+
+              while index < lines.length
+                line = lines[index]
+                break if blank_line?(line)
+                break if parse_labeled_list_line(line)
+                break if !line.strip.empty? && !line.match(/^(?: {2,}|\t)/)
+
+                body_lines << line.sub(/^(?: {2,}|\t)/, '').chomp
+                index += 1
+              end
+
+              body_html =
+                if body_lines.empty?
+                  ''
+                else
+                  parse_blocks(body_lines.map { |l| "#{l}\n" }, 0).join("\n")
+                end
+
+              items << "<dt>#{format_inline(label)}</dt>\n<dd>#{body_html}</dd>"
+              index += 1 while index < lines.length && blank_line?(lines[index])
+            end
+
+            ["<dl>\n#{items.join("\n")}\n</dl>", index]
+          end
+
+          def parse_blockquote(lines, index)
+            quoted_lines = []
+            saw_quote = false
+            previous_blank = false
+
+            while index < lines.length
+              line = lines[index]
+              break if saw_quote && previous_blank && !blockquote_start?(line)
+              break if saw_quote && !blank_line?(line) && !blockquote_start?(line) &&
+                (block_boundary?(line) || line =~ /^(?: {4,}|\t)/ || (previous_blank && indented_code_start?(line)))
+              break unless blank_line?(line) || blockquote_start?(line) || saw_quote
+
+              if blank_line?(line)
+                quoted_lines << "\n"
+                previous_blank = true
+              elsif blockquote_start?(line)
+                line =~ BLOCKQUOTE_RE
+                quoted_lines << "#{$1}\n"
+                saw_quote = true
+                previous_blank = false
+              else
+                quoted_lines << line
+                previous_blank = false
+              end
+              index += 1
+            end
+
+            inner_html = parse_blocks(quoted_lines, 0).join("\n")
+            [inner_html.empty? ? "<blockquote>\n</blockquote>" : "<blockquote>\n#{inner_html}\n</blockquote>", index]
+          end
+
+          def parse_html_block(lines, index)
+            html = []
+            type = html_block_type(lines[index])
+            return ['', index] unless type
+
+            while index < lines.length
+              line = lines[index]
+              break if html.any? && [6, 7].include?(type) && html_block_end?(type, line)
+              break unless html.any? || html_block_type(line)
+
+              html << line.chomp
+              if html_block_end?(type, line)
+                index += 1
+                break
+              end
+              index += 1
+            end
+
+            [html.join("\n"), index]
+          end
+
+          def parse_paragraph(lines, index)
+            buffer = []
+
+            while index < lines.length
+              line = lines[index]
+              break if blank_line?(line)
+              break if thematic_break?(line)
+              break if parse_setext_heading(lines, index)
+              break if parse_heading(line)
+              break if fenced_code_start?(line)
+              break if table_start?(lines, index)
+              break if labeled_list_start?(lines, index)
+              break if blockquote_start?(line)
+              break if list_start?(line, true)
+              break if html_block_start?(line, true)
+
+              buffer << line.chomp
+              index += 1
+            end
+
+            text = buffer.map { |line| line.sub(/^\s{0,3}/, '') }.join("\n").strip
+            [text.empty? ? '' : "<p>#{format_inline(text)}</p>", index]
+          end
+
+          def format_inline(text)
+            placeholders = []
+            text = protect_yard_links(text, placeholders)
+            text = protect_raw_html(text, placeholders)
+            text = protect_code_spans(text, placeholders)
+            text = protect_autolinks(text, placeholders)
+            text = protect_hard_breaks(text, placeholders)
+            text = protect_inline_images(text, placeholders)
+            text = protect_inline_links(text, placeholders)
+            text = protect_reference_images(text, placeholders)
+            text = protect_reference_links(text, placeholders)
+            text = protect_escaped_characters(text, placeholders)
+            text = protect_entities(text, placeholders)
+            text = text.gsub(/[ \t]+\n/, "\n")
+            text = h(text)
+            text = format_emphasis(text)
+            text = format_strikethrough(text)
+            restore_placeholders(autolink_urls(text), placeholders)
+          end
+
+          def protect_code_spans(text, placeholders)
+            output = ''.dup
+            index = 0
+
+            while index < text.length
+              if text[index] == '`' && (index.zero? || text[index - 1] != '\\') && !inside_angle_autolink_candidate?(text, index)
+                opener_length = 1
+                opener_length += 1 while index + opener_length < text.length && text[index + opener_length] == '`'
+                closer_index = find_matching_backtick_run(text, index + opener_length, opener_length)
+                if closer_index
+                  code = normalize_code_span(restore_placeholders(text[(index + opener_length)...closer_index], placeholders))
+                  output << store_placeholder(placeholders, "<code>#{h(code)}</code>")
+                  index = closer_index + opener_length
+                  next
+                end
+
+                output << ('`' * opener_length)
+                index += opener_length
+                next
+              end
+
+              output << text[index]
+              index += 1
+            end
+
+            output.gsub(/(^|[\s>])\+([^\s+\n](?:[^+\n]*?[^\s+\n])?)\+(?=$|[\s<.,;:!?)]|\z)/) do
+              prefix = $1
+              prefix + store_placeholder(placeholders, "<code>#{h(restore_placeholders($2, placeholders))}</code>")
+            end
+          end
+
+          def inside_angle_autolink_candidate?(text, index)
+            opening = text.rindex('<', index)
+            return false unless opening
+
+            closing = text.rindex('>', index)
+            return false if closing && closing > opening
+
+            candidate = text[opening...index]
+            return false if candidate =~ /\s/
+
+            candidate =~ /\A<(?:[A-Za-z][A-Za-z0-9.+-]{1,31}:|[A-Za-z0-9.!#$%&'*+\/=?^_`{|}~-]+@)/
+          end
+
+          def protect_yard_links(text, placeholders)
+            text.gsub(YARD_LINK_RE) do
+              store_placeholder(placeholders, $&)
+            end
+          end
+
+          def protect_autolinks(text, placeholders)
+            text.gsub(AUTOLINK_RE) do
+              href = $1
+              link_href = href.include?('@') && href !~ /\A[A-Za-z][A-Za-z0-9.+-]{1,31}:/ ? "mailto:#{href}" : escape_autolink_url(href)
+              store_placeholder(placeholders, %(<a href="#{h(link_href)}">#{h(href)}</a>))
+            end
+          end
+
+          def protect_raw_html(text, placeholders)
+            text.gsub(/(?<!\\)#{HTML_TAG_RE}/m) do
+              match = $&
+              match_start = Regexp.last_match.begin(0)
+              if match_start > 0 && text[match_start - 1] == '`'
+                match
+              else
+                store_placeholder(placeholders, match)
+              end
+            end
+          end
+
+          def protect_escaped_characters(text, placeholders)
+            text.gsub(ESCAPABLE_CHARS_RE) { store_placeholder(placeholders, h($1)) }
+          end
+
+          def protect_entities(text, placeholders)
+            text.gsub(ENTITY_RE) { store_placeholder(placeholders, h(decode_entity($&))) }
+          end
+
+          def protect_hard_breaks(text, placeholders)
+            text.gsub(/(?:\\|\s{2,})\n/) { store_placeholder(placeholders, "<br />\n") }
+          end
+
+          def protect_inline_images(text, placeholders)
+            replace_inline_constructs(text, placeholders, '!') do |label, dest, title|
+              store_placeholder(placeholders, image_html(
+                restore_placeholders(label, placeholders),
+                restore_placeholders(dest, placeholders),
+                title && restore_placeholders(title, placeholders)
+              ))
+            end
+          end
+
+          def protect_inline_links(text, placeholders)
+            replace_inline_constructs(text, placeholders, nil) do |label, dest, title|
+              store_placeholder(placeholders, link_html(
+                restore_placeholders(label, placeholders),
+                restore_placeholders(dest, placeholders),
+                title && restore_placeholders(title, placeholders)
+              ))
+            end
+          end
+
+          def protect_reference_images(text, placeholders)
+            scan_reference_constructs(text, placeholders, :image)
+          end
+
+          def protect_reference_links(text, placeholders)
+            scan_reference_constructs(text, placeholders, :link)
+          end
+
+          def format_emphasis(text)
+            delimiters = []
+            output = []
+            index = 0
+
+            while index < text.length
+              char = text[index]
+              if char == '*' || char == '_'
+                run_end = index
+                run_end += 1 while run_end < text.length && text[run_end] == char
+                run_length = run_end - index
+                can_open, can_close = delimiter_flags(text, index, run_end, char)
+                token = {
+                  :char => char,
+                  :length => run_length,
+                  :position => output.length,
+                  :left_consumed => 0,
+                  :right_consumed => 0,
+                  :opening_html => ''.dup,
+                  :closing_html => ''.dup,
+                  :can_open => can_open,
+                  :can_close => can_close
+                }
+                output << token
+
+                if can_close
+                  delimiter_index = delimiters.length - 1
+                  while delimiter_index >= 0 && available_delimiter_length(token) > 0
+                    opener = delimiters[delimiter_index]
+                    if opener[:char] == char && available_delimiter_length(opener) > 0 &&
+                        !odd_match_disallowed?(opener, token)
+                      use = available_delimiter_length(opener) >= 2 &&
+                        available_delimiter_length(token) >= 2 ? 2 : 1
+                      opener[:right_consumed] += use
+                      opener[:opening_html].prepend(use == 2 ? '<strong>' : '<em>')
+                      token[:left_consumed] += use
+                      token[:closing_html] << (use == 2 ? '</strong>' : '</em>')
+                      delimiters.reject! do |candidate|
+                        candidate[:position] > opener[:position] &&
+                          candidate[:position] < token[:position] &&
+                          available_delimiter_length(candidate) > 0
+                      end
+                      delimiters.delete_at(delimiter_index) if available_delimiter_length(opener).zero?
+                      delimiter_index = delimiters.length - 1
+                    else
+                      delimiter_index -= 1
+                    end
+                  end
+                end
+
+                delimiters << token if can_open && available_delimiter_length(token) > 0
+                index = run_end
+              else
+                output << char
+                index += 1
+              end
+            end
+
+            output.map do |piece|
+              next piece if piece.is_a?(String)
+
+              piece[:closing_html] +
+                (piece[:char] * available_delimiter_length(piece)) +
+                piece[:opening_html]
+            end.join
+          end
+
+          def format_strikethrough(text)
+            text.gsub(/~~([^\n~](?:.*?[^\n~])?)~~/, '<del>\1</del>')
+          end
+
+          def autolink_urls(text)
+            text.gsub(/(^|[^\w\/{"'=])((?:https?:\/\/|mailto:)[^\s<]+)/) do
+              match = Regexp.last_match
+              prefix = $1
+              before_url = text[0...match.begin(2)]
+              if before_url.end_with?('&lt;') || before_url.end_with?('&lt; ')
+                match[0]
+              else
+                url, trailer = strip_trailing_punctuation($2)
+                %(#{prefix}<a href="#{h(url)}">#{h(url)}</a>#{h(trailer)})
+              end
+            end
+          end
+
+          def restore_placeholders(text, placeholders)
+            text.gsub(PLACEHOLDER_RE) { placeholders[$1.to_i] }
+          end
+
+          def store_placeholder(placeholders, html)
+            placeholders << html
+            "\0#{placeholders.length - 1}\0"
+          end
+
+          def parse_labeled_list_line(line)
+            return [$1, $2] if line =~ LABEL_LIST_COLON_RE
+
+            nil
+          end
+
+          def extract_reference_definitions(text)
+            lines = split_lines(text)
+            kept_lines = []
+            index = 0
+            in_fenced_code = false
+            previous_line = nil
+
+            while index < lines.length
+              line = lines[index]
+              if fenced_code_start?(line)
+                in_fenced_code = !in_fenced_code
+                kept_lines << line
+                index += 1
+                previous_line = line
+                next
+              end
+
+              if in_fenced_code
+                kept_lines << line
+                index += 1
+                previous_line = line
+                next
+              end
+
+              parsed = parse_reference_definition_block(lines, index, previous_line)
+              if parsed
+                normalized = normalize_reference_label(parsed[:label])
+                @references[normalized] ||= parsed[:reference] unless normalized.empty?
+                kept_lines.concat(parsed[:replacement_lines])
+                index = parsed[:next_index]
+                previous_line = kept_lines.last
+                next
+              end
+
+              kept_lines << line
+              index += 1
+              previous_line = line
+            end
+
+            kept_lines.join
+          end
+
+          def normalize_reference_label(label)
+            normalized = label.to_s.gsub(/\\([\[\]])/, '\1').gsub(/\s+/, ' ').strip
+            begin
+              normalized.downcase(:fold)
+            rescue ArgumentError, NoMethodError
+              unicode_casefold_compat(normalized)
+            end
+          end
+
+          def reference_link_html(label, ref)
+            reference = @references[normalize_reference_label(ref)]
+            return nil unless reference
+
+            attrs = %( href="#{h(reference[:url])}")
+            attrs += %( title="#{h(reference[:title])}") if reference[:title]
+            %(<a#{attrs}>#{format_inline(unescape_markdown_punctuation(label))}</a>)
+          end
+
+          def reference_image_html(alt, ref)
+            reference = @references[normalize_reference_label(ref)]
+            return nil unless reference
+
+            attrs = %( src="#{h(reference[:url])}" alt="#{h(plain_text(alt))}")
+            attrs += %( title="#{h(reference[:title])}") if reference[:title]
+            "<img#{attrs} />"
+          end
+
+          def blank_line?(line)
+            line.strip.empty?
+          end
+
+          def thematic_break?(line)
+            line =~ THEMATIC_BREAK_RE
+          end
+
+          def fenced_code_start?(line)
+            !!parse_fence_opener(line)
+          end
+
+          def indented_code_start?(line)
+            line =~ /^(?: {2,}|\t)/
+          end
+
+          def indented_code_block_start?(lines, index)
+            return false unless indented_code_start?(lines[index])
+            return true if lines[index] =~ /^(?: {4,}|\t)/
+
+            !index.zero? && blank_line?(lines[index - 1])
+          end
+
+          def yard_indented_code_start?(lines, index)
+            return false unless lines[index] =~ /^(?: {2,}|\t)!!!([\w.+-]+)[ \t]*$/
+            return false if index + 1 >= lines.length
+
+            indented_code_block_start?(lines, index) && lines[index + 1] =~ /^(?: {2,}|\t)/
+          end
+
+          def list_start?(line, interrupt_paragraph = false)
+            return true if line =~ UNORDERED_LIST_RE || line =~ RDOC_ORDERED_LIST_RE
+            return false unless (marker = parse_list_marker(line))
+            return true unless interrupt_paragraph
+
+            return false if marker[:content].empty?
+
+            !marker[:ordered] || marker[:start] == 1
+          end
+
+          def labeled_list_start?(lines, index)
+            line = lines[index]
+            return true if line =~ LABEL_LIST_COLON_RE
+            false
+          end
+
+          def blockquote_start?(line)
+            line =~ BLOCKQUOTE_RE
+          end
+
+          def html_block_start?(line, interrupt_paragraph = false)
+            !html_block_type(line, interrupt_paragraph).nil?
+          end
+
+          def table_start?(lines, index)
+            return false if index + 1 >= lines.length
+            table_row?(lines[index]) && lines[index + 1] =~ TABLE_SEPARATOR_RE
+          end
+
+          def table_row?(line)
+            stripped = line.strip
+            stripped.include?('|') && stripped !~ /\A[|:\-\s]+\z/
+          end
+
+          def split_table_row(line)
+            line.strip.sub(/\A\|/, '').sub(/\|\z/, '').split('|').map(&:strip)
+          end
+
+          def table_alignment(cell)
+            stripped = cell.strip
+            return 'center' if stripped.start_with?(':') && stripped.end_with?(':')
+            return 'left' if stripped.start_with?(':')
+            return 'right' if stripped.end_with?(':')
+
+            nil
+          end
+
+          def unindent(lines)
+            indent = lines.reject { |line| blank_line?(line) }.map do |line|
+              line.start_with?("\t") ? 4 : line[/\A +/, 0].to_s.length
+            end.min || 4
+
+            lines.map do |line|
+              if line.start_with?("\t")
+                line.sub(/^\t/, '')
+              else
+                line.sub(/\A {0,#{indent}}/, '')
+              end
+            end.join
+          end
+
+          def unindent_indented_code(lines)
+            lines.map do |line|
+              if line.start_with?("\t")
+                line.sub(/^\t/, '')
+              else
+                line.sub(/^ {0,4}/, '')
+              end
+            end.join
+          end
+
+          def code_block(text, lang = nil)
+            lang, text = extract_codeblock_language(text, lang)
+            attrs = lang ? %( class="#{h(lang)}") : ''
+            "<pre><code#{attrs}>#{h(text)}</code></pre>"
+          end
+
+          def extract_codeblock_language(text, lang = nil)
+            return [lang, text] unless text =~ CODE_LANG_RE
+
+            lang ||= unescape_markdown_punctuation(decode_entities($1))
+            [lang, $']
+          end
+
+          def strip_trailing_punctuation(url)
+            trailer = ''.dup
+            while url =~ /[),.;:!?]\z/
+              trailer.prepend(url[-1])
+              url = url[0...-1]
+            end
+            [url, trailer]
+          end
+
+          def parse_atx_heading(line)
+            stripped = line.chomp.sub(/^\s{0,3}/, '')
+            match = stripped.match(/\A(#{'#' * 6}|#{'#' * 5}|#{'#' * 4}|#{'#' * 3}|#{'#' * 2}|#)(?=[ \t]|$)(.*)\z/)
+            return nil unless match
+
+            level = match[1].length
+            content = match[2]
+            content = content.sub(/\A[ \t]+/, '')
+            content = content.sub(/[ \t]+#+[ \t]*\z/, '')
+            content = '' if content =~ /\A#+\z/
+            content = content.rstrip
+            "<h#{level}>#{format_inline(content)}</h#{level}>"
+          end
+
+          def parse_fence_opener(line)
+            match = line.match(FENCE_RE)
+            return nil unless match
+
+            indent = match[1].length
+            fence = match[2]
+            info = match[3].to_s.strip
+            return nil if fence.start_with?('`') && info.include?('`')
+
+            lang = info.empty? ? nil : unescape_markdown_punctuation(decode_entities(info.split(/[ \t]/, 2).first))
+            {:char => fence[0], :length => fence.length, :indent => indent, :lang => lang}
+          end
+
+          def fence_closer?(line, char, min_length)
+            stripped = line.sub(/^\s{0,3}/, '')
+            return false unless stripped.start_with?(char)
+
+            run = stripped[/\A#{Regexp.escape(char)}+/]
+            run && run.length >= min_length && stripped.sub(/\A#{Regexp.escape(run)}/, '').strip.empty?
+          end
+
+          def strip_fenced_indent(line, indent)
+            return line.sub(/^\t/, '') if line.start_with?("\t")
+
+            line.sub(/\A {0,#{indent}}/, '')
+          end
+
+          def parse_list_marker(line)
+            if line =~ /^(\s{0,3})([*+-])([ \t]*)(.*)$/
+              match = Regexp.last_match
+              return nil if match[3].empty? && !match[4].empty?
+
+              return {:ordered => false, :bullet => match[2], :indent => match[1].length,
+                      :marker_length => 1, :padding => match[3].length, :content => match[4]}
+            end
+
+            if line =~ /^(\s{0,3})(\d{1,9})([.)])([ \t]*)(.*)$/
+              match = Regexp.last_match
+              return nil if match[4].empty? && !match[5].empty?
+
+              return {:ordered => true, :delimiter => match[3], :start => match[2].to_i,
+                      :indent => match[1].length, :marker_length => match[2].length + 1,
+                      :padding => match[4].length, :content => match[5]}
+            end
+
+            return nil unless line =~ /^\s{0,3}([A-Za-z])\.(?:[ \t]+(.*))$/
+
+            match = Regexp.last_match
+            {:ordered => true, :delimiter => '.', :start => 1,
+             :indent => line[/\A */].to_s.length, :marker_length => 2, :padding => 1,
+             :content => (match[2] || '')}
+          end
+
+          def list_item_padding(marker)
+            (1..4).cover?(marker[:padding]) ? marker[:padding] : 1
+          end
+
+          def same_list_type?(base, other)
+            return false unless other
+            return base[:bullet] == other[:bullet] if !base[:ordered] && !other[:ordered]
+
+            base[:ordered] && other[:ordered] && base[:delimiter] == other[:delimiter]
+          end
+
+          def block_boundary?(line)
+            thematic_break?(line) || parse_heading(line) || fenced_code_start?(line) ||
+              table_row?(line) || labeled_list_start?([line, ''], 0) || blockquote_start?(line) ||
+              html_block_start?(line) || parse_list_marker(line)
+          end
+
+          def parse_reference_definition(label, definition)
+            definition = definition.to_s
+              return nil if normalize_reference_label(label).empty?
+
+            index = 0
+            index += 1 while index < definition.length && definition[index] =~ /[ \t\n]/
+            return nil if index >= definition.length
+
+            if definition[index] == '<'
+              close = definition.index('>', index + 1)
+              return nil unless close
+              url = definition[(index + 1)...close]
+              return nil if url.include?("\n")
+              index = close + 1
+                return nil if index < definition.length && definition[index] !~ /[ \t\n]/
+            else
+              start = index
+              while index < definition.length && definition[index] !~ /[ \t\n]/
+                index += 1
+              end
+              url = definition[start...index]
+            end
+
+              return nil if url.nil? || url.include?('<') || url.include?('>')
+
+            index += 1 while index < definition.length && definition[index] =~ /[ \t\n]/
+            title = nil
+
+            if index < definition.length
+              delimiter = definition[index]
+              close_delimiter = delimiter == '(' ? ')' : delimiter
+              if delimiter == '"' || delimiter == "'" || delimiter == '('
+                index += 1
+                start = index
+                buffer = ''.dup
+                while index < definition.length
+                  char = definition[index]
+                  if char == '\\' && index + 1 < definition.length
+                    buffer << definition[index, 2]
+                    index += 2
+                    next
+                  end
+                  break if char == close_delimiter
+                  buffer << char
+                  index += 1
+                end
+                return nil if index >= definition.length || definition[index] != close_delimiter
+                title = buffer
+                index += 1
+                index += 1 while index < definition.length && definition[index] =~ /[ \t\n]/
+                return nil unless index == definition.length
+              else
+                return nil
+              end
+            end
+
+            {
+              :url => escape_url(unescape_markdown_punctuation(decode_entities(url))),
+              :title => title && unescape_markdown_punctuation(decode_entities(title))
+            }
+          end
+
+          def replace_inline_constructs(text, placeholders, prefix)
+            output = ''.dup
+            index = 0
+
+            while index < text.length
+              if prefix
+                if text[index, 2] != '![' || (index > 0 && text[index - 1] == '\\')
+                  output << text[index]
+                  index += 1
+                  next
+                end
+                label_start = index + 2
+              else
+                if text[index] != '[' || (index > 0 && text[index - 1] == '\\')
+                  output << text[index]
+                  index += 1
+                  next
+                end
+                label_start = index + 1
+              end
+
+              label_end = find_closing_bracket(text, label_start - 1)
+              unless label_end && text[label_end + 1] == '('
+                output << text[index]
+                index += 1
+                next
+              end
+
+              dest, title, consumed = parse_inline_destination(text, label_end + 2, placeholders)
+              unless consumed
+                output << text[index]
+                index += 1
+                next
+              end
+
+              label = text[label_start...label_end]
+              if !prefix && contains_nested_link?(label, placeholders)
+                output << text[index]
+                index += 1
+                next
+              end
+              output << yield(label, dest, title)
+              index = consumed
+            end
+
+            output
+          end
+
+          def scan_reference_constructs(text, placeholders, kind)
+            output = ''.dup
+            index = 0
+
+            while index < text.length
+              image = kind == :image
+              if image
+                if text[index, 2] != '![' || (index > 0 && text[index - 1] == '\\')
+                  output << text[index]
+                  index += 1
+                  next
+                end
+                label_open = index + 1
+              else
+                if text[index] != '[' || (index > 0 && text[index - 1] == '\\')
+                  output << text[index]
+                  index += 1
+                  next
+                end
+                label_open = index
+              end
+
+              label_close = find_closing_bracket(text, label_open)
+              unless label_close
+                output << text[index]
+                index += 1
+                next
+              end
+
+              next_char = text[label_close + 1]
+              label = restore_placeholders(text[(label_open + 1)...label_close], placeholders)
+              html = nil
+              consumed = nil
+
+              if next_char == '['
+                ref_close = find_closing_bracket(text, label_close + 1)
+                if ref_close
+                  ref = restore_placeholders(text[(label_close + 2)...ref_close], placeholders)
+                  ref = label if ref.empty?
+                  if kind == :link && contains_nested_link?(label, placeholders)
+                    output << text[index]
+                    index += 1
+                    next
+                  end
+                  html = kind == :image ? reference_image_html(label, ref) : reference_link_html(label, ref)
+                  consumed = ref_close + 1 if html
+                end
+              else
+                if kind == :link && contains_nested_link?(label, placeholders)
+                  output << text[index]
+                  index += 1
+                  next
+                end
+                html = kind == :image ? reference_image_html(label, label) : reference_link_html(label, label)
+                consumed = label_close + 1 if html
+              end
+
+              if html
+                output << store_placeholder(placeholders, html)
+                index = consumed
+              else
+                output << text[index]
+                index += 1
+              end
+            end
+
+            output
+          end
+
+          def find_closing_bracket(text, open_index)
+            depth = 0
+            index = open_index
+            while index < text.length
+              char = text[index]
+              if char == '['
+                depth += 1
+              elsif char == ']'
+                depth -= 1
+                return index if depth.zero?
+              elsif char == '\\'
+                index += 1
+              end
+              index += 1
+            end
+            nil
+          end
+
+          def find_matching_backtick_run(text, index, length)
+            while index < text.length
+              if text[index] == '`'
+                run_length = 1
+                run_length += 1 while index + run_length < text.length && text[index + run_length] == '`'
+                return index if run_length == length
+
+                index += run_length
+                next
+              end
+              index += 1
+            end
+
+            nil
+          end
+
+          def parse_inline_destination(text, index, placeholders = nil)
+            while index < text.length && text[index] =~ /[ \t\n]/
+              index += 1
+            end
+
+            if text[index] == '<'
+              close = text.index('>', index + 1)
+              return [nil, nil, nil] unless close
+              dest = text[(index + 1)...close]
+              return [nil, nil, nil] if dest.include?("\n") || dest.include?('\\')
+              dest = dest.gsub(' ', '%20')
+              index = close + 1
+            else
+              close = index
+              parens = 0
+              while close < text.length
+                char = text[close]
+                if char == '\\' && close + 1 < text.length
+                  close += 2
+                  next
+                end
+                break if parens.zero? && (char == ')' || char =~ /\s/)
+                parens += 1 if char == '('
+                parens -= 1 if char == ')'
+                close += 1
+              end
+              dest = text[index...close]
+              index = close
+            end
+
+            if placeholders
+              restored_dest = restore_placeholders(dest.to_s, placeholders)
+              if restored_dest.start_with?('<')
+                return [nil, nil, nil] if restored_dest.include?("\n") || restored_dest.include?('\\')
+                return [nil, nil, nil] unless restored_dest.end_with?('>') && restored_dest.index('>') == restored_dest.length - 1
+
+                dest = restored_dest[1...-1]
+              end
+            end
+
+            while index < text.length && text[index] =~ /[ \t\n]/
+              index += 1
+            end
+
+            title = nil
+            if text[index] == '"' || text[index] == "'"
+              delimiter = text[index]
+              index += 1
+              buffer = ''.dup
+              while index < text.length
+                char = text[index]
+                if char == '\\' && index + 1 < text.length
+                  buffer << text[index, 2]
+                  index += 2
+                  next
+                end
+                break if char == delimiter
+                buffer << char
+                index += 1
+              end
+              return [nil, nil, nil] unless index < text.length && text[index] == delimiter
+              title = buffer
+              index += 1
+            elsif text[index] == '('
+              index += 1
+              buffer = ''.dup
+              depth = 1
+              while index < text.length
+                char = text[index]
+                if char == '\\' && index + 1 < text.length
+                  buffer << text[index, 2]
+                  index += 2
+                  next
+                end
+                if char == '('
+                  depth += 1
+                elsif char == ')'
+                  depth -= 1
+                  break if depth.zero?
+                end
+                buffer << char
+                index += 1
+              end
+              return [nil, nil, nil] unless index < text.length && text[index] == ')'
+              title = buffer
+              index += 1
+            end
+
+            while index < text.length && text[index] =~ /[ \t\n]/
+              index += 1
+            end
+            return [nil, nil, nil] unless text[index] == ')'
+
+            [dest.to_s, title, index + 1]
+          end
+
+          def plain_text(text)
+            text = text.to_s.gsub(/!\[([^\]]*)\]\([^)]+\)/, '\1')
+            text = text.gsub(/\[([^\]]+)\]\([^)]+\)/, '\1')
+            text = text.gsub(/[*_~`]/, '')
+            decode_entities(unescape_markdown_punctuation(text))
+          end
+
+          def link_html(label, dest, title = nil)
+            href = escape_url(unescape_markdown_punctuation(decode_entities(dest.to_s)))
+            normalized_title = title && unescape_markdown_punctuation(decode_entities(title))
+            attrs = %( href="#{h(href)}")
+            attrs += %( title="#{h(normalized_title)}") if normalized_title
+            %(<a#{attrs}>#{format_inline(label)}</a>)
+          end
+
+          def image_html(label, dest, title = nil)
+            src = escape_url(unescape_markdown_punctuation(decode_entities(dest.to_s)))
+            normalized_title = title && unescape_markdown_punctuation(decode_entities(title))
+            attrs = %( src="#{h(src)}" alt="#{h(plain_text(label))}")
+            attrs += %( title="#{h(normalized_title)}") if normalized_title
+            "<img#{attrs} />"
+          end
+
+          def decode_entities(text)
+            text.gsub(ENTITY_RE) do |entity|
+              decode_entity(entity)
+            end
+          end
+
+          def unescape_markdown_punctuation(text)
+            text.to_s.gsub(/\\([\\`*_{}\[\]()#+\-.!<>~|])/, '\1')
+          end
+
+          def reference_definition_continuation?(line)
+            return true if line =~ /^(?: {1,3}|\t)(.*)$/
+            return true if line =~ /\A<(?:[^>\n]*)>\s*\z/
+            return true if line =~ /\A(?:"[^"]*"|'[^']*'|\([^)]*\))\s*\z/
+
+            false
+          end
+
+          def normalize_code_span(code)
+            code = code.gsub(/\n/, ' ')
+            if code.length > 1 && code.start_with?(' ') && code.end_with?(' ') && code.strip != ''
+              code[1...-1]
+            else
+              code
+            end
+          end
+
+          def available_delimiter_length(token)
+            token[:length] - token[:left_consumed] - token[:right_consumed]
+          end
+
+          def odd_match_disallowed?(opener, closer)
+            return false unless opener[:can_close] || closer[:can_open]
+
+            opener_len = available_delimiter_length(opener)
+            closer_len = available_delimiter_length(closer)
+            ((opener_len + closer_len) % 3).zero? &&
+              (opener_len % 3 != 0 || closer_len % 3 != 0)
+          end
+
+          def delimiter_flags(text, run_start, run_end, char)
+            before = run_start.zero? ? nil : text[run_start - 1]
+            after = run_end >= text.length ? nil : text[run_end]
+            before_whitespace = whitespace_char?(before)
+            after_whitespace = whitespace_char?(after)
+            before_punctuation = punctuation_char?(before)
+            after_punctuation = punctuation_char?(after)
+
+            left_flanking = !after_whitespace && (!after_punctuation || before_whitespace || before_punctuation)
+            right_flanking = !before_whitespace && (!before_punctuation || after_whitespace || after_punctuation)
+
+            if char == '_'
+              [
+                left_flanking && (!right_flanking || before_punctuation),
+                right_flanking && (!left_flanking || after_punctuation)
+              ]
+            else
+              [left_flanking, right_flanking]
+            end
+          end
+
+          def whitespace_char?(char)
+            char.nil? || char =~ /\s/ || char == NAMED_ENTITIES['nbsp']
+          end
+
+          def punctuation_char?(char)
+            !char.nil? && char =~ /[\p{P}\p{S}]/
+          end
+
+          def leading_spaces(line)
+            line[/\A */, 0].to_s.length
+          end
+
+          def strip_list_item_indent(line, content_indent)
+            if line.start_with?("\t")
+              line.sub(/^\t/, '')
+            else
+              line.sub(/\A {0,#{content_indent}}/, '')
+            end
+          end
+
+          def escape_url(url)
+            percent_encode_url(url.to_s, /[A-Za-z0-9\-._~:\/?#\[\]@!$&'()*+,;=%]/)
+          end
+
+          def escape_autolink_url(url)
+            percent_encode_url(url.to_s, /[A-Za-z0-9\-._~:\/?#@!$&'()*+,;=%]/)
+          end
+
+          def parse_reference_definition_block(lines, index, previous_line)
+            line = lines[index]
+            return nil unless reference_definition_context?(previous_line)
+
+            prefix, content = split_reference_container_prefix(line)
+            return nil unless content =~ /^\s{0,3}\[/
+
+            label_buffer = content.sub(/^\s{0,3}/, '')
+            consumed_lines = [line]
+            label_end = find_reference_label_end(label_buffer)
+            current_index = index
+
+            while label_end.nil?
+              current_index += 1
+              return nil if current_index >= lines.length
+
+              next_prefix, next_content = split_reference_container_prefix(lines[current_index])
+              return nil unless next_prefix == prefix
+
+              label_buffer << next_content
+              consumed_lines << lines[current_index]
+              label_end = find_reference_label_end(label_buffer)
+            end
+
+            label = label_buffer[1...label_end]
+            remainder = label_buffer[(label_end + 2)..-1].to_s
+            current_index += 1
+
+            while remainder.strip.empty? && current_index < lines.length
+              next_prefix, next_content = split_reference_container_prefix(lines[current_index])
+              break unless next_prefix == prefix
+              break if blank_line?(next_content)
+
+              remainder << (remainder.empty? ? next_content : "\n#{next_content}")
+              consumed_lines << lines[current_index]
+              current_index += 1
+            end
+
+            while unclosed_reference_title?(remainder) && current_index < lines.length
+              next_prefix, next_content = split_reference_container_prefix(lines[current_index])
+              break unless next_prefix == prefix
+              break if blank_line?(next_content)
+
+              remainder << "\n#{next_content}"
+              consumed_lines << lines[current_index]
+              current_index += 1
+            end
+
+            while current_index < lines.length
+              next_prefix, next_content = split_reference_container_prefix(lines[current_index])
+              break unless next_prefix == prefix
+              break unless reference_definition_continuation?(next_content)
+
+              remainder << "\n#{next_content.strip}"
+              consumed_lines << lines[current_index]
+              current_index += 1
+            end
+
+            reference = parse_reference_definition(label, remainder)
+            return nil unless reference
+
+            {
+              :label => label,
+              :reference => reference,
+              :replacement_lines => consumed_lines.map { |consumed| reference_definition_replacement_line(consumed, prefix) },
+              :next_index => current_index
+            }
+          end
+
+          def reference_definition_context?(previous_line)
+            return true if previous_line.nil?
+            return true if blank_line?(previous_line)
+
+            stripped = split_reference_container_prefix(previous_line).last
+            block_boundary?(stripped)
+          end
+
+          def split_reference_container_prefix(line)
+            prefix = ''.dup
+            content = line.chomp
+
+            while content =~ /\A(\s{0,3}> ?)(.*)\z/
+              prefix << $1
+              content = $2
+            end
+
+            [prefix, content]
+          end
+
+          def reference_definition_replacement_line(line, prefix)
+            return '' if prefix.empty?
+
+            prefix.rstrip + "\n"
+          end
+
+          def find_reference_label_end(text)
+            return nil unless text.start_with?('[')
+
+            index = 1
+            while index < text.length
+              char = text[index]
+              if char == '\\'
+                index += 2
+                next
+              end
+              return nil if char == '['
+              return index if char == ']' && text[index + 1] == ':'
+
+              index += 1
+            end
+
+            nil
+          end
+
+          def contains_nested_link?(label, placeholders)
+            text = restore_placeholders(label.to_s, placeholders)
+            return true if text.include?('<a ')
+
+            index = 0
+
+            while index < text.length
+              if text[index, 2] == '![' && (index.zero? || text[index - 1] != '\\')
+                label_open = index + 1
+              elsif text[index] == '[' && (index.zero? || text[index - 1] != '\\')
+                label_open = index
+              else
+                index += 1
+                next
+              end
+
+              label_close = find_closing_bracket(text, label_open)
+              if label_close
+                next_char = text[label_close + 1]
+                return true if next_char == '(' || next_char == '['
+              end
+
+              index += 1
+            end
+
+            false
+          end
+
+          def unclosed_reference_title?(text)
+            stripped = text.to_s.rstrip
+            return false if stripped.empty?
+
+            single_quotes = stripped.count("'")
+            double_quotes = stripped.count('"')
+            open_parens = stripped.count('(')
+            close_parens = stripped.count(')')
+
+            single_quotes.odd? || double_quotes.odd? || open_parens > close_parens
+          end
+
+          def percent_encode_url(text, allowed_re)
+            encoded = ''.dup
+
+            each_char_compat(text.to_s) do |char|
+              if ascii_only_compat?(char) && char =~ /\A#{allowed_re.source}\z/
+                encoded << char
+              else
+                utf8_bytes(char).each do |byte|
+                  encoded << sprintf('%%%02X', byte)
+                end
+              end
+            end
+
+            encoded
+          end
+
+          def html_block_type(line, interrupt_paragraph = false)
+            stripped = line.chomp
+            return nil unless stripped =~ /^\s{0,3}</ || stripped =~ /^\s{0,3}<(?!!--)/
+
+            return 1 if stripped =~ /^\s{0,3}<(?:script|pre|style|textarea)(?:\s|>|$)/i
+            return 2 if stripped =~ /^\s{0,3}<!--/
+            return 3 if stripped =~ /^\s{0,3}<\?/
+            return 4 if stripped =~ /^\s{0,3}<![A-Z]/
+            return 5 if stripped =~ /^\s{0,3}<!\[CDATA\[/
+            return 6 if stripped =~ /^\s{0,3}<\/?(?:#{HTML_BLOCK_TAGS.join('|')})(?:\s|\/?>|$)/i
+            return nil if interrupt_paragraph
+
+            return 7 if stripped =~ /^\s{0,3}(?:<[A-Za-z][A-Za-z0-9-]*(?:\s+[A-Za-z_:][\w:.-]*(?:\s*=\s*(?:"[^"]*"|'[^']*'|[^\s"'=<>`]+))?)*\s*\/?>|<\/[A-Za-z][A-Za-z0-9-]*\s*>)\s*$/
+
+            nil
+          end
+
+          def html_block_end?(type, line)
+            case type
+            when 1
+              line =~ %r{</(?:script|pre|style|textarea)\s*>}i
+            when 2
+              line.include?('-->')
+            when 3
+              line.include?('?>')
+            when 4
+              line.include?('>')
+            when 5
+              line.include?(']]>')
+            when 6, 7
+              blank_line?(line)
+            else
+              false
+            end
+          end
+
+          def decode_entity(entity)
+            case entity
+            when /\A&#(\d+);\z/
+              codepoint = $1.to_i
+            when /\A&#[xX]([0-9A-Fa-f]+);\z/
+              codepoint = $1.to_i(16)
+            else
+              name = entity[1..-2]
+              return [0x00E4].pack('U') if name == 'auml'
+              return NAMED_ENTITIES[name] || CGI.unescapeHTML(entity)
+            end
+
+            return [0xFFFD].pack('U') if codepoint.zero?
+            return entity if codepoint > 0x10FFFF
+            [codepoint].pack('U')
+          rescue RangeError
+            entity
+          end
+
+          def h(text)
+            text.to_s.gsub('&', '&amp;').gsub('<', '&lt;').gsub('>', '&gt;').gsub('"', '&quot;')
+          end
+
+          def unescape_markdown_punctuation(text)
+            text.to_s.gsub(ESCAPABLE_CHARS_RE, '\1')
+          end
+
+          def split_lines(text)
+            text.to_s.split(/^/, -1)
+          end
+
+          def each_char_compat(text)
+            if text.respond_to?(:each_char)
+              text.each_char { |char| yield char }
+            else
+              text.scan(/./m) { |char| yield char }
+            end
+          end
+
+          def ascii_only_compat?(text)
+            if text.respond_to?(:ascii_only?)
+              text.ascii_only?
+            else
+              text.to_s.unpack('C*').all? { |byte| byte < 128 }
+            end
+          end
+
+          def utf8_bytes(char)
+            if defined?(Encoding)
+              char.encode(Encoding::UTF_8).unpack('C*')
+            else
+              [char[0]].pack('U').unpack('C*')
+            end
+          end
+
+          def unicode_casefold_compat(text)
+            codepoints = text.to_s.unpack('U*')
+            folded = ''.dup
+
+            codepoints.each do |codepoint|
+              append_folded_codepoint(folded, codepoint)
+            end
+
+            folded
+          end
+
+          def append_folded_codepoint(buffer, codepoint)
+            case codepoint
+            when 0x41..0x5A
+              buffer << [codepoint + 32].pack('U')
+            when 0x0391..0x03A1
+              buffer << [codepoint + 32].pack('U')
+            when 0x03A3..0x03AB
+              buffer << [codepoint + 32].pack('U')
+            when 0x03C2
+              buffer << [0x03C3].pack('U')
+            when 0x00DF, 0x1E9E
+              buffer << 'ss'
+            else
+              begin
+                buffer << [codepoint].pack('U').downcase
+              rescue StandardError
+                buffer << [codepoint].pack('U')
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard/templates/helpers/markup/hybrid_markdown.rb
+++ b/lib/yard/templates/helpers/markup/hybrid_markdown.rb
@@ -91,6 +91,7 @@ module YARD
 
           def parse_blocks(lines, index)
             blocks = []
+            previous_block_type = nil
 
             while index < lines.length
               line = lines[index]
@@ -100,39 +101,51 @@ module YARD
               elsif yard_indented_code_start?(lines, index)
                 block, index = parse_yard_indented_code(lines, index)
                 blocks << block
+                previous_block_type = :code
               elsif thematic_break?(line)
                 blocks << '<hr />'
                 index += 1
+                previous_block_type = :hr
               elsif (heading = parse_setext_heading(lines, index))
                 blocks << heading[0]
                 index = heading[1]
+                previous_block_type = :heading
               elsif (heading = parse_heading(line))
                 blocks << heading
                 index += 1
+                previous_block_type = :heading
               elsif fenced_code_start?(line)
                 block, index = parse_fenced_code(lines, index)
                 blocks << block
+                previous_block_type = :code
               elsif table_start?(lines, index)
                 block, index = parse_table(lines, index)
                 blocks << block
+                previous_block_type = :table
               elsif labeled_list_start?(lines, index)
                 block, index = parse_labeled_list(lines, index)
                 blocks << block
+                previous_block_type = :list
               elsif blockquote_start?(line)
                 block, index = parse_blockquote(lines, index)
                 blocks << block
+                previous_block_type = :blockquote
               elsif list_start?(line)
                 block, index = parse_list(lines, index)
                 blocks << block
+                previous_block_type = :list
               elsif html_block_start?(line)
                 block, index = parse_html_block(lines, index)
                 blocks << block
-              elsif indented_code_block_start?(lines, index)
+                previous_block_type = :html
+              elsif indented_code_block_start?(lines, index, previous_block_type)
                 block, index = parse_indented_code(lines, index)
                 blocks << block
+                previous_block_type = :code
               else
                 block, index = parse_paragraph(lines, index)
                 blocks << block unless block.empty?
+                previous_block_type = :paragraph unless block.empty?
               end
             end
 
@@ -331,7 +344,9 @@ module YARD
                   item_lines << stripped
                   blank_seen = false
                 elsif !blank_seen
-                  item_lines << strip_list_item_indent(line, lazy_indent)
+                  stripped = strip_list_item_indent(line, lazy_indent)
+                  stripped = escape_list_marker_text(stripped) if parse_list_marker(stripped)
+                  item_lines << stripped
                   blank_seen = false
                 else
                   break
@@ -813,9 +828,10 @@ module YARD
             leading_columns(line) >= 2
           end
 
-          def indented_code_block_start?(lines, index)
+          def indented_code_block_start?(lines, index, previous_block_type = nil)
             return false unless indented_code_start?(lines[index])
             return true if leading_columns(lines[index]) >= 4
+            return false if previous_block_type == :list
 
             !index.zero? && blank_line?(lines[index - 1])
           end
@@ -1460,6 +1476,21 @@ module YARD
 
           def strip_list_item_indent(line, content_indent)
             consume_columns(line, content_indent, 0, true)
+          end
+
+          def escape_list_marker_text(line)
+            source = line.to_s
+            newline = source.sub!(/\n\z/, '') ? "\n" : ''
+
+            if source =~ /\A([*+-])([ \t].*)\z/
+              "\\#{$1}#{$2}#{newline}"
+            elsif source =~ /\A(\d{1,9}[.)])([ \t].*)\z/
+              "\\#{$1}#{$2}#{newline}"
+            elsif source =~ /\A([A-Za-z]\.)([ \t].*)\z/
+              "\\#{$1}#{$2}#{newline}"
+            else
+              source + newline
+            end
           end
 
           def escape_url(url)

--- a/lib/yard/templates/helpers/markup/hybrid_markdown.rb
+++ b/lib/yard/templates/helpers/markup/hybrid_markdown.rb
@@ -1,10 +1,4 @@
-# frozen_string_literal: true
-
-if RUBY_VERSION < '3.5'
-  require 'cgi/util'
-else
-  require 'cgi/escape'
-end
+require 'cgi'
 require 'uri'
 
 module YARD
@@ -33,7 +27,7 @@ module YARD
 
           ATX_HEADING_RE = /^\s{0,3}#{Regexp.escape('#')}{1,6}(?=[ \t]|$)/.freeze
           RDOC_HEADING_RE = /^\s*(=+)[ \t]+(.+?)\s*$/.freeze
-          SETEXT_HEADING_RE = /^\s*(=+|-+)\s*$/.freeze
+          SETEXT_HEADING_RE = /^\s{0,3}(=+|-+)\s*$/.freeze
           FENCE_RE = /^(\s{0,3})(`{3,}|~{3,})([^\n]*)$/.freeze
           THEMATIC_BREAK_RE = /^\s{0,3}(?:(?:-\s*){3,}|(?:\*\s*){3,}|(?:_\s*){3,})\s*$/.freeze
           TABLE_SEPARATOR_RE = /^\s*\|?(?:\s*:?-+:?\s*\|)+(?:\s*:?-+:?\s*)\|?\s*$/.freeze
@@ -109,8 +103,8 @@ module YARD
                 blocks << '<hr />'
                 index += 1
               elsif (heading = parse_setext_heading(lines, index))
-                blocks << heading
-                index += 2
+                blocks << heading[0]
+                index = heading[1]
               elsif (heading = parse_heading(line))
                 blocks << heading
                 index += 1
@@ -160,10 +154,34 @@ module YARD
             return nil if lines[index].strip.empty?
             return nil if lines[index] =~ /^\s{0,3}>/
             return nil if parse_list_marker(lines[index])
-            return nil unless lines[index + 1] =~ SETEXT_HEADING_RE
+            return nil if lines[index] =~ /^(?: {4,}|\t)/
+            return nil if parse_heading(lines[index])
+            return nil if fenced_code_start?(lines[index])
 
-            level = $1.start_with?('=') ? 1 : 2
-            "<h#{level}>#{format_inline(lines[index].strip)}</h#{level}>"
+            content_lines = []
+            current_index = index
+
+            while current_index < lines.length
+              line = lines[current_index]
+              return nil if blank_line?(line)
+
+              if line =~ SETEXT_HEADING_RE
+                return nil if content_lines.empty?
+
+                level = $1.start_with?('=') ? 1 : 2
+                text = content_lines.join("\n")
+                return ["<h#{level}>#{format_inline(text)}</h#{level}>", current_index + 1]
+              end
+
+              if current_index > index && block_boundary?(line)
+                return nil
+              end
+
+              content_lines << normalize_heading_line(line)
+              current_index += 1
+            end
+
+            nil
           end
 
           def parse_fenced_code(lines, index)
@@ -253,9 +271,12 @@ module YARD
             start_attr = ordered && marker[:start] != 1 ? %( start="#{marker[:start]}") : ''
             items = []
             tight = true
+            loose_by_separator = false
             list_indent = marker[:indent]
 
             while index < lines.length
+              break if items.any? && thematic_break?(lines[index]) && leading_spaces(lines[index]) <= list_indent + 3
+
               item_marker = parse_list_marker(lines[index])
               break unless item_marker && same_list_type?(marker, item_marker)
 
@@ -274,14 +295,20 @@ module YARD
 
               while index < lines.length
                 line = lines[index]
+                break if thematic_break?(line) && !indented_to?(line, content_indent)
+                break if setext_underline_line?(line) && !indented_to?(line, content_indent)
+
                 next_marker = parse_list_marker(line)
                 if next_marker && same_list_type?(marker, next_marker) &&
                     (next_marker[:indent] == item_marker[:indent] || (blank_seen && next_marker[:indent] <= list_indent + 3))
-                  tight = false if blank_seen
+                  if blank_seen
+                    tight = false
+                    loose_by_separator = true
+                  end
                   break
                 end
                 break if next_marker && next_marker[:indent] < content_indent
-                break if !blank_seen && line !~ /^(?: {0,#{content_indent}}|\t)/ && block_boundary?(line)
+                break if !blank_seen && !indented_to?(line, content_indent) && block_boundary?(line)
 
                 if blank_line?(line)
                   item_lines << "\n"
@@ -327,20 +354,21 @@ module YARD
 
             items.map! do |item|
               item_html = item[:html]
-              if tight
-                item_html = item_html.sub(/\A<p>(.*?)<\/p>\z/m, '\1')
-                item_html = item_html.sub(/\A<p>(.*?)<\/p>(?=\n<(?:ul|ol|blockquote|pre|h\d|table|hr))/m, '\1')
-                item_html = item_html.sub(/\n<p>(.*?)<\/p>\z/m, "\n\\1")
-              end
+              item_html = "<p>#{item_html}</p>" if !tight && !item_html.empty? && item_html !~ /\A</m
+              item_html = item_html.sub(/\A<p>(.*?)<\/p>(?=\n<(?:ul|ol|blockquote|pre|h\d|table|hr))/m, '\1') if tight
+              item_html = item_html.sub(/\n<p>(.*?)<\/p>\z/m, "\n\\1") if tight
+              item_html = item_html.sub(/\A<p>(.*?)<\/p>\z/m, '\1') if item[:simple] && tight
+
               if item_html.empty?
                 '<li></li>'
-              elsif tight && item[:simple]
+              elsif item[:simple] && tight
                 "<li>#{item_html}</li>"
-              elsif tight && item_html !~ /\A</m
+              elsif item_html !~ /\A</m
                 suffix = item_html.include?("\n") ? "\n" : ''
                 "<li>#{item_html}#{suffix}</li>"
               else
-                "<li>\n#{item_html}\n</li>"
+                suffix = item_html =~ /(?:<\/(?:p|pre|blockquote|ul|ol|dl|table|h\d)>|<hr \/>|<[A-Za-z][A-Za-z0-9-]*>)\z/m ? "\n" : ''
+                "<li>\n#{item_html}#{suffix}</li>"
               end
             end
 
@@ -389,9 +417,11 @@ module YARD
 
             while index < lines.length
               line = lines[index]
-              break if saw_quote && previous_blank && !blockquote_start?(line)
+              break if saw_quote && quoted_lines.last == "\n" && !blockquote_start?(line)
+              break if saw_quote && blank_line?(line) && blockquote_open_fence?(quoted_lines)
+              break if saw_quote && previous_blank
               break if saw_quote && !blank_line?(line) && !blockquote_start?(line) &&
-                (block_boundary?(line) || line =~ /^(?: {4,}|\t)/ || (previous_blank && indented_code_start?(line)))
+                !lazy_blockquote_continuation?(quoted_lines, line)
               break unless blank_line?(line) || blockquote_start?(line) || saw_quote
 
               if blank_line?(line)
@@ -403,7 +433,11 @@ module YARD
                 saw_quote = true
                 previous_blank = false
               else
-                quoted_lines << line
+                if setext_underline_line?(line)
+                  quoted_lines << "    #{line.lstrip}"
+                else
+                  quoted_lines << line
+                end
                 previous_blank = false
               end
               index += 1
@@ -454,7 +488,7 @@ module YARD
               index += 1
             end
 
-            text = buffer.map { |line| line.sub(/^\s{0,3}/, '') }.join("\n").strip
+            text = buffer.map { |line| normalize_paragraph_line(line) }.join("\n").strip
             [text.empty? ? '' : "<p>#{format_inline(text)}</p>", index]
           end
 
@@ -479,13 +513,13 @@ module YARD
           end
 
           def protect_code_spans(text, placeholders)
-            output = ''.dup
+            output = ''
             index = 0
 
             while index < text.length
-              if text[index] == '`' && (index.zero? || text[index - 1] != '\\') && !inside_angle_autolink_candidate?(text, index)
+              if text[index, 1] == '`' && (index.zero? || text[index - 1, 1] != '\\') && !inside_angle_autolink_candidate?(text, index)
                 opener_length = 1
-                opener_length += 1 while index + opener_length < text.length && text[index + opener_length] == '`'
+                opener_length += 1 while index + opener_length < text.length && text[index + opener_length, 1] == '`'
                 closer_index = find_matching_backtick_run(text, index + opener_length, opener_length)
                 if closer_index
                   code = normalize_code_span(restore_placeholders(text[(index + opener_length)...closer_index], placeholders))
@@ -499,7 +533,7 @@ module YARD
                 next
               end
 
-              output << text[index]
+              output << text[index, 1]
               index += 1
             end
 
@@ -540,7 +574,7 @@ module YARD
             text.gsub(/(?<!\\)#{HTML_TAG_RE}/m) do
               match = $&
               match_start = Regexp.last_match.begin(0)
-              if match_start > 0 && text[match_start - 1] == '`'
+              if match_start > 0 && text[match_start - 1, 1] == '`'
                 match
               else
                 store_placeholder(placeholders, match)
@@ -594,10 +628,10 @@ module YARD
             index = 0
 
             while index < text.length
-              char = text[index]
+              char = text[index, 1]
               if char == '*' || char == '_'
                 run_end = index
-                run_end += 1 while run_end < text.length && text[run_end] == char
+                run_end += 1 while run_end < text.length && text[run_end, 1] == char
                 run_length = run_end - index
                 can_open, can_close = delimiter_flags(text, index, run_end, char)
                 token = {
@@ -606,8 +640,8 @@ module YARD
                   :position => output.length,
                   :left_consumed => 0,
                   :right_consumed => 0,
-                  :opening_html => ''.dup,
-                  :closing_html => ''.dup,
+                  :opening_html => '',
+                  :closing_html => '',
                   :can_open => can_open,
                   :can_close => can_close
                 }
@@ -622,7 +656,7 @@ module YARD
                       use = available_delimiter_length(opener) >= 2 &&
                         available_delimiter_length(token) >= 2 ? 2 : 1
                       opener[:right_consumed] += use
-                      opener[:opening_html].prepend(use == 2 ? '<strong>' : '<em>')
+                      opener[:opening_html] = (use == 2 ? '<strong>' : '<em>') + opener[:opening_html]
                       token[:left_consumed] += use
                       token[:closing_html] << (use == 2 ? '</strong>' : '</em>')
                       delimiters.reject! do |candidate|
@@ -732,11 +766,7 @@ module YARD
 
           def normalize_reference_label(label)
             normalized = label.to_s.gsub(/\\([\[\]])/, '\1').gsub(/\s+/, ' ').strip
-            begin
-              normalized.downcase(:fold)
-            rescue ArgumentError, NoMethodError
-              unicode_casefold_compat(normalized)
-            end
+            unicode_casefold_compat(normalized)
           end
 
           def reference_link_html(label, ref)
@@ -763,6 +793,10 @@ module YARD
 
           def thematic_break?(line)
             line =~ THEMATIC_BREAK_RE
+          end
+
+          def setext_underline_line?(line)
+            line =~ SETEXT_HEADING_RE
           end
 
           def fenced_code_start?(line)
@@ -872,9 +906,9 @@ module YARD
           end
 
           def strip_trailing_punctuation(url)
-            trailer = ''.dup
+            trailer = ''
             while url =~ /[),.;:!?]\z/
-              trailer.prepend(url[-1])
+              trailer = url[-1, 1] + trailer
               url = url[0...-1]
             end
             [url, trailer]
@@ -904,7 +938,7 @@ module YARD
             return nil if fence.start_with?('`') && info.include?('`')
 
             lang = info.empty? ? nil : unescape_markdown_punctuation(decode_entities(info.split(/[ \t]/, 2).first))
-            {:char => fence[0], :length => fence.length, :indent => indent, :lang => lang}
+            {:char => fence[0, 1], :length => fence.length, :indent => indent, :lang => lang}
           end
 
           def fence_closer?(line, char, min_length)
@@ -948,7 +982,7 @@ module YARD
           end
 
           def list_item_padding(marker)
-            (1..4).cover?(marker[:padding]) ? marker[:padding] : 1
+            (1..4).include?(marker[:padding]) ? marker[:padding] : 1
           end
 
           def same_list_type?(base, other)
@@ -998,7 +1032,7 @@ module YARD
               if delimiter == '"' || delimiter == "'" || delimiter == '('
                 index += 1
                 start = index
-                buffer = ''.dup
+                buffer = ''
                 while index < definition.length
                   char = definition[index]
                   if char == '\\' && index + 1 < definition.length
@@ -1027,7 +1061,7 @@ module YARD
           end
 
           def replace_inline_constructs(text, placeholders, prefix)
-            output = ''.dup
+            output = ''
             index = 0
 
             while index < text.length
@@ -1075,7 +1109,7 @@ module YARD
           end
 
           def scan_reference_constructs(text, placeholders, kind)
-            output = ''.dup
+            output = ''
             index = 0
 
             while index < text.length
@@ -1225,7 +1259,7 @@ module YARD
             if text[index] == '"' || text[index] == "'"
               delimiter = text[index]
               index += 1
-              buffer = ''.dup
+              buffer = ''
               while index < text.length
                 char = text[index]
                 if char == '\\' && index + 1 < text.length
@@ -1242,7 +1276,7 @@ module YARD
               index += 1
             elsif text[index] == '('
               index += 1
-              buffer = ''.dup
+              buffer = ''
               depth = 1
               while index < text.length
                 char = text[index]
@@ -1362,11 +1396,15 @@ module YARD
           end
 
           def punctuation_char?(char)
-            !char.nil? && char =~ /[\p{P}\p{S}]/
+            !char.nil? && char =~ /[[:punct:]]/
           end
 
           def leading_spaces(line)
             line[/\A */, 0].to_s.length
+          end
+
+          def indented_to?(line, indent)
+            line.start_with?("\t") || leading_spaces(line) >= indent
           end
 
           def strip_list_item_indent(line, content_indent)
@@ -1463,7 +1501,7 @@ module YARD
           end
 
           def split_reference_container_prefix(line)
-            prefix = ''.dup
+            prefix = ''
             content = line.chomp
 
             while content =~ /\A(\s{0,3}> ?)(.*)\z/
@@ -1540,7 +1578,7 @@ module YARD
           end
 
           def percent_encode_url(text, allowed_re)
-            encoded = ''.dup
+            encoded = ''
 
             each_char_compat(text.to_s) do |char|
               if ascii_only_compat?(char) && char =~ /\A#{allowed_re.source}\z/
@@ -1622,6 +1660,51 @@ module YARD
             text.to_s.split(/^/, -1)
           end
 
+          def lazy_blockquote_continuation?(quoted_lines, line)
+            return false if block_boundary?(line)
+            return false if indented_code_start?(line) && !blockquote_paragraph_context?(quoted_lines)
+
+            last_content = quoted_lines.reverse.find { |quoted| !blank_line?(quoted) }
+            return false if last_content && fenced_code_start?(last_content)
+            return false if last_content && indented_code_start?(last_content)
+
+            true
+          end
+
+          def blockquote_open_fence?(quoted_lines)
+            opener = nil
+
+            quoted_lines.each do |quoted|
+              next if blank_line?(quoted)
+
+              if opener
+                opener = nil if fence_closer?(quoted, opener[:char], opener[:length])
+              else
+                opener = parse_fence_opener(quoted)
+              end
+            end
+
+            !opener.nil?
+          end
+
+          def blockquote_paragraph_context?(quoted_lines)
+            last_content = quoted_lines.reverse.find { |quoted| !blank_line?(quoted) }
+            return false unless last_content
+            return false if fenced_code_start?(last_content)
+            return false if parse_heading(last_content)
+            return false if thematic_break?(last_content)
+
+            true
+          end
+
+          def normalize_paragraph_line(line)
+            line.to_s.chomp.sub(/^\s+/, '')
+          end
+
+          def normalize_heading_line(line)
+            normalize_paragraph_line(line).rstrip
+          end
+
           def each_char_compat(text)
             if text.respond_to?(:each_char)
               text.each_char { |char| yield char }
@@ -1648,7 +1731,7 @@ module YARD
 
           def unicode_casefold_compat(text)
             codepoints = text.to_s.unpack('U*')
-            folded = ''.dup
+            folded = ''
 
             codepoints.each do |codepoint|
               append_folded_codepoint(folded, codepoint)

--- a/lib/yard/templates/helpers/markup_helper.rb
+++ b/lib/yard/templates/helpers/markup_helper.rb
@@ -23,6 +23,7 @@ module YARD
       # The default list of markup providers for each markup type
       MARKUP_PROVIDERS = {
         :markdown => [
+          {:lib => :yard, :const => 'YARD::Templates::Helpers::Markup::HybridMarkdown'},
           {:lib => :redcarpet, :const => 'RedcarpetCompat'},
           {:lib => :rdiscount, :const => 'RDiscount'},
           {:lib => :kramdown, :const => 'Kramdown::Document'},
@@ -39,7 +40,8 @@ module YARD
           {:lib => :redcloth, :const => 'RedCloth'}
         ],
         :rdoc => [
-          {:lib => nil, :const => 'YARD::Templates::Helpers::Markup::RDocMarkup'}
+          {:lib => :yard, :const => 'YARD::Templates::Helpers::Markup::HybridMarkdown'},
+          {:lib => :rdoc, :const => 'YARD::Templates::Helpers::Markup::RDocMarkup'}
         ],
         :org => [
           {:lib => :'org-ruby', :const => 'Orgmode::Parser'}

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -156,13 +156,6 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
     end
 
     it "creates tables (markdown specific)" do
-      log.enter_level(Logger::FATAL) do
-        supports_table = %w(RedcarpetCompat Kramdown::Document CommonMarker)
-        unless supports_table.include?(markup_class(:markdown).to_s)
-          pending "This test depends on a markdown engine that supports tables"
-        end
-      end
-
       markdown = <<-EOF.strip
         City    | State | Country
         --------|-------|--------
@@ -177,12 +170,6 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
     end
 
     it "handles fenced code blocks (Redcarpet specific)" do
-      log.enter_level(Logger::FATAL) do
-        unless markup_class(:markdown).to_s == 'RedcarpetCompat'
-          pending 'This test is Redcarpet specific'
-        end
-      end
-
       markdown = "Introduction:\n```ruby\nputs\n\nputs\n```"
       html = htmlify(markdown, :markdown)
       expect(html).to match %r{^<p>Introduction:</p>.*<code class="ruby">}m

--- a/spec/templates/helpers/markup/fixtures/commonmark_0.31.2.json
+++ b/spec/templates/helpers/markup/fixtures/commonmark_0.31.2.json
@@ -1,0 +1,5218 @@
+[
+  {
+    "markdown": "\tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 1,
+    "start_line": 355,
+    "end_line": 360,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  \tfoo\tbaz\t\tbim\n",
+    "html": "<pre><code>foo\tbaz\t\tbim\n</code></pre>\n",
+    "example": 2,
+    "start_line": 362,
+    "end_line": 367,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    a\ta\n    ὐ\ta\n",
+    "html": "<pre><code>a\ta\nὐ\ta\n</code></pre>\n",
+    "example": 3,
+    "start_line": 369,
+    "end_line": 376,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "  - foo\n\n\tbar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 4,
+    "start_line": 382,
+    "end_line": 393,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "- foo\n\n\t\tbar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>  bar\n</code></pre>\n</li>\n</ul>\n",
+    "example": 5,
+    "start_line": 395,
+    "end_line": 407,
+    "section": "Tabs"
+  },
+  {
+    "markdown": ">\t\tfoo\n",
+    "html": "<blockquote>\n<pre><code>  foo\n</code></pre>\n</blockquote>\n",
+    "example": 6,
+    "start_line": 418,
+    "end_line": 425,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "-\t\tfoo\n",
+    "html": "<ul>\n<li>\n<pre><code>  foo\n</code></pre>\n</li>\n</ul>\n",
+    "example": 7,
+    "start_line": 427,
+    "end_line": 436,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "    foo\n\tbar\n",
+    "html": "<pre><code>foo\nbar\n</code></pre>\n",
+    "example": 8,
+    "start_line": 439,
+    "end_line": 446,
+    "section": "Tabs"
+  },
+  {
+    "markdown": " - foo\n   - bar\n\t - baz\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 9,
+    "start_line": 448,
+    "end_line": 464,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "#\tFoo\n",
+    "html": "<h1>Foo</h1>\n",
+    "example": 10,
+    "start_line": 466,
+    "end_line": 470,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "*\t*\t*\t\n",
+    "html": "<hr />\n",
+    "example": 11,
+    "start_line": 472,
+    "end_line": 476,
+    "section": "Tabs"
+  },
+  {
+    "markdown": "\\!\\\"\\#\\$\\%\\&\\'\\(\\)\\*\\+\\,\\-\\.\\/\\:\\;\\<\\=\\>\\?\\@\\[\\\\\\]\\^\\_\\`\\{\\|\\}\\~\n",
+    "html": "<p>!&quot;#$%&amp;'()*+,-./:;&lt;=&gt;?@[\\]^_`{|}~</p>\n",
+    "example": 12,
+    "start_line": 489,
+    "end_line": 493,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\t\\A\\a\\ \\3\\φ\\«\n",
+    "html": "<p>\\\t\\A\\a\\ \\3\\φ\\«</p>\n",
+    "example": 13,
+    "start_line": 499,
+    "end_line": 503,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\*not emphasized*\n\\<br/> not a tag\n\\[not a link](/foo)\n\\`not code`\n1\\. not a list\n\\* not a list\n\\# not a heading\n\\[foo]: /url \"not a reference\"\n\\&ouml; not a character entity\n",
+    "html": "<p>*not emphasized*\n&lt;br/&gt; not a tag\n[not a link](/foo)\n`not code`\n1. not a list\n* not a list\n# not a heading\n[foo]: /url &quot;not a reference&quot;\n&amp;ouml; not a character entity</p>\n",
+    "example": 14,
+    "start_line": 509,
+    "end_line": 529,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "\\\\*emphasis*\n",
+    "html": "<p>\\<em>emphasis</em></p>\n",
+    "example": 15,
+    "start_line": 534,
+    "end_line": 538,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "foo\\\nbar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 16,
+    "start_line": 543,
+    "end_line": 549,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "`` \\[\\` ``\n",
+    "html": "<p><code>\\[\\`</code></p>\n",
+    "example": 17,
+    "start_line": 555,
+    "end_line": 559,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "    \\[\\]\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 18,
+    "start_line": 562,
+    "end_line": 567,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "~~~\n\\[\\]\n~~~\n",
+    "html": "<pre><code>\\[\\]\n</code></pre>\n",
+    "example": 19,
+    "start_line": 570,
+    "end_line": 577,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<https://example.com?find=\\*>\n",
+    "html": "<p><a href=\"https://example.com?find=%5C*\">https://example.com?find=\\*</a></p>\n",
+    "example": 20,
+    "start_line": 580,
+    "end_line": 584,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "<a href=\"/bar\\/)\">\n",
+    "html": "<a href=\"/bar\\/)\">\n",
+    "example": 21,
+    "start_line": 587,
+    "end_line": 591,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo](/bar\\* \"ti\\*tle\")\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 22,
+    "start_line": 597,
+    "end_line": 601,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /bar\\* \"ti\\*tle\"\n",
+    "html": "<p><a href=\"/bar*\" title=\"ti*tle\">foo</a></p>\n",
+    "example": 23,
+    "start_line": 604,
+    "end_line": 610,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "``` foo\\+bar\nfoo\n```\n",
+    "html": "<pre><code class=\"foo+bar\">foo\n</code></pre>\n",
+    "example": 24,
+    "start_line": 613,
+    "end_line": 620,
+    "section": "Backslash escapes"
+  },
+  {
+    "markdown": "&nbsp; &amp; &copy; &AElig; &Dcaron;\n&frac34; &HilbertSpace; &DifferentialD;\n&ClockwiseContourIntegral; &ngE;\n",
+    "html": "<p>  &amp; © Æ Ď\n¾ ℋ ⅆ\n∲ ≧̸</p>\n",
+    "example": 25,
+    "start_line": 649,
+    "end_line": 657,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#35; &#1234; &#992; &#0;\n",
+    "html": "<p># Ӓ Ϡ �</p>\n",
+    "example": 26,
+    "start_line": 668,
+    "end_line": 672,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#X22; &#XD06; &#xcab;\n",
+    "html": "<p>&quot; ആ ಫ</p>\n",
+    "example": 27,
+    "start_line": 681,
+    "end_line": 685,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&nbsp &x; &#; &#x;\n&#87654321;\n&#abcdef0;\n&ThisIsNotDefined; &hi?;\n",
+    "html": "<p>&amp;nbsp &amp;x; &amp;#; &amp;#x;\n&amp;#87654321;\n&amp;#abcdef0;\n&amp;ThisIsNotDefined; &amp;hi?;</p>\n",
+    "example": 28,
+    "start_line": 690,
+    "end_line": 700,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&copy\n",
+    "html": "<p>&amp;copy</p>\n",
+    "example": 29,
+    "start_line": 707,
+    "end_line": 711,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&MadeUpEntity;\n",
+    "html": "<p>&amp;MadeUpEntity;</p>\n",
+    "example": 30,
+    "start_line": 717,
+    "end_line": 721,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "<a href=\"&ouml;&ouml;.html\">\n",
+    "html": "<a href=\"&ouml;&ouml;.html\">\n",
+    "example": 31,
+    "start_line": 728,
+    "end_line": 732,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo](/f&ouml;&ouml; \"f&ouml;&ouml;\")\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 32,
+    "start_line": 735,
+    "end_line": 739,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /f&ouml;&ouml; \"f&ouml;&ouml;\"\n",
+    "html": "<p><a href=\"/f%C3%B6%C3%B6\" title=\"föö\">foo</a></p>\n",
+    "example": 33,
+    "start_line": 742,
+    "end_line": 748,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "``` f&ouml;&ouml;\nfoo\n```\n",
+    "html": "<pre><code class=\"föö\">foo\n</code></pre>\n",
+    "example": 34,
+    "start_line": 751,
+    "end_line": 758,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "`f&ouml;&ouml;`\n",
+    "html": "<p><code>f&amp;ouml;&amp;ouml;</code></p>\n",
+    "example": 35,
+    "start_line": 764,
+    "end_line": 768,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "    f&ouml;f&ouml;\n",
+    "html": "<pre><code>f&amp;ouml;f&amp;ouml;\n</code></pre>\n",
+    "example": 36,
+    "start_line": 771,
+    "end_line": 776,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#42;foo&#42;\n*foo*\n",
+    "html": "<p>*foo*\n<em>foo</em></p>\n",
+    "example": 37,
+    "start_line": 783,
+    "end_line": 789,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#42; foo\n\n* foo\n",
+    "html": "<p>* foo</p>\n<ul>\n<li>foo</li>\n</ul>\n",
+    "example": 38,
+    "start_line": 791,
+    "end_line": 800,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "foo&#10;&#10;bar\n",
+    "html": "<p>foo\n\nbar</p>\n",
+    "example": 39,
+    "start_line": 802,
+    "end_line": 808,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "&#9;foo\n",
+    "html": "<p>\tfoo</p>\n",
+    "example": 40,
+    "start_line": 810,
+    "end_line": 814,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "[a](url &quot;tit&quot;)\n",
+    "html": "<p>[a](url &quot;tit&quot;)</p>\n",
+    "example": 41,
+    "start_line": 817,
+    "end_line": 821,
+    "section": "Entity and numeric character references"
+  },
+  {
+    "markdown": "- `one\n- two`\n",
+    "html": "<ul>\n<li>`one</li>\n<li>two`</li>\n</ul>\n",
+    "example": 42,
+    "start_line": 840,
+    "end_line": 848,
+    "section": "Precedence"
+  },
+  {
+    "markdown": "***\n---\n___\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 43,
+    "start_line": 879,
+    "end_line": 887,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "+++\n",
+    "html": "<p>+++</p>\n",
+    "example": 44,
+    "start_line": 892,
+    "end_line": 896,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "===\n",
+    "html": "<p>===</p>\n",
+    "example": 45,
+    "start_line": 899,
+    "end_line": 903,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "--\n**\n__\n",
+    "html": "<p>--\n**\n__</p>\n",
+    "example": 46,
+    "start_line": 908,
+    "end_line": 916,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " ***\n  ***\n   ***\n",
+    "html": "<hr />\n<hr />\n<hr />\n",
+    "example": 47,
+    "start_line": 921,
+    "end_line": 929,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "    ***\n",
+    "html": "<pre><code>***\n</code></pre>\n",
+    "example": 48,
+    "start_line": 934,
+    "end_line": 939,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n    ***\n",
+    "html": "<p>Foo\n***</p>\n",
+    "example": 49,
+    "start_line": 942,
+    "end_line": 948,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_____________________________________\n",
+    "html": "<hr />\n",
+    "example": 50,
+    "start_line": 953,
+    "end_line": 957,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " - - -\n",
+    "html": "<hr />\n",
+    "example": 51,
+    "start_line": 962,
+    "end_line": 966,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " **  * ** * ** * **\n",
+    "html": "<hr />\n",
+    "example": 52,
+    "start_line": 969,
+    "end_line": 973,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "-     -      -      -\n",
+    "html": "<hr />\n",
+    "example": 53,
+    "start_line": 976,
+    "end_line": 980,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- - - -    \n",
+    "html": "<hr />\n",
+    "example": 54,
+    "start_line": 985,
+    "end_line": 989,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "_ _ _ _ a\n\na------\n\n---a---\n",
+    "html": "<p>_ _ _ _ a</p>\n<p>a------</p>\n<p>---a---</p>\n",
+    "example": 55,
+    "start_line": 994,
+    "end_line": 1004,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": " *-*\n",
+    "html": "<p><em>-</em></p>\n",
+    "example": 56,
+    "start_line": 1010,
+    "end_line": 1014,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- foo\n***\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 57,
+    "start_line": 1019,
+    "end_line": 1031,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n***\nbar\n",
+    "html": "<p>Foo</p>\n<hr />\n<p>bar</p>\n",
+    "example": 58,
+    "start_line": 1036,
+    "end_line": 1044,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "Foo\n---\nbar\n",
+    "html": "<h2>Foo</h2>\n<p>bar</p>\n",
+    "example": 59,
+    "start_line": 1053,
+    "end_line": 1060,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "* Foo\n* * *\n* Bar\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n<ul>\n<li>Bar</li>\n</ul>\n",
+    "example": 60,
+    "start_line": 1066,
+    "end_line": 1078,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "- Foo\n- * * *\n",
+    "html": "<ul>\n<li>Foo</li>\n<li>\n<hr />\n</li>\n</ul>\n",
+    "example": 61,
+    "start_line": 1083,
+    "end_line": 1093,
+    "section": "Thematic breaks"
+  },
+  {
+    "markdown": "# foo\n## foo\n### foo\n#### foo\n##### foo\n###### foo\n",
+    "html": "<h1>foo</h1>\n<h2>foo</h2>\n<h3>foo</h3>\n<h4>foo</h4>\n<h5>foo</h5>\n<h6>foo</h6>\n",
+    "example": 62,
+    "start_line": 1112,
+    "end_line": 1126,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "####### foo\n",
+    "html": "<p>####### foo</p>\n",
+    "example": 63,
+    "start_line": 1131,
+    "end_line": 1135,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#5 bolt\n\n#hashtag\n",
+    "html": "<p>#5 bolt</p>\n<p>#hashtag</p>\n",
+    "example": 64,
+    "start_line": 1146,
+    "end_line": 1153,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "\\## foo\n",
+    "html": "<p>## foo</p>\n",
+    "example": 65,
+    "start_line": 1158,
+    "end_line": 1162,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo *bar* \\*baz\\*\n",
+    "html": "<h1>foo <em>bar</em> *baz*</h1>\n",
+    "example": 66,
+    "start_line": 1167,
+    "end_line": 1171,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "#                  foo                     \n",
+    "html": "<h1>foo</h1>\n",
+    "example": 67,
+    "start_line": 1176,
+    "end_line": 1180,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": " ### foo\n  ## foo\n   # foo\n",
+    "html": "<h3>foo</h3>\n<h2>foo</h2>\n<h1>foo</h1>\n",
+    "example": 68,
+    "start_line": 1185,
+    "end_line": 1193,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "    # foo\n",
+    "html": "<pre><code># foo\n</code></pre>\n",
+    "example": 69,
+    "start_line": 1198,
+    "end_line": 1203,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "foo\n    # bar\n",
+    "html": "<p>foo\n# bar</p>\n",
+    "example": 70,
+    "start_line": 1206,
+    "end_line": 1212,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## foo ##\n  ###   bar    ###\n",
+    "html": "<h2>foo</h2>\n<h3>bar</h3>\n",
+    "example": 71,
+    "start_line": 1217,
+    "end_line": 1223,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo ##################################\n##### foo ##\n",
+    "html": "<h1>foo</h1>\n<h5>foo</h5>\n",
+    "example": 72,
+    "start_line": 1228,
+    "end_line": 1234,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ###     \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 73,
+    "start_line": 1239,
+    "end_line": 1243,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo ### b\n",
+    "html": "<h3>foo ### b</h3>\n",
+    "example": 74,
+    "start_line": 1250,
+    "end_line": 1254,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "# foo#\n",
+    "html": "<h1>foo#</h1>\n",
+    "example": 75,
+    "start_line": 1259,
+    "end_line": 1263,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "### foo \\###\n## foo #\\##\n# foo \\#\n",
+    "html": "<h3>foo ###</h3>\n<h2>foo ###</h2>\n<h1>foo #</h1>\n",
+    "example": 76,
+    "start_line": 1269,
+    "end_line": 1277,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "****\n## foo\n****\n",
+    "html": "<hr />\n<h2>foo</h2>\n<hr />\n",
+    "example": 77,
+    "start_line": 1283,
+    "end_line": 1291,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo bar\n# baz\nBar foo\n",
+    "html": "<p>Foo bar</p>\n<h1>baz</h1>\n<p>Bar foo</p>\n",
+    "example": 78,
+    "start_line": 1294,
+    "end_line": 1302,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "## \n#\n### ###\n",
+    "html": "<h2></h2>\n<h1></h1>\n<h3></h3>\n",
+    "example": 79,
+    "start_line": 1307,
+    "end_line": 1315,
+    "section": "ATX headings"
+  },
+  {
+    "markdown": "Foo *bar*\n=========\n\nFoo *bar*\n---------\n",
+    "html": "<h1>Foo <em>bar</em></h1>\n<h2>Foo <em>bar</em></h2>\n",
+    "example": 80,
+    "start_line": 1347,
+    "end_line": 1356,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo *bar\nbaz*\n====\n",
+    "html": "<h1>Foo <em>bar\nbaz</em></h1>\n",
+    "example": 81,
+    "start_line": 1361,
+    "end_line": 1368,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "  Foo *bar\nbaz*\t\n====\n",
+    "html": "<h1>Foo <em>bar\nbaz</em></h1>\n",
+    "example": 82,
+    "start_line": 1375,
+    "end_line": 1382,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n-------------------------\n\nFoo\n=\n",
+    "html": "<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 83,
+    "start_line": 1387,
+    "end_line": 1396,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "   Foo\n---\n\n  Foo\n-----\n\n  Foo\n  ===\n",
+    "html": "<h2>Foo</h2>\n<h2>Foo</h2>\n<h1>Foo</h1>\n",
+    "example": 84,
+    "start_line": 1402,
+    "end_line": 1415,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    Foo\n    ---\n\n    Foo\n---\n",
+    "html": "<pre><code>Foo\n---\n\nFoo\n</code></pre>\n<hr />\n",
+    "example": 85,
+    "start_line": 1420,
+    "end_line": 1433,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n   ----      \n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 86,
+    "start_line": 1439,
+    "end_line": 1444,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n    ---\n",
+    "html": "<p>Foo\n---</p>\n",
+    "example": 87,
+    "start_line": 1449,
+    "end_line": 1455,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n= =\n\nFoo\n--- -\n",
+    "html": "<p>Foo\n= =</p>\n<p>Foo</p>\n<hr />\n",
+    "example": 88,
+    "start_line": 1460,
+    "end_line": 1471,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo  \n-----\n",
+    "html": "<h2>Foo</h2>\n",
+    "example": 89,
+    "start_line": 1476,
+    "end_line": 1481,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\\\n----\n",
+    "html": "<h2>Foo\\</h2>\n",
+    "example": 90,
+    "start_line": 1486,
+    "end_line": 1491,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "`Foo\n----\n`\n\n<a title=\"a lot\n---\nof dashes\"/>\n",
+    "html": "<h2>`Foo</h2>\n<p>`</p>\n<h2>&lt;a title=&quot;a lot</h2>\n<p>of dashes&quot;/&gt;</p>\n",
+    "example": 91,
+    "start_line": 1497,
+    "end_line": 1510,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> Foo\n---\n",
+    "html": "<blockquote>\n<p>Foo</p>\n</blockquote>\n<hr />\n",
+    "example": 92,
+    "start_line": 1516,
+    "end_line": 1524,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> foo\nbar\n===\n",
+    "html": "<blockquote>\n<p>foo\nbar\n===</p>\n</blockquote>\n",
+    "example": 93,
+    "start_line": 1527,
+    "end_line": 1537,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- Foo\n---\n",
+    "html": "<ul>\n<li>Foo</li>\n</ul>\n<hr />\n",
+    "example": 94,
+    "start_line": 1540,
+    "end_line": 1548,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nBar\n---\n",
+    "html": "<h2>Foo\nBar</h2>\n",
+    "example": 95,
+    "start_line": 1555,
+    "end_line": 1562,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\nFoo\n---\nBar\n---\nBaz\n",
+    "html": "<hr />\n<h2>Foo</h2>\n<h2>Bar</h2>\n<p>Baz</p>\n",
+    "example": 96,
+    "start_line": 1568,
+    "end_line": 1580,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\n====\n",
+    "html": "<p>====</p>\n",
+    "example": 97,
+    "start_line": 1585,
+    "end_line": 1590,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "---\n---\n",
+    "html": "<hr />\n<hr />\n",
+    "example": 98,
+    "start_line": 1597,
+    "end_line": 1603,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "- foo\n-----\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<hr />\n",
+    "example": 99,
+    "start_line": 1606,
+    "end_line": 1614,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    foo\n---\n",
+    "html": "<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 100,
+    "start_line": 1617,
+    "end_line": 1624,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "> foo\n-----\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 101,
+    "start_line": 1627,
+    "end_line": 1635,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "\\> foo\n------\n",
+    "html": "<h2>&gt; foo</h2>\n",
+    "example": 102,
+    "start_line": 1641,
+    "end_line": 1646,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\n\nbar\n---\nbaz\n",
+    "html": "<p>Foo</p>\n<h2>bar</h2>\n<p>baz</p>\n",
+    "example": 103,
+    "start_line": 1672,
+    "end_line": 1682,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n\n---\n\nbaz\n",
+    "html": "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n",
+    "example": 104,
+    "start_line": 1688,
+    "end_line": 1700,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n* * *\nbaz\n",
+    "html": "<p>Foo\nbar</p>\n<hr />\n<p>baz</p>\n",
+    "example": 105,
+    "start_line": 1706,
+    "end_line": 1716,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "Foo\nbar\n\\---\nbaz\n",
+    "html": "<p>Foo\nbar\n---\nbaz</p>\n",
+    "example": 106,
+    "start_line": 1721,
+    "end_line": 1731,
+    "section": "Setext headings"
+  },
+  {
+    "markdown": "    a simple\n      indented code block\n",
+    "html": "<pre><code>a simple\n  indented code block\n</code></pre>\n",
+    "example": 107,
+    "start_line": 1749,
+    "end_line": 1756,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "  - foo\n\n    bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 108,
+    "start_line": 1763,
+    "end_line": 1774,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "1.  foo\n\n    - bar\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 109,
+    "start_line": 1777,
+    "end_line": 1790,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    <a/>\n    *hi*\n\n    - one\n",
+    "html": "<pre><code>&lt;a/&gt;\n*hi*\n\n- one\n</code></pre>\n",
+    "example": 110,
+    "start_line": 1797,
+    "end_line": 1808,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n\n    chunk2\n  \n \n \n    chunk3\n",
+    "html": "<pre><code>chunk1\n\nchunk2\n\n\n\nchunk3\n</code></pre>\n",
+    "example": 111,
+    "start_line": 1813,
+    "end_line": 1830,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    chunk1\n      \n      chunk2\n",
+    "html": "<pre><code>chunk1\n  \n  chunk2\n</code></pre>\n",
+    "example": 112,
+    "start_line": 1836,
+    "end_line": 1845,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "Foo\n    bar\n\n",
+    "html": "<p>Foo\nbar</p>\n",
+    "example": 113,
+    "start_line": 1851,
+    "end_line": 1858,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo\nbar\n",
+    "html": "<pre><code>foo\n</code></pre>\n<p>bar</p>\n",
+    "example": 114,
+    "start_line": 1865,
+    "end_line": 1872,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "# Heading\n    foo\nHeading\n------\n    foo\n----\n",
+    "html": "<h1>Heading</h1>\n<pre><code>foo\n</code></pre>\n<h2>Heading</h2>\n<pre><code>foo\n</code></pre>\n<hr />\n",
+    "example": 115,
+    "start_line": 1878,
+    "end_line": 1893,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "        foo\n    bar\n",
+    "html": "<pre><code>    foo\nbar\n</code></pre>\n",
+    "example": 116,
+    "start_line": 1898,
+    "end_line": 1905,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "\n    \n    foo\n    \n\n",
+    "html": "<pre><code>foo\n</code></pre>\n",
+    "example": 117,
+    "start_line": 1911,
+    "end_line": 1920,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "    foo  \n",
+    "html": "<pre><code>foo  \n</code></pre>\n",
+    "example": 118,
+    "start_line": 1925,
+    "end_line": 1930,
+    "section": "Indented code blocks"
+  },
+  {
+    "markdown": "```\n<\n >\n```\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 119,
+    "start_line": 1980,
+    "end_line": 1989,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\n<\n >\n~~~\n",
+    "html": "<pre><code>&lt;\n &gt;\n</code></pre>\n",
+    "example": 120,
+    "start_line": 1994,
+    "end_line": 2003,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``\nfoo\n``\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 121,
+    "start_line": 2007,
+    "end_line": 2013,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n~~~\n```\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 122,
+    "start_line": 2018,
+    "end_line": 2027,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~\naaa\n```\n~~~\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 123,
+    "start_line": 2030,
+    "end_line": 2039,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````\naaa\n```\n``````\n",
+    "html": "<pre><code>aaa\n```\n</code></pre>\n",
+    "example": 124,
+    "start_line": 2044,
+    "end_line": 2053,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~\naaa\n~~~\n~~~~\n",
+    "html": "<pre><code>aaa\n~~~\n</code></pre>\n",
+    "example": 125,
+    "start_line": 2056,
+    "end_line": 2065,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 126,
+    "start_line": 2071,
+    "end_line": 2075,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "`````\n\n```\naaa\n",
+    "html": "<pre><code>\n```\naaa\n</code></pre>\n",
+    "example": 127,
+    "start_line": 2078,
+    "end_line": 2088,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "> ```\n> aaa\n\nbbb\n",
+    "html": "<blockquote>\n<pre><code>aaa\n</code></pre>\n</blockquote>\n<p>bbb</p>\n",
+    "example": 128,
+    "start_line": 2091,
+    "end_line": 2102,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n\n  \n```\n",
+    "html": "<pre><code>\n  \n</code></pre>\n",
+    "example": 129,
+    "start_line": 2107,
+    "end_line": 2116,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n```\n",
+    "html": "<pre><code></code></pre>\n",
+    "example": 130,
+    "start_line": 2121,
+    "end_line": 2126,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": " ```\n aaa\naaa\n```\n",
+    "html": "<pre><code>aaa\naaa\n</code></pre>\n",
+    "example": 131,
+    "start_line": 2133,
+    "end_line": 2142,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "  ```\naaa\n  aaa\naaa\n  ```\n",
+    "html": "<pre><code>aaa\naaa\naaa\n</code></pre>\n",
+    "example": 132,
+    "start_line": 2145,
+    "end_line": 2156,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\n   aaa\n    aaa\n  aaa\n   ```\n",
+    "html": "<pre><code>aaa\n aaa\naaa\n</code></pre>\n",
+    "example": 133,
+    "start_line": 2159,
+    "end_line": 2170,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "    ```\n    aaa\n    ```\n",
+    "html": "<pre><code>```\naaa\n```\n</code></pre>\n",
+    "example": 134,
+    "start_line": 2175,
+    "end_line": 2184,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 135,
+    "start_line": 2190,
+    "end_line": 2197,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "   ```\naaa\n  ```\n",
+    "html": "<pre><code>aaa\n</code></pre>\n",
+    "example": 136,
+    "start_line": 2200,
+    "end_line": 2207,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\naaa\n    ```\n",
+    "html": "<pre><code>aaa\n    ```\n</code></pre>\n",
+    "example": 137,
+    "start_line": 2212,
+    "end_line": 2220,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` ```\naaa\n",
+    "html": "<p><code> </code>\naaa</p>\n",
+    "example": 138,
+    "start_line": 2226,
+    "end_line": 2232,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~~~\naaa\n~~~ ~~\n",
+    "html": "<pre><code>aaa\n~~~ ~~\n</code></pre>\n",
+    "example": 139,
+    "start_line": 2235,
+    "end_line": 2243,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n```\nbar\n```\nbaz\n",
+    "html": "<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n",
+    "example": 140,
+    "start_line": 2249,
+    "end_line": 2260,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "foo\n---\n~~~\nbar\n~~~\n# baz\n",
+    "html": "<h2>foo</h2>\n<pre><code>bar\n</code></pre>\n<h1>baz</h1>\n",
+    "example": 141,
+    "start_line": 2266,
+    "end_line": 2278,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```ruby\ndef foo(x)\n  return 3\nend\n```\n",
+    "html": "<pre><code class=\"ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 142,
+    "start_line": 2288,
+    "end_line": 2299,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~~    ruby startline=3 $%@#$\ndef foo(x)\n  return 3\nend\n~~~~~~~\n",
+    "html": "<pre><code class=\"ruby\">def foo(x)\n  return 3\nend\n</code></pre>\n",
+    "example": 143,
+    "start_line": 2302,
+    "end_line": 2313,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "````;\n````\n",
+    "html": "<pre><code class=\";\"></code></pre>\n",
+    "example": 144,
+    "start_line": 2316,
+    "end_line": 2321,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "``` aa ```\nfoo\n",
+    "html": "<p><code>aa</code>\nfoo</p>\n",
+    "example": 145,
+    "start_line": 2326,
+    "end_line": 2332,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "~~~ aa ``` ~~~\nfoo\n~~~\n",
+    "html": "<pre><code class=\"aa\">foo\n</code></pre>\n",
+    "example": 146,
+    "start_line": 2337,
+    "end_line": 2344,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "```\n``` aaa\n```\n",
+    "html": "<pre><code>``` aaa\n</code></pre>\n",
+    "example": 147,
+    "start_line": 2349,
+    "end_line": 2356,
+    "section": "Fenced code blocks"
+  },
+  {
+    "markdown": "<table><tr><td>\n<pre>\n**Hello**,\n\n_world_.\n</pre>\n</td></tr></table>\n",
+    "html": "<table><tr><td>\n<pre>\n**Hello**,\n<p><em>world</em>.\n</pre></p>\n</td></tr></table>\n",
+    "example": 148,
+    "start_line": 2428,
+    "end_line": 2443,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n\nokay.\n",
+    "html": "<table>\n  <tr>\n    <td>\n           hi\n    </td>\n  </tr>\n</table>\n<p>okay.</p>\n",
+    "example": 149,
+    "start_line": 2457,
+    "end_line": 2476,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": " <div>\n  *hello*\n         <foo><a>\n",
+    "html": " <div>\n  *hello*\n         <foo><a>\n",
+    "example": 150,
+    "start_line": 2479,
+    "end_line": 2487,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</div>\n*foo*\n",
+    "html": "</div>\n*foo*\n",
+    "example": 151,
+    "start_line": 2492,
+    "end_line": 2498,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<DIV CLASS=\"foo\">\n\n*Markdown*\n\n</DIV>\n",
+    "html": "<DIV CLASS=\"foo\">\n<p><em>Markdown</em></p>\n</DIV>\n",
+    "example": 152,
+    "start_line": 2503,
+    "end_line": 2513,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "html": "<div id=\"foo\"\n  class=\"bar\">\n</div>\n",
+    "example": 153,
+    "start_line": 2519,
+    "end_line": 2527,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "html": "<div id=\"foo\" class=\"bar\n  baz\">\n</div>\n",
+    "example": 154,
+    "start_line": 2530,
+    "end_line": 2538,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*foo*\n\n*bar*\n",
+    "html": "<div>\n*foo*\n<p><em>bar</em></p>\n",
+    "example": 155,
+    "start_line": 2542,
+    "end_line": 2551,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div id=\"foo\"\n*hi*\n",
+    "html": "<div id=\"foo\"\n*hi*\n",
+    "example": 156,
+    "start_line": 2558,
+    "end_line": 2564,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div class\nfoo\n",
+    "html": "<div class\nfoo\n",
+    "example": 157,
+    "start_line": 2567,
+    "end_line": 2573,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div *???-&&&-<---\n*foo*\n",
+    "html": "<div *???-&&&-<---\n*foo*\n",
+    "example": 158,
+    "start_line": 2579,
+    "end_line": 2585,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "html": "<div><a href=\"bar\">*foo*</a></div>\n",
+    "example": 159,
+    "start_line": 2591,
+    "end_line": 2595,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "html": "<table><tr><td>\nfoo\n</td></tr></table>\n",
+    "example": 160,
+    "start_line": 2598,
+    "end_line": 2606,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "html": "<div></div>\n``` c\nint x = 33;\n```\n",
+    "example": 161,
+    "start_line": 2615,
+    "end_line": 2625,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "html": "<a href=\"foo\">\n*bar*\n</a>\n",
+    "example": 162,
+    "start_line": 2632,
+    "end_line": 2640,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<Warning>\n*bar*\n</Warning>\n",
+    "html": "<Warning>\n*bar*\n</Warning>\n",
+    "example": 163,
+    "start_line": 2645,
+    "end_line": 2653,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "html": "<i class=\"foo\">\n*bar*\n</i>\n",
+    "example": 164,
+    "start_line": 2656,
+    "end_line": 2664,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "</ins>\n*bar*\n",
+    "html": "</ins>\n*bar*\n",
+    "example": 165,
+    "start_line": 2667,
+    "end_line": 2673,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n*foo*\n</del>\n",
+    "html": "<del>\n*foo*\n</del>\n",
+    "example": 166,
+    "start_line": 2682,
+    "end_line": 2690,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>\n\n*foo*\n\n</del>\n",
+    "html": "<del>\n<p><em>foo</em></p>\n</del>\n",
+    "example": 167,
+    "start_line": 2697,
+    "end_line": 2707,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<del>*foo*</del>\n",
+    "html": "<p><del><em>foo</em></del></p>\n",
+    "example": 168,
+    "start_line": 2715,
+    "end_line": 2719,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\nokay\n",
+    "html": "<pre language=\"haskell\"><code>\nimport Text.HTML.TagSoup\n\nmain :: IO ()\nmain = print $ parseTags tags\n</code></pre>\n<p>okay</p>\n",
+    "example": 169,
+    "start_line": 2731,
+    "end_line": 2747,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\nokay\n",
+    "html": "<script type=\"text/javascript\">\n// JavaScript example\n\ndocument.getElementById(\"demo\").innerHTML = \"Hello JavaScript!\";\n</script>\n<p>okay</p>\n",
+    "example": 170,
+    "start_line": 2752,
+    "end_line": 2766,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<textarea>\n\n*foo*\n\n_bar_\n\n</textarea>\n",
+    "html": "<textarea>\n\n*foo*\n\n_bar_\n\n</textarea>\n",
+    "example": 171,
+    "start_line": 2771,
+    "end_line": 2787,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\nokay\n",
+    "html": "<style\n  type=\"text/css\">\nh1 {color:red;}\n\np {color:blue;}\n</style>\n<p>okay</p>\n",
+    "example": 172,
+    "start_line": 2791,
+    "end_line": 2807,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "html": "<style\n  type=\"text/css\">\n\nfoo\n",
+    "example": 173,
+    "start_line": 2814,
+    "end_line": 2824,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "> <div>\n> foo\n\nbar\n",
+    "html": "<blockquote>\n<div>\nfoo\n</blockquote>\n<p>bar</p>\n",
+    "example": 174,
+    "start_line": 2827,
+    "end_line": 2838,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "- <div>\n- foo\n",
+    "html": "<ul>\n<li>\n<div>\n</li>\n<li>foo</li>\n</ul>\n",
+    "example": 175,
+    "start_line": 2841,
+    "end_line": 2851,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<style>p{color:red;}</style>\n*foo*\n",
+    "html": "<style>p{color:red;}</style>\n<p><em>foo</em></p>\n",
+    "example": 176,
+    "start_line": 2856,
+    "end_line": 2862,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- foo -->*bar*\n*baz*\n",
+    "html": "<!-- foo -->*bar*\n<p><em>baz</em></p>\n",
+    "example": 177,
+    "start_line": 2865,
+    "end_line": 2871,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<script>\nfoo\n</script>1. *bar*\n",
+    "html": "<script>\nfoo\n</script>1. *bar*\n",
+    "example": 178,
+    "start_line": 2877,
+    "end_line": 2885,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!-- Foo\n\nbar\n   baz -->\nokay\n",
+    "html": "<!-- Foo\n\nbar\n   baz -->\n<p>okay</p>\n",
+    "example": 179,
+    "start_line": 2890,
+    "end_line": 2902,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<?php\n\n  echo '>';\n\n?>\nokay\n",
+    "html": "<?php\n\n  echo '>';\n\n?>\n<p>okay</p>\n",
+    "example": 180,
+    "start_line": 2908,
+    "end_line": 2922,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<!DOCTYPE html>\n",
+    "html": "<!DOCTYPE html>\n",
+    "example": 181,
+    "start_line": 2927,
+    "end_line": 2931,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\nokay\n",
+    "html": "<![CDATA[\nfunction matchwo(a,b)\n{\n  if (a < b && a < 0) then {\n    return 1;\n\n  } else {\n\n    return 0;\n  }\n}\n]]>\n<p>okay</p>\n",
+    "example": 182,
+    "start_line": 2936,
+    "end_line": 2964,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <!-- foo -->\n\n    <!-- foo -->\n",
+    "html": "  <!-- foo -->\n<pre><code>&lt;!-- foo --&gt;\n</code></pre>\n",
+    "example": 183,
+    "start_line": 2970,
+    "end_line": 2978,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "  <div>\n\n    <div>\n",
+    "html": "  <div>\n<pre><code>&lt;div&gt;\n</code></pre>\n",
+    "example": 184,
+    "start_line": 2981,
+    "end_line": 2989,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<div>\nbar\n</div>\n",
+    "html": "<p>Foo</p>\n<div>\nbar\n</div>\n",
+    "example": 185,
+    "start_line": 2995,
+    "end_line": 3005,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\nbar\n</div>\n*foo*\n",
+    "html": "<div>\nbar\n</div>\n*foo*\n",
+    "example": 186,
+    "start_line": 3012,
+    "end_line": 3022,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "Foo\n<a href=\"bar\">\nbaz\n",
+    "html": "<p>Foo\n<a href=\"bar\">\nbaz</p>\n",
+    "example": 187,
+    "start_line": 3027,
+    "end_line": 3035,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n\n*Emphasized* text.\n\n</div>\n",
+    "html": "<div>\n<p><em>Emphasized</em> text.</p>\n</div>\n",
+    "example": 188,
+    "start_line": 3068,
+    "end_line": 3078,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<div>\n*Emphasized* text.\n</div>\n",
+    "html": "<div>\n*Emphasized* text.\n</div>\n",
+    "example": 189,
+    "start_line": 3081,
+    "end_line": 3089,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n<tr>\n\n<td>\nHi\n</td>\n\n</tr>\n\n</table>\n",
+    "html": "<table>\n<tr>\n<td>\nHi\n</td>\n</tr>\n</table>\n",
+    "example": 190,
+    "start_line": 3103,
+    "end_line": 3123,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "<table>\n\n  <tr>\n\n    <td>\n      Hi\n    </td>\n\n  </tr>\n\n</table>\n",
+    "html": "<table>\n  <tr>\n<pre><code>&lt;td&gt;\n  Hi\n&lt;/td&gt;\n</code></pre>\n  </tr>\n</table>\n",
+    "example": 191,
+    "start_line": 3130,
+    "end_line": 3151,
+    "section": "HTML blocks"
+  },
+  {
+    "markdown": "[foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 192,
+    "start_line": 3179,
+    "end_line": 3185,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "   [foo]: \n      /url  \n           'the title'  \n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"the title\">foo</a></p>\n",
+    "example": 193,
+    "start_line": 3188,
+    "end_line": 3196,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo*bar\\]]:my_(url) 'title (with parens)'\n\n[Foo*bar\\]]\n",
+    "html": "<p><a href=\"my_(url)\" title=\"title (with parens)\">Foo*bar]</a></p>\n",
+    "example": 194,
+    "start_line": 3199,
+    "end_line": 3205,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[Foo bar]:\n<my url>\n'title'\n\n[Foo bar]\n",
+    "html": "<p><a href=\"my%20url\" title=\"title\">Foo bar</a></p>\n",
+    "example": 195,
+    "start_line": 3208,
+    "end_line": 3216,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url '\ntitle\nline1\nline2\n'\n\n[foo]\n",
+    "html": "<p><a href=\"/url\" title=\"\ntitle\nline1\nline2\n\">foo</a></p>\n",
+    "example": 196,
+    "start_line": 3221,
+    "end_line": 3235,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url 'title\n\nwith blank line'\n\n[foo]\n",
+    "html": "<p>[foo]: /url 'title</p>\n<p>with blank line'</p>\n<p>[foo]</p>\n",
+    "example": 197,
+    "start_line": 3240,
+    "end_line": 3250,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n/url\n\n[foo]\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n",
+    "example": 198,
+    "start_line": 3255,
+    "end_line": 3262,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]:\n\n[foo]\n",
+    "html": "<p>[foo]:</p>\n<p>[foo]</p>\n",
+    "example": 199,
+    "start_line": 3267,
+    "end_line": 3274,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: <>\n\n[foo]\n",
+    "html": "<p><a href=\"\">foo</a></p>\n",
+    "example": 200,
+    "start_line": 3279,
+    "end_line": 3285,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: <bar>(baz)\n\n[foo]\n",
+    "html": "<p>[foo]: <bar>(baz)</p>\n<p>[foo]</p>\n",
+    "example": 201,
+    "start_line": 3290,
+    "end_line": 3297,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\\bar\\*baz \"foo\\\"bar\\baz\"\n\n[foo]\n",
+    "html": "<p><a href=\"/url%5Cbar*baz\" title=\"foo&quot;bar\\baz\">foo</a></p>\n",
+    "example": 202,
+    "start_line": 3303,
+    "end_line": 3309,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: url\n",
+    "html": "<p><a href=\"url\">foo</a></p>\n",
+    "example": 203,
+    "start_line": 3314,
+    "end_line": 3320,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: first\n[foo]: second\n",
+    "html": "<p><a href=\"first\">foo</a></p>\n",
+    "example": 204,
+    "start_line": 3326,
+    "end_line": 3333,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[FOO]: /url\n\n[Foo]\n",
+    "html": "<p><a href=\"/url\">Foo</a></p>\n",
+    "example": 205,
+    "start_line": 3339,
+    "end_line": 3345,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[ΑΓΩ]: /φου\n\n[αγω]\n",
+    "html": "<p><a href=\"/%CF%86%CE%BF%CF%85\">αγω</a></p>\n",
+    "example": 206,
+    "start_line": 3348,
+    "end_line": 3354,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n",
+    "html": "",
+    "example": 207,
+    "start_line": 3363,
+    "end_line": 3366,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[\nfoo\n]: /url\nbar\n",
+    "html": "<p>bar</p>\n",
+    "example": 208,
+    "start_line": 3371,
+    "end_line": 3378,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url \"title\" ok\n",
+    "html": "<p>[foo]: /url &quot;title&quot; ok</p>\n",
+    "example": 209,
+    "start_line": 3384,
+    "end_line": 3388,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n\"title\" ok\n",
+    "html": "<p>&quot;title&quot; ok</p>\n",
+    "example": 210,
+    "start_line": 3393,
+    "end_line": 3398,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "    [foo]: /url \"title\"\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url &quot;title&quot;\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 211,
+    "start_line": 3404,
+    "end_line": 3412,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "```\n[foo]: /url\n```\n\n[foo]\n",
+    "html": "<pre><code>[foo]: /url\n</code></pre>\n<p>[foo]</p>\n",
+    "example": 212,
+    "start_line": 3418,
+    "end_line": 3428,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "Foo\n[bar]: /baz\n\n[bar]\n",
+    "html": "<p>Foo\n[bar]: /baz</p>\n<p>[bar]</p>\n",
+    "example": 213,
+    "start_line": 3433,
+    "end_line": 3442,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "# [Foo]\n[foo]: /url\n> bar\n",
+    "html": "<h1><a href=\"/url\">Foo</a></h1>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 214,
+    "start_line": 3448,
+    "end_line": 3457,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\nbar\n===\n[foo]\n",
+    "html": "<h1>bar</h1>\n<p><a href=\"/url\">foo</a></p>\n",
+    "example": 215,
+    "start_line": 3459,
+    "end_line": 3467,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /url\n===\n[foo]\n",
+    "html": "<p>===\n<a href=\"/url\">foo</a></p>\n",
+    "example": 216,
+    "start_line": 3469,
+    "end_line": 3476,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]: /foo-url \"foo\"\n[bar]: /bar-url\n  \"bar\"\n[baz]: /baz-url\n\n[foo],\n[bar],\n[baz]\n",
+    "html": "<p><a href=\"/foo-url\" title=\"foo\">foo</a>,\n<a href=\"/bar-url\" title=\"bar\">bar</a>,\n<a href=\"/baz-url\">baz</a></p>\n",
+    "example": 217,
+    "start_line": 3482,
+    "end_line": 3495,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "[foo]\n\n> [foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a></p>\n<blockquote>\n</blockquote>\n",
+    "example": 218,
+    "start_line": 3503,
+    "end_line": 3511,
+    "section": "Link reference definitions"
+  },
+  {
+    "markdown": "aaa\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 219,
+    "start_line": 3525,
+    "end_line": 3532,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\nbbb\n\nccc\nddd\n",
+    "html": "<p>aaa\nbbb</p>\n<p>ccc\nddd</p>\n",
+    "example": 220,
+    "start_line": 3537,
+    "end_line": 3548,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n\n\nbbb\n",
+    "html": "<p>aaa</p>\n<p>bbb</p>\n",
+    "example": 221,
+    "start_line": 3553,
+    "end_line": 3561,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  aaa\n bbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 222,
+    "start_line": 3566,
+    "end_line": 3572,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa\n             bbb\n                                       ccc\n",
+    "html": "<p>aaa\nbbb\nccc</p>\n",
+    "example": 223,
+    "start_line": 3578,
+    "end_line": 3586,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "   aaa\nbbb\n",
+    "html": "<p>aaa\nbbb</p>\n",
+    "example": 224,
+    "start_line": 3592,
+    "end_line": 3598,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "    aaa\nbbb\n",
+    "html": "<pre><code>aaa\n</code></pre>\n<p>bbb</p>\n",
+    "example": 225,
+    "start_line": 3601,
+    "end_line": 3608,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "aaa     \nbbb     \n",
+    "html": "<p>aaa<br />\nbbb</p>\n",
+    "example": 226,
+    "start_line": 3615,
+    "end_line": 3621,
+    "section": "Paragraphs"
+  },
+  {
+    "markdown": "  \n\naaa\n  \n\n# aaa\n\n  \n",
+    "html": "<p>aaa</p>\n<h1>aaa</h1>\n",
+    "example": 227,
+    "start_line": 3632,
+    "end_line": 3644,
+    "section": "Blank lines"
+  },
+  {
+    "markdown": "> # Foo\n> bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 228,
+    "start_line": 3700,
+    "end_line": 3710,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "># Foo\n>bar\n> baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 229,
+    "start_line": 3715,
+    "end_line": 3725,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "   > # Foo\n   > bar\n > baz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 230,
+    "start_line": 3730,
+    "end_line": 3740,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "    > # Foo\n    > bar\n    > baz\n",
+    "html": "<pre><code>&gt; # Foo\n&gt; bar\n&gt; baz\n</code></pre>\n",
+    "example": 231,
+    "start_line": 3745,
+    "end_line": 3754,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> # Foo\n> bar\nbaz\n",
+    "html": "<blockquote>\n<h1>Foo</h1>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 232,
+    "start_line": 3760,
+    "end_line": 3770,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n> foo\n",
+    "html": "<blockquote>\n<p>bar\nbaz\nfoo</p>\n</blockquote>\n",
+    "example": 233,
+    "start_line": 3776,
+    "end_line": 3786,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n---\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<hr />\n",
+    "example": 234,
+    "start_line": 3800,
+    "end_line": 3808,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> - foo\n- bar\n",
+    "html": "<blockquote>\n<ul>\n<li>foo</li>\n</ul>\n</blockquote>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 235,
+    "start_line": 3820,
+    "end_line": 3832,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     foo\n    bar\n",
+    "html": "<blockquote>\n<pre><code>foo\n</code></pre>\n</blockquote>\n<pre><code>bar\n</code></pre>\n",
+    "example": 236,
+    "start_line": 3838,
+    "end_line": 3848,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> ```\nfoo\n```\n",
+    "html": "<blockquote>\n<pre><code></code></pre>\n</blockquote>\n<p>foo</p>\n<pre><code></code></pre>\n",
+    "example": 237,
+    "start_line": 3851,
+    "end_line": 3861,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n    - bar\n",
+    "html": "<blockquote>\n<p>foo\n- bar</p>\n</blockquote>\n",
+    "example": 238,
+    "start_line": 3867,
+    "end_line": 3875,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 239,
+    "start_line": 3891,
+    "end_line": 3896,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n>  \n> \n",
+    "html": "<blockquote>\n</blockquote>\n",
+    "example": 240,
+    "start_line": 3899,
+    "end_line": 3906,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">\n> foo\n>  \n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n",
+    "example": 241,
+    "start_line": 3911,
+    "end_line": 3919,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n</blockquote>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 242,
+    "start_line": 3924,
+    "end_line": 3935,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n> bar\n",
+    "html": "<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n",
+    "example": 243,
+    "start_line": 3946,
+    "end_line": 3954,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> foo\n>\n> bar\n",
+    "html": "<blockquote>\n<p>foo</p>\n<p>bar</p>\n</blockquote>\n",
+    "example": 244,
+    "start_line": 3959,
+    "end_line": 3968,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "foo\n> bar\n",
+    "html": "<p>foo</p>\n<blockquote>\n<p>bar</p>\n</blockquote>\n",
+    "example": 245,
+    "start_line": 3973,
+    "end_line": 3981,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> aaa\n***\n> bbb\n",
+    "html": "<blockquote>\n<p>aaa</p>\n</blockquote>\n<hr />\n<blockquote>\n<p>bbb</p>\n</blockquote>\n",
+    "example": 246,
+    "start_line": 3987,
+    "end_line": 3999,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\nbaz\n",
+    "html": "<blockquote>\n<p>bar\nbaz</p>\n</blockquote>\n",
+    "example": 247,
+    "start_line": 4005,
+    "end_line": 4013,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 248,
+    "start_line": 4016,
+    "end_line": 4025,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> bar\n>\nbaz\n",
+    "html": "<blockquote>\n<p>bar</p>\n</blockquote>\n<p>baz</p>\n",
+    "example": 249,
+    "start_line": 4028,
+    "end_line": 4037,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "> > > foo\nbar\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 250,
+    "start_line": 4044,
+    "end_line": 4056,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">>> foo\n> bar\n>>baz\n",
+    "html": "<blockquote>\n<blockquote>\n<blockquote>\n<p>foo\nbar\nbaz</p>\n</blockquote>\n</blockquote>\n</blockquote>\n",
+    "example": 251,
+    "start_line": 4059,
+    "end_line": 4073,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": ">     code\n\n>    not code\n",
+    "html": "<blockquote>\n<pre><code>code\n</code></pre>\n</blockquote>\n<blockquote>\n<p>not code</p>\n</blockquote>\n",
+    "example": 252,
+    "start_line": 4081,
+    "end_line": 4093,
+    "section": "Block quotes"
+  },
+  {
+    "markdown": "A paragraph\nwith two lines.\n\n    indented code\n\n> A block quote.\n",
+    "html": "<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n",
+    "example": 253,
+    "start_line": 4135,
+    "end_line": 4150,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  A paragraph\n    with two lines.\n\n        indented code\n\n    > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 254,
+    "start_line": 4157,
+    "end_line": 4176,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n",
+    "example": 255,
+    "start_line": 4190,
+    "end_line": 4199,
+    "section": "List items"
+  },
+  {
+    "markdown": "- one\n\n  two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 256,
+    "start_line": 4202,
+    "end_line": 4213,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n     two\n",
+    "html": "<ul>\n<li>one</li>\n</ul>\n<pre><code> two\n</code></pre>\n",
+    "example": 257,
+    "start_line": 4216,
+    "end_line": 4226,
+    "section": "List items"
+  },
+  {
+    "markdown": " -    one\n\n      two\n",
+    "html": "<ul>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ul>\n",
+    "example": 258,
+    "start_line": 4229,
+    "end_line": 4240,
+    "section": "List items"
+  },
+  {
+    "markdown": "   > > 1.  one\n>>\n>>     two\n",
+    "html": "<blockquote>\n<blockquote>\n<ol>\n<li>\n<p>one</p>\n<p>two</p>\n</li>\n</ol>\n</blockquote>\n</blockquote>\n",
+    "example": 259,
+    "start_line": 4251,
+    "end_line": 4266,
+    "section": "List items"
+  },
+  {
+    "markdown": ">>- one\n>>\n  >  > two\n",
+    "html": "<blockquote>\n<blockquote>\n<ul>\n<li>one</li>\n</ul>\n<p>two</p>\n</blockquote>\n</blockquote>\n",
+    "example": 260,
+    "start_line": 4278,
+    "end_line": 4291,
+    "section": "List items"
+  },
+  {
+    "markdown": "-one\n\n2.two\n",
+    "html": "<p>-one</p>\n<p>2.two</p>\n",
+    "example": 261,
+    "start_line": 4297,
+    "end_line": 4304,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n\n  bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 262,
+    "start_line": 4310,
+    "end_line": 4322,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.  foo\n\n    ```\n    bar\n    ```\n\n    baz\n\n    > bam\n",
+    "html": "<ol>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n<p>baz</p>\n<blockquote>\n<p>bam</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 263,
+    "start_line": 4327,
+    "end_line": 4349,
+    "section": "List items"
+  },
+  {
+    "markdown": "- Foo\n\n      bar\n\n\n      baz\n",
+    "html": "<ul>\n<li>\n<p>Foo</p>\n<pre><code>bar\n\n\nbaz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 264,
+    "start_line": 4355,
+    "end_line": 4373,
+    "section": "List items"
+  },
+  {
+    "markdown": "123456789. ok\n",
+    "html": "<ol start=\"123456789\">\n<li>ok</li>\n</ol>\n",
+    "example": 265,
+    "start_line": 4377,
+    "end_line": 4383,
+    "section": "List items"
+  },
+  {
+    "markdown": "1234567890. not ok\n",
+    "html": "<p>1234567890. not ok</p>\n",
+    "example": 266,
+    "start_line": 4386,
+    "end_line": 4390,
+    "section": "List items"
+  },
+  {
+    "markdown": "0. ok\n",
+    "html": "<ol start=\"0\">\n<li>ok</li>\n</ol>\n",
+    "example": 267,
+    "start_line": 4395,
+    "end_line": 4401,
+    "section": "List items"
+  },
+  {
+    "markdown": "003. ok\n",
+    "html": "<ol start=\"3\">\n<li>ok</li>\n</ol>\n",
+    "example": 268,
+    "start_line": 4404,
+    "end_line": 4410,
+    "section": "List items"
+  },
+  {
+    "markdown": "-1. not ok\n",
+    "html": "<p>-1. not ok</p>\n",
+    "example": 269,
+    "start_line": 4415,
+    "end_line": 4419,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n\n      bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ul>\n",
+    "example": 270,
+    "start_line": 4438,
+    "end_line": 4450,
+    "section": "List items"
+  },
+  {
+    "markdown": "  10.  foo\n\n           bar\n",
+    "html": "<ol start=\"10\">\n<li>\n<p>foo</p>\n<pre><code>bar\n</code></pre>\n</li>\n</ol>\n",
+    "example": 271,
+    "start_line": 4455,
+    "end_line": 4467,
+    "section": "List items"
+  },
+  {
+    "markdown": "    indented code\n\nparagraph\n\n    more code\n",
+    "html": "<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n",
+    "example": 272,
+    "start_line": 4474,
+    "end_line": 4486,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.     indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code>indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 273,
+    "start_line": 4489,
+    "end_line": 4505,
+    "section": "List items"
+  },
+  {
+    "markdown": "1.      indented code\n\n   paragraph\n\n       more code\n",
+    "html": "<ol>\n<li>\n<pre><code> indented code\n</code></pre>\n<p>paragraph</p>\n<pre><code>more code\n</code></pre>\n</li>\n</ol>\n",
+    "example": 274,
+    "start_line": 4511,
+    "end_line": 4527,
+    "section": "List items"
+  },
+  {
+    "markdown": "   foo\n\nbar\n",
+    "html": "<p>foo</p>\n<p>bar</p>\n",
+    "example": 275,
+    "start_line": 4538,
+    "end_line": 4545,
+    "section": "List items"
+  },
+  {
+    "markdown": "-    foo\n\n  bar\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n<p>bar</p>\n",
+    "example": 276,
+    "start_line": 4548,
+    "end_line": 4557,
+    "section": "List items"
+  },
+  {
+    "markdown": "-  foo\n\n   bar\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>bar</p>\n</li>\n</ul>\n",
+    "example": 277,
+    "start_line": 4565,
+    "end_line": 4576,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n  foo\n-\n  ```\n  bar\n  ```\n-\n      baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>\n<pre><code>bar\n</code></pre>\n</li>\n<li>\n<pre><code>baz\n</code></pre>\n</li>\n</ul>\n",
+    "example": 278,
+    "start_line": 4592,
+    "end_line": 4613,
+    "section": "List items"
+  },
+  {
+    "markdown": "-   \n  foo\n",
+    "html": "<ul>\n<li>foo</li>\n</ul>\n",
+    "example": 279,
+    "start_line": 4618,
+    "end_line": 4625,
+    "section": "List items"
+  },
+  {
+    "markdown": "-\n\n  foo\n",
+    "html": "<ul>\n<li></li>\n</ul>\n<p>foo</p>\n",
+    "example": 280,
+    "start_line": 4632,
+    "end_line": 4641,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-\n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 281,
+    "start_line": 4646,
+    "end_line": 4656,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n-   \n- bar\n",
+    "html": "<ul>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ul>\n",
+    "example": 282,
+    "start_line": 4661,
+    "end_line": 4671,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. foo\n2.\n3. bar\n",
+    "html": "<ol>\n<li>foo</li>\n<li></li>\n<li>bar</li>\n</ol>\n",
+    "example": 283,
+    "start_line": 4676,
+    "end_line": 4686,
+    "section": "List items"
+  },
+  {
+    "markdown": "*\n",
+    "html": "<ul>\n<li></li>\n</ul>\n",
+    "example": 284,
+    "start_line": 4691,
+    "end_line": 4697,
+    "section": "List items"
+  },
+  {
+    "markdown": "foo\n*\n\nfoo\n1.\n",
+    "html": "<p>foo\n*</p>\n<p>foo\n1.</p>\n",
+    "example": 285,
+    "start_line": 4701,
+    "end_line": 4712,
+    "section": "List items"
+  },
+  {
+    "markdown": " 1.  A paragraph\n     with two lines.\n\n         indented code\n\n     > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 286,
+    "start_line": 4723,
+    "end_line": 4742,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n      with two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 287,
+    "start_line": 4747,
+    "end_line": 4766,
+    "section": "List items"
+  },
+  {
+    "markdown": "   1.  A paragraph\n       with two lines.\n\n           indented code\n\n       > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 288,
+    "start_line": 4771,
+    "end_line": 4790,
+    "section": "List items"
+  },
+  {
+    "markdown": "    1.  A paragraph\n        with two lines.\n\n            indented code\n\n        > A block quote.\n",
+    "html": "<pre><code>1.  A paragraph\n    with two lines.\n\n        indented code\n\n    &gt; A block quote.\n</code></pre>\n",
+    "example": 289,
+    "start_line": 4795,
+    "end_line": 4810,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\nwith two lines.\n\n          indented code\n\n      > A block quote.\n",
+    "html": "<ol>\n<li>\n<p>A paragraph\nwith two lines.</p>\n<pre><code>indented code\n</code></pre>\n<blockquote>\n<p>A block quote.</p>\n</blockquote>\n</li>\n</ol>\n",
+    "example": 290,
+    "start_line": 4825,
+    "end_line": 4844,
+    "section": "List items"
+  },
+  {
+    "markdown": "  1.  A paragraph\n    with two lines.\n",
+    "html": "<ol>\n<li>A paragraph\nwith two lines.</li>\n</ol>\n",
+    "example": 291,
+    "start_line": 4849,
+    "end_line": 4857,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\ncontinued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 292,
+    "start_line": 4862,
+    "end_line": 4876,
+    "section": "List items"
+  },
+  {
+    "markdown": "> 1. > Blockquote\n> continued here.\n",
+    "html": "<blockquote>\n<ol>\n<li>\n<blockquote>\n<p>Blockquote\ncontinued here.</p>\n</blockquote>\n</li>\n</ol>\n</blockquote>\n",
+    "example": 293,
+    "start_line": 4879,
+    "end_line": 4893,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n      - boo\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>baz\n<ul>\n<li>boo</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 294,
+    "start_line": 4907,
+    "end_line": 4928,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n - bar\n  - baz\n   - boo\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n<li>baz</li>\n<li>boo</li>\n</ul>\n",
+    "example": 295,
+    "start_line": 4933,
+    "end_line": 4945,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n    - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo\n<ul>\n<li>bar</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 296,
+    "start_line": 4950,
+    "end_line": 4961,
+    "section": "List items"
+  },
+  {
+    "markdown": "10) foo\n   - bar\n",
+    "html": "<ol start=\"10\">\n<li>foo</li>\n</ol>\n<ul>\n<li>bar</li>\n</ul>\n",
+    "example": 297,
+    "start_line": 4966,
+    "end_line": 4976,
+    "section": "List items"
+  },
+  {
+    "markdown": "- - foo\n",
+    "html": "<ul>\n<li>\n<ul>\n<li>foo</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 298,
+    "start_line": 4981,
+    "end_line": 4991,
+    "section": "List items"
+  },
+  {
+    "markdown": "1. - 2. foo\n",
+    "html": "<ol>\n<li>\n<ul>\n<li>\n<ol start=\"2\">\n<li>foo</li>\n</ol>\n</li>\n</ul>\n</li>\n</ol>\n",
+    "example": 299,
+    "start_line": 4994,
+    "end_line": 5008,
+    "section": "List items"
+  },
+  {
+    "markdown": "- # Foo\n- Bar\n  ---\n  baz\n",
+    "html": "<ul>\n<li>\n<h1>Foo</h1>\n</li>\n<li>\n<h2>Bar</h2>\nbaz</li>\n</ul>\n",
+    "example": 300,
+    "start_line": 5013,
+    "end_line": 5027,
+    "section": "List items"
+  },
+  {
+    "markdown": "- foo\n- bar\n+ baz\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<ul>\n<li>baz</li>\n</ul>\n",
+    "example": 301,
+    "start_line": 5249,
+    "end_line": 5261,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. foo\n2. bar\n3) baz\n",
+    "html": "<ol>\n<li>foo</li>\n<li>bar</li>\n</ol>\n<ol start=\"3\">\n<li>baz</li>\n</ol>\n",
+    "example": 302,
+    "start_line": 5264,
+    "end_line": 5276,
+    "section": "Lists"
+  },
+  {
+    "markdown": "Foo\n- bar\n- baz\n",
+    "html": "<p>Foo</p>\n<ul>\n<li>bar</li>\n<li>baz</li>\n</ul>\n",
+    "example": 303,
+    "start_line": 5283,
+    "end_line": 5293,
+    "section": "Lists"
+  },
+  {
+    "markdown": "The number of windows in my house is\n14.  The number of doors is 6.\n",
+    "html": "<p>The number of windows in my house is\n14.  The number of doors is 6.</p>\n",
+    "example": 304,
+    "start_line": 5360,
+    "end_line": 5366,
+    "section": "Lists"
+  },
+  {
+    "markdown": "The number of windows in my house is\n1.  The number of doors is 6.\n",
+    "html": "<p>The number of windows in my house is</p>\n<ol>\n<li>The number of doors is 6.</li>\n</ol>\n",
+    "example": 305,
+    "start_line": 5370,
+    "end_line": 5378,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n\n- bar\n\n\n- baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n</li>\n<li>\n<p>bar</p>\n</li>\n<li>\n<p>baz</p>\n</li>\n</ul>\n",
+    "example": 306,
+    "start_line": 5384,
+    "end_line": 5403,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n  - bar\n    - baz\n\n\n      bim\n",
+    "html": "<ul>\n<li>foo\n<ul>\n<li>bar\n<ul>\n<li>\n<p>baz</p>\n<p>bim</p>\n</li>\n</ul>\n</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 307,
+    "start_line": 5405,
+    "end_line": 5427,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- foo\n- bar\n\n<!-- -->\n\n- baz\n- bim\n",
+    "html": "<ul>\n<li>foo</li>\n<li>bar</li>\n</ul>\n<!-- -->\n<ul>\n<li>baz</li>\n<li>bim</li>\n</ul>\n",
+    "example": 308,
+    "start_line": 5435,
+    "end_line": 5453,
+    "section": "Lists"
+  },
+  {
+    "markdown": "-   foo\n\n    notcode\n\n-   foo\n\n<!-- -->\n\n    code\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<p>notcode</p>\n</li>\n<li>\n<p>foo</p>\n</li>\n</ul>\n<!-- -->\n<pre><code>code\n</code></pre>\n",
+    "example": 309,
+    "start_line": 5456,
+    "end_line": 5479,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n - b\n  - c\n   - d\n  - e\n - f\n- g\n",
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d</li>\n<li>e</li>\n<li>f</li>\n<li>g</li>\n</ul>\n",
+    "example": 310,
+    "start_line": 5487,
+    "end_line": 5505,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. a\n\n  2. b\n\n   3. c\n",
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ol>\n",
+    "example": 311,
+    "start_line": 5508,
+    "end_line": 5526,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n - b\n  - c\n   - d\n    - e\n",
+    "html": "<ul>\n<li>a</li>\n<li>b</li>\n<li>c</li>\n<li>d\n- e</li>\n</ul>\n",
+    "example": 312,
+    "start_line": 5532,
+    "end_line": 5546,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. a\n\n  2. b\n\n    3. c\n",
+    "html": "<ol>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n</ol>\n<pre><code>3. c\n</code></pre>\n",
+    "example": 313,
+    "start_line": 5552,
+    "end_line": 5569,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n- c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 314,
+    "start_line": 5575,
+    "end_line": 5592,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n*\n\n* c\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li></li>\n<li>\n<p>c</p>\n</li>\n</ul>\n",
+    "example": 315,
+    "start_line": 5597,
+    "end_line": 5612,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  c\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 316,
+    "start_line": 5619,
+    "end_line": 5638,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- b\n\n  [ref]: /url\n- d\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n</li>\n<li>\n<p>b</p>\n</li>\n<li>\n<p>d</p>\n</li>\n</ul>\n",
+    "example": 317,
+    "start_line": 5641,
+    "end_line": 5659,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n- ```\n  b\n\n\n  ```\n- c\n",
+    "html": "<ul>\n<li>a</li>\n<li>\n<pre><code>b\n\n\n</code></pre>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 318,
+    "start_line": 5664,
+    "end_line": 5683,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n\n    c\n- d\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>\n<p>b</p>\n<p>c</p>\n</li>\n</ul>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 319,
+    "start_line": 5690,
+    "end_line": 5708,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* a\n  > b\n  >\n* c\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n</li>\n<li>c</li>\n</ul>\n",
+    "example": 320,
+    "start_line": 5714,
+    "end_line": 5728,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  > b\n  ```\n  c\n  ```\n- d\n",
+    "html": "<ul>\n<li>a\n<blockquote>\n<p>b</p>\n</blockquote>\n<pre><code>c\n</code></pre>\n</li>\n<li>d</li>\n</ul>\n",
+    "example": 321,
+    "start_line": 5734,
+    "end_line": 5752,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n",
+    "html": "<ul>\n<li>a</li>\n</ul>\n",
+    "example": 322,
+    "start_line": 5757,
+    "end_line": 5763,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n",
+    "html": "<ul>\n<li>a\n<ul>\n<li>b</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 323,
+    "start_line": 5766,
+    "end_line": 5777,
+    "section": "Lists"
+  },
+  {
+    "markdown": "1. ```\n   foo\n   ```\n\n   bar\n",
+    "html": "<ol>\n<li>\n<pre><code>foo\n</code></pre>\n<p>bar</p>\n</li>\n</ol>\n",
+    "example": 324,
+    "start_line": 5783,
+    "end_line": 5797,
+    "section": "Lists"
+  },
+  {
+    "markdown": "* foo\n  * bar\n\n  baz\n",
+    "html": "<ul>\n<li>\n<p>foo</p>\n<ul>\n<li>bar</li>\n</ul>\n<p>baz</p>\n</li>\n</ul>\n",
+    "example": 325,
+    "start_line": 5802,
+    "end_line": 5817,
+    "section": "Lists"
+  },
+  {
+    "markdown": "- a\n  - b\n  - c\n\n- d\n  - e\n  - f\n",
+    "html": "<ul>\n<li>\n<p>a</p>\n<ul>\n<li>b</li>\n<li>c</li>\n</ul>\n</li>\n<li>\n<p>d</p>\n<ul>\n<li>e</li>\n<li>f</li>\n</ul>\n</li>\n</ul>\n",
+    "example": 326,
+    "start_line": 5820,
+    "end_line": 5845,
+    "section": "Lists"
+  },
+  {
+    "markdown": "`hi`lo`\n",
+    "html": "<p><code>hi</code>lo`</p>\n",
+    "example": 327,
+    "start_line": 5854,
+    "end_line": 5858,
+    "section": "Inlines"
+  },
+  {
+    "markdown": "`foo`\n",
+    "html": "<p><code>foo</code></p>\n",
+    "example": 328,
+    "start_line": 5886,
+    "end_line": 5890,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`` foo ` bar ``\n",
+    "html": "<p><code>foo ` bar</code></p>\n",
+    "example": 329,
+    "start_line": 5897,
+    "end_line": 5901,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "` `` `\n",
+    "html": "<p><code>``</code></p>\n",
+    "example": 330,
+    "start_line": 5907,
+    "end_line": 5911,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`  ``  `\n",
+    "html": "<p><code> `` </code></p>\n",
+    "example": 331,
+    "start_line": 5915,
+    "end_line": 5919,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "` a`\n",
+    "html": "<p><code> a</code></p>\n",
+    "example": 332,
+    "start_line": 5924,
+    "end_line": 5928,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "` b `\n",
+    "html": "<p><code> b </code></p>\n",
+    "example": 333,
+    "start_line": 5933,
+    "end_line": 5937,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "` `\n`  `\n",
+    "html": "<p><code> </code>\n<code>  </code></p>\n",
+    "example": 334,
+    "start_line": 5941,
+    "end_line": 5947,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "``\nfoo\nbar  \nbaz\n``\n",
+    "html": "<p><code>foo bar   baz</code></p>\n",
+    "example": 335,
+    "start_line": 5952,
+    "end_line": 5960,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "``\nfoo \n``\n",
+    "html": "<p><code>foo </code></p>\n",
+    "example": 336,
+    "start_line": 5962,
+    "end_line": 5968,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo   bar \nbaz`\n",
+    "html": "<p><code>foo   bar  baz</code></p>\n",
+    "example": 337,
+    "start_line": 5973,
+    "end_line": 5978,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\\`bar`\n",
+    "html": "<p><code>foo\\</code>bar`</p>\n",
+    "example": 338,
+    "start_line": 5990,
+    "end_line": 5994,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "``foo`bar``\n",
+    "html": "<p><code>foo`bar</code></p>\n",
+    "example": 339,
+    "start_line": 6001,
+    "end_line": 6005,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "` foo `` bar `\n",
+    "html": "<p><code>foo `` bar</code></p>\n",
+    "example": 340,
+    "start_line": 6007,
+    "end_line": 6011,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo`*`\n",
+    "html": "<p>*foo<code>*</code></p>\n",
+    "example": 341,
+    "start_line": 6019,
+    "end_line": 6023,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "[not a `link](/foo`)\n",
+    "html": "<p>[not a <code>link](/foo</code>)</p>\n",
+    "example": 342,
+    "start_line": 6028,
+    "end_line": 6032,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<a href=\"`\">`\n",
+    "html": "<p><code>&lt;a href=&quot;</code>&quot;&gt;`</p>\n",
+    "example": 343,
+    "start_line": 6038,
+    "end_line": 6042,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<a href=\"`\">`\n",
+    "html": "<p><a href=\"`\">`</p>\n",
+    "example": 344,
+    "start_line": 6047,
+    "end_line": 6051,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`<https://foo.bar.`baz>`\n",
+    "html": "<p><code>&lt;https://foo.bar.</code>baz&gt;`</p>\n",
+    "example": 345,
+    "start_line": 6056,
+    "end_line": 6060,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "<https://foo.bar.`baz>`\n",
+    "html": "<p><a href=\"https://foo.bar.%60baz\">https://foo.bar.`baz</a>`</p>\n",
+    "example": 346,
+    "start_line": 6065,
+    "end_line": 6069,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "```foo``\n",
+    "html": "<p>```foo``</p>\n",
+    "example": 347,
+    "start_line": 6075,
+    "end_line": 6079,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo\n",
+    "html": "<p>`foo</p>\n",
+    "example": 348,
+    "start_line": 6082,
+    "end_line": 6086,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "`foo``bar``\n",
+    "html": "<p>`foo<code>bar</code></p>\n",
+    "example": 349,
+    "start_line": 6091,
+    "end_line": 6095,
+    "section": "Code spans"
+  },
+  {
+    "markdown": "*foo bar*\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 350,
+    "start_line": 6308,
+    "end_line": 6312,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a * foo bar*\n",
+    "html": "<p>a * foo bar*</p>\n",
+    "example": 351,
+    "start_line": 6318,
+    "end_line": 6322,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a*\"foo\"*\n",
+    "html": "<p>a*&quot;foo&quot;*</p>\n",
+    "example": 352,
+    "start_line": 6329,
+    "end_line": 6333,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "* a *\n",
+    "html": "<p>* a *</p>\n",
+    "example": 353,
+    "start_line": 6338,
+    "end_line": 6342,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*$*alpha.\n\n*£*bravo.\n\n*€*charlie.\n",
+    "html": "<p>*$*alpha.</p>\n<p>*£*bravo.</p>\n<p>*€*charlie.</p>\n",
+    "example": 354,
+    "start_line": 6347,
+    "end_line": 6357,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo*bar*\n",
+    "html": "<p>foo<em>bar</em></p>\n",
+    "example": 355,
+    "start_line": 6362,
+    "end_line": 6366,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5*6*78\n",
+    "html": "<p>5<em>6</em>78</p>\n",
+    "example": 356,
+    "start_line": 6369,
+    "end_line": 6373,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar_\n",
+    "html": "<p><em>foo bar</em></p>\n",
+    "example": 357,
+    "start_line": 6378,
+    "end_line": 6382,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_ foo bar_\n",
+    "html": "<p>_ foo bar_</p>\n",
+    "example": 358,
+    "start_line": 6388,
+    "end_line": 6392,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a_\"foo\"_\n",
+    "html": "<p>a_&quot;foo&quot;_</p>\n",
+    "example": 359,
+    "start_line": 6398,
+    "end_line": 6402,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo_bar_\n",
+    "html": "<p>foo_bar_</p>\n",
+    "example": 360,
+    "start_line": 6407,
+    "end_line": 6411,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5_6_78\n",
+    "html": "<p>5_6_78</p>\n",
+    "example": 361,
+    "start_line": 6414,
+    "end_line": 6418,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням_стремятся_\n",
+    "html": "<p>пристаням_стремятся_</p>\n",
+    "example": 362,
+    "start_line": 6421,
+    "end_line": 6425,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "aa_\"bb\"_cc\n",
+    "html": "<p>aa_&quot;bb&quot;_cc</p>\n",
+    "example": 363,
+    "start_line": 6431,
+    "end_line": 6435,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-_(bar)_\n",
+    "html": "<p>foo-<em>(bar)</em></p>\n",
+    "example": 364,
+    "start_line": 6442,
+    "end_line": 6446,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo*\n",
+    "html": "<p>_foo*</p>\n",
+    "example": 365,
+    "start_line": 6454,
+    "end_line": 6458,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar *\n",
+    "html": "<p>*foo bar *</p>\n",
+    "example": 366,
+    "start_line": 6464,
+    "end_line": 6468,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo bar\n*\n",
+    "html": "<p>*foo bar\n*</p>\n",
+    "example": 367,
+    "start_line": 6473,
+    "end_line": 6479,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo)\n",
+    "html": "<p>*(*foo)</p>\n",
+    "example": 368,
+    "start_line": 6486,
+    "end_line": 6490,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(*foo*)*\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 369,
+    "start_line": 6496,
+    "end_line": 6500,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo*bar\n",
+    "html": "<p><em>foo</em>bar</p>\n",
+    "example": 370,
+    "start_line": 6505,
+    "end_line": 6509,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo bar _\n",
+    "html": "<p>_foo bar _</p>\n",
+    "example": 371,
+    "start_line": 6518,
+    "end_line": 6522,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo)\n",
+    "html": "<p>_(_foo)</p>\n",
+    "example": 372,
+    "start_line": 6528,
+    "end_line": 6532,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(_foo_)_\n",
+    "html": "<p><em>(<em>foo</em>)</em></p>\n",
+    "example": 373,
+    "start_line": 6537,
+    "end_line": 6541,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar\n",
+    "html": "<p>_foo_bar</p>\n",
+    "example": 374,
+    "start_line": 6546,
+    "end_line": 6550,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_пристаням_стремятся\n",
+    "html": "<p>_пристаням_стремятся</p>\n",
+    "example": 375,
+    "start_line": 6553,
+    "end_line": 6557,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo_bar_baz_\n",
+    "html": "<p><em>foo_bar_baz</em></p>\n",
+    "example": 376,
+    "start_line": 6560,
+    "end_line": 6564,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(bar)_.\n",
+    "html": "<p><em>(bar)</em>.</p>\n",
+    "example": 377,
+    "start_line": 6571,
+    "end_line": 6575,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar**\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 378,
+    "start_line": 6580,
+    "end_line": 6584,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** foo bar**\n",
+    "html": "<p>** foo bar**</p>\n",
+    "example": 379,
+    "start_line": 6590,
+    "end_line": 6594,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a**\"foo\"**\n",
+    "html": "<p>a**&quot;foo&quot;**</p>\n",
+    "example": 380,
+    "start_line": 6601,
+    "end_line": 6605,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo**bar**\n",
+    "html": "<p>foo<strong>bar</strong></p>\n",
+    "example": 381,
+    "start_line": 6610,
+    "end_line": 6614,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar__\n",
+    "html": "<p><strong>foo bar</strong></p>\n",
+    "example": 382,
+    "start_line": 6619,
+    "end_line": 6623,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ foo bar__\n",
+    "html": "<p>__ foo bar__</p>\n",
+    "example": 383,
+    "start_line": 6629,
+    "end_line": 6633,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__\nfoo bar__\n",
+    "html": "<p>__\nfoo bar__</p>\n",
+    "example": 384,
+    "start_line": 6637,
+    "end_line": 6643,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "a__\"foo\"__\n",
+    "html": "<p>a__&quot;foo&quot;__</p>\n",
+    "example": 385,
+    "start_line": 6649,
+    "end_line": 6653,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo__bar__\n",
+    "html": "<p>foo__bar__</p>\n",
+    "example": 386,
+    "start_line": 6658,
+    "end_line": 6662,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "5__6__78\n",
+    "html": "<p>5__6__78</p>\n",
+    "example": 387,
+    "start_line": 6665,
+    "end_line": 6669,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "пристаням__стремятся__\n",
+    "html": "<p>пристаням__стремятся__</p>\n",
+    "example": 388,
+    "start_line": 6672,
+    "end_line": 6676,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo, __bar__, baz__\n",
+    "html": "<p><strong>foo, <strong>bar</strong>, baz</strong></p>\n",
+    "example": 389,
+    "start_line": 6679,
+    "end_line": 6683,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo-__(bar)__\n",
+    "html": "<p>foo-<strong>(bar)</strong></p>\n",
+    "example": 390,
+    "start_line": 6690,
+    "end_line": 6694,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo bar **\n",
+    "html": "<p>**foo bar **</p>\n",
+    "example": 391,
+    "start_line": 6703,
+    "end_line": 6707,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**(**foo)\n",
+    "html": "<p>**(**foo)</p>\n",
+    "example": 392,
+    "start_line": 6716,
+    "end_line": 6720,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*(**foo**)*\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 393,
+    "start_line": 6726,
+    "end_line": 6730,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**Gomphocarpus (*Gomphocarpus physocarpus*, syn.\n*Asclepias physocarpa*)**\n",
+    "html": "<p><strong>Gomphocarpus (<em>Gomphocarpus physocarpus</em>, syn.\n<em>Asclepias physocarpa</em>)</strong></p>\n",
+    "example": 394,
+    "start_line": 6733,
+    "end_line": 6739,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo \"*bar*\" foo**\n",
+    "html": "<p><strong>foo &quot;<em>bar</em>&quot; foo</strong></p>\n",
+    "example": 395,
+    "start_line": 6742,
+    "end_line": 6746,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**bar\n",
+    "html": "<p><strong>foo</strong>bar</p>\n",
+    "example": 396,
+    "start_line": 6751,
+    "end_line": 6755,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo bar __\n",
+    "html": "<p>__foo bar __</p>\n",
+    "example": 397,
+    "start_line": 6763,
+    "end_line": 6767,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(__foo)\n",
+    "html": "<p>__(__foo)</p>\n",
+    "example": 398,
+    "start_line": 6773,
+    "end_line": 6777,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_(__foo__)_\n",
+    "html": "<p><em>(<strong>foo</strong>)</em></p>\n",
+    "example": 399,
+    "start_line": 6783,
+    "end_line": 6787,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar\n",
+    "html": "<p>__foo__bar</p>\n",
+    "example": 400,
+    "start_line": 6792,
+    "end_line": 6796,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__пристаням__стремятся\n",
+    "html": "<p>__пристаням__стремятся</p>\n",
+    "example": 401,
+    "start_line": 6799,
+    "end_line": 6803,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__bar__baz__\n",
+    "html": "<p><strong>foo__bar__baz</strong></p>\n",
+    "example": 402,
+    "start_line": 6806,
+    "end_line": 6810,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__(bar)__.\n",
+    "html": "<p><strong>(bar)</strong>.</p>\n",
+    "example": 403,
+    "start_line": 6817,
+    "end_line": 6821,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [bar](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\">bar</a></em></p>\n",
+    "example": 404,
+    "start_line": 6829,
+    "end_line": 6833,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo\nbar*\n",
+    "html": "<p><em>foo\nbar</em></p>\n",
+    "example": 405,
+    "start_line": 6836,
+    "end_line": 6842,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo __bar__ baz_\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 406,
+    "start_line": 6848,
+    "end_line": 6852,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo _bar_ baz_\n",
+    "html": "<p><em>foo <em>bar</em> baz</em></p>\n",
+    "example": 407,
+    "start_line": 6855,
+    "end_line": 6859,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_ bar_\n",
+    "html": "<p><em><em>foo</em> bar</em></p>\n",
+    "example": 408,
+    "start_line": 6862,
+    "end_line": 6866,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar**\n",
+    "html": "<p><em>foo <em>bar</em></em></p>\n",
+    "example": 409,
+    "start_line": 6869,
+    "end_line": 6873,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar** baz*\n",
+    "html": "<p><em>foo <strong>bar</strong> baz</em></p>\n",
+    "example": 410,
+    "start_line": 6876,
+    "end_line": 6880,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar**baz*\n",
+    "html": "<p><em>foo<strong>bar</strong>baz</em></p>\n",
+    "example": 411,
+    "start_line": 6882,
+    "end_line": 6886,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar*\n",
+    "html": "<p><em>foo**bar</em></p>\n",
+    "example": 412,
+    "start_line": 6906,
+    "end_line": 6910,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo** bar*\n",
+    "html": "<p><em><strong>foo</strong> bar</em></p>\n",
+    "example": 413,
+    "start_line": 6919,
+    "end_line": 6923,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar***\n",
+    "html": "<p><em>foo <strong>bar</strong></em></p>\n",
+    "example": 414,
+    "start_line": 6926,
+    "end_line": 6930,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**bar***\n",
+    "html": "<p><em>foo<strong>bar</strong></em></p>\n",
+    "example": 415,
+    "start_line": 6933,
+    "end_line": 6937,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo***bar***baz\n",
+    "html": "<p>foo<em><strong>bar</strong></em>baz</p>\n",
+    "example": 416,
+    "start_line": 6944,
+    "end_line": 6948,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo******bar*********baz\n",
+    "html": "<p>foo<strong><strong><strong>bar</strong></strong></strong>***baz</p>\n",
+    "example": 417,
+    "start_line": 6950,
+    "end_line": 6954,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo **bar *baz* bim** bop*\n",
+    "html": "<p><em>foo <strong>bar <em>baz</em> bim</strong> bop</em></p>\n",
+    "example": 418,
+    "start_line": 6959,
+    "end_line": 6963,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo [*bar*](/url)*\n",
+    "html": "<p><em>foo <a href=\"/url\"><em>bar</em></a></em></p>\n",
+    "example": 419,
+    "start_line": 6966,
+    "end_line": 6970,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "** is not an empty emphasis\n",
+    "html": "<p>** is not an empty emphasis</p>\n",
+    "example": 420,
+    "start_line": 6975,
+    "end_line": 6979,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**** is not an empty strong emphasis\n",
+    "html": "<p>**** is not an empty strong emphasis</p>\n",
+    "example": 421,
+    "start_line": 6982,
+    "end_line": 6986,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [bar](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\">bar</a></strong></p>\n",
+    "example": 422,
+    "start_line": 6995,
+    "end_line": 6999,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo\nbar**\n",
+    "html": "<p><strong>foo\nbar</strong></p>\n",
+    "example": 423,
+    "start_line": 7002,
+    "end_line": 7008,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo _bar_ baz__\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 424,
+    "start_line": 7014,
+    "end_line": 7018,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo __bar__ baz__\n",
+    "html": "<p><strong>foo <strong>bar</strong> baz</strong></p>\n",
+    "example": 425,
+    "start_line": 7021,
+    "end_line": 7025,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo__ bar__\n",
+    "html": "<p><strong><strong>foo</strong> bar</strong></p>\n",
+    "example": 426,
+    "start_line": 7028,
+    "end_line": 7032,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar****\n",
+    "html": "<p><strong>foo <strong>bar</strong></strong></p>\n",
+    "example": 427,
+    "start_line": 7035,
+    "end_line": 7039,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar* baz**\n",
+    "html": "<p><strong>foo <em>bar</em> baz</strong></p>\n",
+    "example": 428,
+    "start_line": 7042,
+    "end_line": 7046,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*bar*baz**\n",
+    "html": "<p><strong>foo<em>bar</em>baz</strong></p>\n",
+    "example": 429,
+    "start_line": 7049,
+    "end_line": 7053,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo* bar**\n",
+    "html": "<p><strong><em>foo</em> bar</strong></p>\n",
+    "example": 430,
+    "start_line": 7056,
+    "end_line": 7060,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar***\n",
+    "html": "<p><strong>foo <em>bar</em></strong></p>\n",
+    "example": 431,
+    "start_line": 7063,
+    "end_line": 7067,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo *bar **baz**\nbim* bop**\n",
+    "html": "<p><strong>foo <em>bar <strong>baz</strong>\nbim</em> bop</strong></p>\n",
+    "example": 432,
+    "start_line": 7072,
+    "end_line": 7078,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo [*bar*](/url)**\n",
+    "html": "<p><strong>foo <a href=\"/url\"><em>bar</em></a></strong></p>\n",
+    "example": 433,
+    "start_line": 7081,
+    "end_line": 7085,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__ is not an empty emphasis\n",
+    "html": "<p>__ is not an empty emphasis</p>\n",
+    "example": 434,
+    "start_line": 7090,
+    "end_line": 7094,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____ is not an empty strong emphasis\n",
+    "html": "<p>____ is not an empty strong emphasis</p>\n",
+    "example": 435,
+    "start_line": 7097,
+    "end_line": 7101,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ***\n",
+    "html": "<p>foo ***</p>\n",
+    "example": 436,
+    "start_line": 7107,
+    "end_line": 7111,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *\\**\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 437,
+    "start_line": 7114,
+    "end_line": 7118,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *_*\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 438,
+    "start_line": 7121,
+    "end_line": 7125,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo *****\n",
+    "html": "<p>foo *****</p>\n",
+    "example": 439,
+    "start_line": 7128,
+    "end_line": 7132,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **\\***\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 440,
+    "start_line": 7135,
+    "end_line": 7139,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo **_**\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 441,
+    "start_line": 7142,
+    "end_line": 7146,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo*\n",
+    "html": "<p>*<em>foo</em></p>\n",
+    "example": 442,
+    "start_line": 7153,
+    "end_line": 7157,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo**\n",
+    "html": "<p><em>foo</em>*</p>\n",
+    "example": 443,
+    "start_line": 7160,
+    "end_line": 7164,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo**\n",
+    "html": "<p>*<strong>foo</strong></p>\n",
+    "example": 444,
+    "start_line": 7167,
+    "end_line": 7171,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo*\n",
+    "html": "<p>***<em>foo</em></p>\n",
+    "example": 445,
+    "start_line": 7174,
+    "end_line": 7178,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo***\n",
+    "html": "<p><strong>foo</strong>*</p>\n",
+    "example": 446,
+    "start_line": 7181,
+    "end_line": 7185,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo****\n",
+    "html": "<p><em>foo</em>***</p>\n",
+    "example": 447,
+    "start_line": 7188,
+    "end_line": 7192,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo ___\n",
+    "html": "<p>foo ___</p>\n",
+    "example": 448,
+    "start_line": 7198,
+    "end_line": 7202,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _\\__\n",
+    "html": "<p>foo <em>_</em></p>\n",
+    "example": 449,
+    "start_line": 7205,
+    "end_line": 7209,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _*_\n",
+    "html": "<p>foo <em>*</em></p>\n",
+    "example": 450,
+    "start_line": 7212,
+    "end_line": 7216,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo _____\n",
+    "html": "<p>foo _____</p>\n",
+    "example": 451,
+    "start_line": 7219,
+    "end_line": 7223,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __\\___\n",
+    "html": "<p>foo <strong>_</strong></p>\n",
+    "example": 452,
+    "start_line": 7226,
+    "end_line": 7230,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "foo __*__\n",
+    "html": "<p>foo <strong>*</strong></p>\n",
+    "example": 453,
+    "start_line": 7233,
+    "end_line": 7237,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo_\n",
+    "html": "<p>_<em>foo</em></p>\n",
+    "example": 454,
+    "start_line": 7240,
+    "end_line": 7244,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo__\n",
+    "html": "<p><em>foo</em>_</p>\n",
+    "example": 455,
+    "start_line": 7251,
+    "end_line": 7255,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "___foo__\n",
+    "html": "<p>_<strong>foo</strong></p>\n",
+    "example": 456,
+    "start_line": 7258,
+    "end_line": 7262,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo_\n",
+    "html": "<p>___<em>foo</em></p>\n",
+    "example": 457,
+    "start_line": 7265,
+    "end_line": 7269,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo___\n",
+    "html": "<p><strong>foo</strong>_</p>\n",
+    "example": 458,
+    "start_line": 7272,
+    "end_line": 7276,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo____\n",
+    "html": "<p><em>foo</em>___</p>\n",
+    "example": 459,
+    "start_line": 7279,
+    "end_line": 7283,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo**\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 460,
+    "start_line": 7289,
+    "end_line": 7293,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*_foo_*\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 461,
+    "start_line": 7296,
+    "end_line": 7300,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__foo__\n",
+    "html": "<p><strong>foo</strong></p>\n",
+    "example": 462,
+    "start_line": 7303,
+    "end_line": 7307,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_*foo*_\n",
+    "html": "<p><em><em>foo</em></em></p>\n",
+    "example": 463,
+    "start_line": 7310,
+    "end_line": 7314,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "****foo****\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 464,
+    "start_line": 7320,
+    "end_line": 7324,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "____foo____\n",
+    "html": "<p><strong><strong>foo</strong></strong></p>\n",
+    "example": 465,
+    "start_line": 7327,
+    "end_line": 7331,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "******foo******\n",
+    "html": "<p><strong><strong><strong>foo</strong></strong></strong></p>\n",
+    "example": 466,
+    "start_line": 7338,
+    "end_line": 7342,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "***foo***\n",
+    "html": "<p><em><strong>foo</strong></em></p>\n",
+    "example": 467,
+    "start_line": 7347,
+    "end_line": 7351,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_____foo_____\n",
+    "html": "<p><em><strong><strong>foo</strong></strong></em></p>\n",
+    "example": 468,
+    "start_line": 7354,
+    "end_line": 7358,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo _bar* baz_\n",
+    "html": "<p><em>foo _bar</em> baz_</p>\n",
+    "example": 469,
+    "start_line": 7363,
+    "end_line": 7367,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo __bar *baz bim__ bam*\n",
+    "html": "<p><em>foo <strong>bar *baz bim</strong> bam</em></p>\n",
+    "example": 470,
+    "start_line": 7370,
+    "end_line": 7374,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**foo **bar baz**\n",
+    "html": "<p>**foo <strong>bar baz</strong></p>\n",
+    "example": 471,
+    "start_line": 7379,
+    "end_line": 7383,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*foo *bar baz*\n",
+    "html": "<p>*foo <em>bar baz</em></p>\n",
+    "example": 472,
+    "start_line": 7386,
+    "end_line": 7390,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*[bar*](/url)\n",
+    "html": "<p>*<a href=\"/url\">bar*</a></p>\n",
+    "example": 473,
+    "start_line": 7395,
+    "end_line": 7399,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_foo [bar_](/url)\n",
+    "html": "<p>_foo <a href=\"/url\">bar_</a></p>\n",
+    "example": 474,
+    "start_line": 7402,
+    "end_line": 7406,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*<img src=\"foo\" title=\"*\"/>\n",
+    "html": "<p>*<img src=\"foo\" title=\"*\"/></p>\n",
+    "example": 475,
+    "start_line": 7409,
+    "end_line": 7413,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**<a href=\"**\">\n",
+    "html": "<p>**<a href=\"**\"></p>\n",
+    "example": 476,
+    "start_line": 7416,
+    "end_line": 7420,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__<a href=\"__\">\n",
+    "html": "<p>__<a href=\"__\"></p>\n",
+    "example": 477,
+    "start_line": 7423,
+    "end_line": 7427,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "*a `*`*\n",
+    "html": "<p><em>a <code>*</code></em></p>\n",
+    "example": 478,
+    "start_line": 7430,
+    "end_line": 7434,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "_a `_`_\n",
+    "html": "<p><em>a <code>_</code></em></p>\n",
+    "example": 479,
+    "start_line": 7437,
+    "end_line": 7441,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "**a<https://foo.bar/?q=**>\n",
+    "html": "<p>**a<a href=\"https://foo.bar/?q=**\">https://foo.bar/?q=**</a></p>\n",
+    "example": 480,
+    "start_line": 7444,
+    "end_line": 7448,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "__a<https://foo.bar/?q=__>\n",
+    "html": "<p>__a<a href=\"https://foo.bar/?q=__\">https://foo.bar/?q=__</a></p>\n",
+    "example": 481,
+    "start_line": 7451,
+    "end_line": 7455,
+    "section": "Emphasis and strong emphasis"
+  },
+  {
+    "markdown": "[link](/uri \"title\")\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 482,
+    "start_line": 7539,
+    "end_line": 7543,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/uri)\n",
+    "html": "<p><a href=\"/uri\">link</a></p>\n",
+    "example": 483,
+    "start_line": 7549,
+    "end_line": 7553,
+    "section": "Links"
+  },
+  {
+    "markdown": "[](./target.md)\n",
+    "html": "<p><a href=\"./target.md\"></a></p>\n",
+    "example": 484,
+    "start_line": 7555,
+    "end_line": 7559,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link]()\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 485,
+    "start_line": 7562,
+    "end_line": 7566,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<>)\n",
+    "html": "<p><a href=\"\">link</a></p>\n",
+    "example": 486,
+    "start_line": 7569,
+    "end_line": 7573,
+    "section": "Links"
+  },
+  {
+    "markdown": "[]()\n",
+    "html": "<p><a href=\"\"></a></p>\n",
+    "example": 487,
+    "start_line": 7576,
+    "end_line": 7580,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/my uri)\n",
+    "html": "<p>[link](/my uri)</p>\n",
+    "example": 488,
+    "start_line": 7585,
+    "end_line": 7589,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](</my uri>)\n",
+    "html": "<p><a href=\"/my%20uri\">link</a></p>\n",
+    "example": 489,
+    "start_line": 7591,
+    "end_line": 7595,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\nbar)\n",
+    "html": "<p>[link](foo\nbar)</p>\n",
+    "example": 490,
+    "start_line": 7600,
+    "end_line": 7606,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo\nbar>)\n",
+    "html": "<p>[link](<foo\nbar>)</p>\n",
+    "example": 491,
+    "start_line": 7608,
+    "end_line": 7614,
+    "section": "Links"
+  },
+  {
+    "markdown": "[a](<b)c>)\n",
+    "html": "<p><a href=\"b)c\">a</a></p>\n",
+    "example": 492,
+    "start_line": 7619,
+    "end_line": 7623,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo\\>)\n",
+    "html": "<p>[link](&lt;foo&gt;)</p>\n",
+    "example": 493,
+    "start_line": 7627,
+    "end_line": 7631,
+    "section": "Links"
+  },
+  {
+    "markdown": "[a](<b)c\n[a](<b)c>\n[a](<b>c)\n",
+    "html": "<p>[a](&lt;b)c\n[a](&lt;b)c&gt;\n[a](<b>c)</p>\n",
+    "example": 494,
+    "start_line": 7636,
+    "end_line": 7644,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](\\(foo\\))\n",
+    "html": "<p><a href=\"(foo)\">link</a></p>\n",
+    "example": 495,
+    "start_line": 7648,
+    "end_line": 7652,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and(bar)))\n",
+    "html": "<p><a href=\"foo(and(bar))\">link</a></p>\n",
+    "example": 496,
+    "start_line": 7657,
+    "end_line": 7661,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo(and(bar))\n",
+    "html": "<p>[link](foo(and(bar))</p>\n",
+    "example": 497,
+    "start_line": 7666,
+    "end_line": 7670,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\(and\\(bar\\))\n",
+    "html": "<p><a href=\"foo(and(bar)\">link</a></p>\n",
+    "example": 498,
+    "start_line": 7673,
+    "end_line": 7677,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](<foo(and(bar)>)\n",
+    "html": "<p><a href=\"foo(and(bar)\">link</a></p>\n",
+    "example": 499,
+    "start_line": 7680,
+    "end_line": 7684,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\)\\:)\n",
+    "html": "<p><a href=\"foo):\">link</a></p>\n",
+    "example": 500,
+    "start_line": 7690,
+    "end_line": 7694,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](#fragment)\n\n[link](https://example.com#fragment)\n\n[link](https://example.com?foo=3#frag)\n",
+    "html": "<p><a href=\"#fragment\">link</a></p>\n<p><a href=\"https://example.com#fragment\">link</a></p>\n<p><a href=\"https://example.com?foo=3#frag\">link</a></p>\n",
+    "example": 501,
+    "start_line": 7699,
+    "end_line": 7709,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo\\bar)\n",
+    "html": "<p><a href=\"foo%5Cbar\">link</a></p>\n",
+    "example": 502,
+    "start_line": 7715,
+    "end_line": 7719,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](foo%20b&auml;)\n",
+    "html": "<p><a href=\"foo%20b%C3%A4\">link</a></p>\n",
+    "example": 503,
+    "start_line": 7731,
+    "end_line": 7735,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](\"title\")\n",
+    "html": "<p><a href=\"%22title%22\">link</a></p>\n",
+    "example": 504,
+    "start_line": 7742,
+    "end_line": 7746,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title\")\n[link](/url 'title')\n[link](/url (title))\n",
+    "html": "<p><a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a>\n<a href=\"/url\" title=\"title\">link</a></p>\n",
+    "example": 505,
+    "start_line": 7751,
+    "end_line": 7759,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \\\"&quot;\")\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;&quot;\">link</a></p>\n",
+    "example": 506,
+    "start_line": 7765,
+    "end_line": 7769,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title\")\n",
+    "html": "<p><a href=\"/url%C2%A0%22title%22\">link</a></p>\n",
+    "example": 507,
+    "start_line": 7776,
+    "end_line": 7780,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url \"title \"and\" title\")\n",
+    "html": "<p>[link](/url &quot;title &quot;and&quot; title&quot;)</p>\n",
+    "example": 508,
+    "start_line": 7785,
+    "end_line": 7789,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](/url 'title \"and\" title')\n",
+    "html": "<p><a href=\"/url\" title=\"title &quot;and&quot; title\">link</a></p>\n",
+    "example": 509,
+    "start_line": 7794,
+    "end_line": 7798,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link](   /uri\n  \"title\"  )\n",
+    "html": "<p><a href=\"/uri\" title=\"title\">link</a></p>\n",
+    "example": 510,
+    "start_line": 7819,
+    "end_line": 7824,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] (/uri)\n",
+    "html": "<p>[link] (/uri)</p>\n",
+    "example": 511,
+    "start_line": 7830,
+    "end_line": 7834,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 512,
+    "start_line": 7840,
+    "end_line": 7844,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link] bar](/uri)\n",
+    "html": "<p>[link] bar](/uri)</p>\n",
+    "example": 513,
+    "start_line": 7847,
+    "end_line": 7851,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [bar](/uri)\n",
+    "html": "<p>[link <a href=\"/uri\">bar</a></p>\n",
+    "example": 514,
+    "start_line": 7854,
+    "end_line": 7858,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar](/uri)\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 515,
+    "start_line": 7861,
+    "end_line": 7865,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*](/uri)\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 516,
+    "start_line": 7870,
+    "end_line": 7874,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)](/uri)\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 517,
+    "start_line": 7877,
+    "end_line": 7881,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)](/uri)\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>](/uri)</p>\n",
+    "example": 518,
+    "start_line": 7886,
+    "end_line": 7890,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *[bar [baz](/uri)](/uri)*](/uri)\n",
+    "html": "<p>[foo <em>[bar <a href=\"/uri\">baz</a>](/uri)</em>](/uri)</p>\n",
+    "example": 519,
+    "start_line": 7893,
+    "end_line": 7897,
+    "section": "Links"
+  },
+  {
+    "markdown": "![[[foo](uri1)](uri2)](uri3)\n",
+    "html": "<p><img src=\"uri3\" alt=\"[foo](uri2)\" /></p>\n",
+    "example": 520,
+    "start_line": 7900,
+    "end_line": 7904,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*](/uri)\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 521,
+    "start_line": 7910,
+    "end_line": 7914,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar](baz*)\n",
+    "html": "<p><a href=\"baz*\">foo *bar</a></p>\n",
+    "example": 522,
+    "start_line": 7917,
+    "end_line": 7921,
+    "section": "Links"
+  },
+  {
+    "markdown": "*foo [bar* baz]\n",
+    "html": "<p><em>foo [bar</em> baz]</p>\n",
+    "example": 523,
+    "start_line": 7927,
+    "end_line": 7931,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"](baz)\">\n",
+    "html": "<p>[foo <bar attr=\"](baz)\"></p>\n",
+    "example": 524,
+    "start_line": 7937,
+    "end_line": 7941,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`](/uri)`\n",
+    "html": "<p>[foo<code>](/uri)</code></p>\n",
+    "example": 525,
+    "start_line": 7944,
+    "end_line": 7948,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<https://example.com/?search=](uri)>\n",
+    "html": "<p>[foo<a href=\"https://example.com/?search=%5D(uri)\">https://example.com/?search=](uri)</a></p>\n",
+    "example": 526,
+    "start_line": 7951,
+    "end_line": 7955,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 527,
+    "start_line": 7989,
+    "end_line": 7995,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link [foo [bar]]][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [foo [bar]]</a></p>\n",
+    "example": 528,
+    "start_line": 8004,
+    "end_line": 8010,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link \\[bar][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link [bar</a></p>\n",
+    "example": 529,
+    "start_line": 8013,
+    "end_line": 8019,
+    "section": "Links"
+  },
+  {
+    "markdown": "[link *foo **bar** `#`*][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">link <em>foo <strong>bar</strong> <code>#</code></em></a></p>\n",
+    "example": 530,
+    "start_line": 8024,
+    "end_line": 8030,
+    "section": "Links"
+  },
+  {
+    "markdown": "[![moon](moon.jpg)][ref]\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\"><img src=\"moon.jpg\" alt=\"moon\" /></a></p>\n",
+    "example": 531,
+    "start_line": 8033,
+    "end_line": 8039,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo [bar](/uri)][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <a href=\"/uri\">bar</a>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 532,
+    "start_line": 8044,
+    "end_line": 8050,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar [baz][ref]*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>[foo <em>bar <a href=\"/uri\">baz</a></em>]<a href=\"/uri\">ref</a></p>\n",
+    "example": 533,
+    "start_line": 8053,
+    "end_line": 8059,
+    "section": "Links"
+  },
+  {
+    "markdown": "*[foo*][ref]\n\n[ref]: /uri\n",
+    "html": "<p>*<a href=\"/uri\">foo*</a></p>\n",
+    "example": 534,
+    "start_line": 8068,
+    "end_line": 8074,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo *bar][ref]*\n\n[ref]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo *bar</a>*</p>\n",
+    "example": 535,
+    "start_line": 8077,
+    "end_line": 8083,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo <bar attr=\"][ref]\">\n\n[ref]: /uri\n",
+    "html": "<p>[foo <bar attr=\"][ref]\"></p>\n",
+    "example": 536,
+    "start_line": 8089,
+    "end_line": 8095,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo`][ref]`\n\n[ref]: /uri\n",
+    "html": "<p>[foo<code>][ref]</code></p>\n",
+    "example": 537,
+    "start_line": 8098,
+    "end_line": 8104,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo<https://example.com/?search=][ref]>\n\n[ref]: /uri\n",
+    "html": "<p>[foo<a href=\"https://example.com/?search=%5D%5Bref%5D\">https://example.com/?search=][ref]</a></p>\n",
+    "example": 538,
+    "start_line": 8107,
+    "end_line": 8113,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][BaR]\n\n[bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 539,
+    "start_line": 8118,
+    "end_line": 8124,
+    "section": "Links"
+  },
+  {
+    "markdown": "[ẞ]\n\n[SS]: /url\n",
+    "html": "<p><a href=\"/url\">ẞ</a></p>\n",
+    "example": 540,
+    "start_line": 8129,
+    "end_line": 8135,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo\n  bar]: /url\n\n[Baz][Foo bar]\n",
+    "html": "<p><a href=\"/url\">Baz</a></p>\n",
+    "example": 541,
+    "start_line": 8141,
+    "end_line": 8148,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] [bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo] <a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 542,
+    "start_line": 8154,
+    "end_line": 8160,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n[bar]\n\n[bar]: /url \"title\"\n",
+    "html": "<p>[foo]\n<a href=\"/url\" title=\"title\">bar</a></p>\n",
+    "example": 543,
+    "start_line": 8163,
+    "end_line": 8171,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]: /url1\n\n[foo]: /url2\n\n[bar][foo]\n",
+    "html": "<p><a href=\"/url1\">bar</a></p>\n",
+    "example": 544,
+    "start_line": 8204,
+    "end_line": 8212,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar][foo\\!]\n\n[foo!]: /url\n",
+    "html": "<p>[bar][foo!]</p>\n",
+    "example": 545,
+    "start_line": 8219,
+    "end_line": 8225,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[]\n\n[ref[]: /uri\n",
+    "html": "<p>[foo][ref[]</p>\n<p>[ref[]: /uri</p>\n",
+    "example": 546,
+    "start_line": 8231,
+    "end_line": 8238,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref[bar]]\n\n[ref[bar]]: /uri\n",
+    "html": "<p>[foo][ref[bar]]</p>\n<p>[ref[bar]]: /uri</p>\n",
+    "example": 547,
+    "start_line": 8241,
+    "end_line": 8248,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[[foo]]]\n\n[[[foo]]]: /url\n",
+    "html": "<p>[[[foo]]]</p>\n<p>[[[foo]]]: /url</p>\n",
+    "example": 548,
+    "start_line": 8251,
+    "end_line": 8258,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][ref\\[]\n\n[ref\\[]: /uri\n",
+    "html": "<p><a href=\"/uri\">foo</a></p>\n",
+    "example": 549,
+    "start_line": 8261,
+    "end_line": 8267,
+    "section": "Links"
+  },
+  {
+    "markdown": "[bar\\\\]: /uri\n\n[bar\\\\]\n",
+    "html": "<p><a href=\"/uri\">bar\\</a></p>\n",
+    "example": 550,
+    "start_line": 8272,
+    "end_line": 8278,
+    "section": "Links"
+  },
+  {
+    "markdown": "[]\n\n[]: /uri\n",
+    "html": "<p>[]</p>\n<p>[]: /uri</p>\n",
+    "example": 551,
+    "start_line": 8284,
+    "end_line": 8291,
+    "section": "Links"
+  },
+  {
+    "markdown": "[\n ]\n\n[\n ]: /uri\n",
+    "html": "<p>[\n]</p>\n<p>[\n]: /uri</p>\n",
+    "example": 552,
+    "start_line": 8294,
+    "end_line": 8305,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 553,
+    "start_line": 8317,
+    "end_line": 8323,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 554,
+    "start_line": 8326,
+    "end_line": 8332,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 555,
+    "start_line": 8337,
+    "end_line": 8343,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a>\n[]</p>\n",
+    "example": 556,
+    "start_line": 8350,
+    "end_line": 8358,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 557,
+    "start_line": 8370,
+    "end_line": 8376,
+    "section": "Links"
+  },
+  {
+    "markdown": "[*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\"><em>foo</em> bar</a></p>\n",
+    "example": 558,
+    "start_line": 8379,
+    "end_line": 8385,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[*foo* bar]]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p>[<a href=\"/url\" title=\"title\"><em>foo</em> bar</a>]</p>\n",
+    "example": 559,
+    "start_line": 8388,
+    "end_line": 8394,
+    "section": "Links"
+  },
+  {
+    "markdown": "[[bar [foo]\n\n[foo]: /url\n",
+    "html": "<p>[[bar <a href=\"/url\">foo</a></p>\n",
+    "example": 560,
+    "start_line": 8397,
+    "end_line": 8403,
+    "section": "Links"
+  },
+  {
+    "markdown": "[Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><a href=\"/url\" title=\"title\">Foo</a></p>\n",
+    "example": 561,
+    "start_line": 8408,
+    "end_line": 8414,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo] bar\n\n[foo]: /url\n",
+    "html": "<p><a href=\"/url\">foo</a> bar</p>\n",
+    "example": 562,
+    "start_line": 8419,
+    "end_line": 8425,
+    "section": "Links"
+  },
+  {
+    "markdown": "\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>[foo]</p>\n",
+    "example": 563,
+    "start_line": 8431,
+    "end_line": 8437,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo*]: /url\n\n*[foo*]\n",
+    "html": "<p>*<a href=\"/url\">foo*</a></p>\n",
+    "example": 564,
+    "start_line": 8443,
+    "end_line": 8449,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar]\n\n[foo]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a></p>\n",
+    "example": 565,
+    "start_line": 8455,
+    "end_line": 8462,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][]\n\n[foo]: /url1\n",
+    "html": "<p><a href=\"/url1\">foo</a></p>\n",
+    "example": 566,
+    "start_line": 8464,
+    "end_line": 8470,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo]()\n\n[foo]: /url1\n",
+    "html": "<p><a href=\"\">foo</a></p>\n",
+    "example": 567,
+    "start_line": 8474,
+    "end_line": 8480,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo](not a link)\n\n[foo]: /url1\n",
+    "html": "<p><a href=\"/url1\">foo</a>(not a link)</p>\n",
+    "example": 568,
+    "start_line": 8482,
+    "end_line": 8488,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url\n",
+    "html": "<p>[foo]<a href=\"/url\">bar</a></p>\n",
+    "example": 569,
+    "start_line": 8493,
+    "end_line": 8499,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[bar]: /url2\n",
+    "html": "<p><a href=\"/url2\">foo</a><a href=\"/url1\">baz</a></p>\n",
+    "example": 570,
+    "start_line": 8505,
+    "end_line": 8512,
+    "section": "Links"
+  },
+  {
+    "markdown": "[foo][bar][baz]\n\n[baz]: /url1\n[foo]: /url2\n",
+    "html": "<p>[foo]<a href=\"/url1\">bar</a></p>\n",
+    "example": 571,
+    "start_line": 8518,
+    "end_line": 8525,
+    "section": "Links"
+  },
+  {
+    "markdown": "![foo](/url \"title\")\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 572,
+    "start_line": 8541,
+    "end_line": 8545,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 573,
+    "start_line": 8548,
+    "end_line": 8554,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo ![bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 574,
+    "start_line": 8557,
+    "end_line": 8561,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo [bar](/url)](/url2)\n",
+    "html": "<p><img src=\"/url2\" alt=\"foo bar\" /></p>\n",
+    "example": 575,
+    "start_line": 8564,
+    "end_line": 8568,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][]\n\n[foo *bar*]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 576,
+    "start_line": 8578,
+    "end_line": 8584,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo *bar*][foobar]\n\n[FOOBAR]: train.jpg \"train & tracks\"\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo bar\" title=\"train &amp; tracks\" /></p>\n",
+    "example": 577,
+    "start_line": 8587,
+    "end_line": 8593,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](train.jpg)\n",
+    "html": "<p><img src=\"train.jpg\" alt=\"foo\" /></p>\n",
+    "example": 578,
+    "start_line": 8596,
+    "end_line": 8600,
+    "section": "Images"
+  },
+  {
+    "markdown": "My ![foo bar](/path/to/train.jpg  \"title\"   )\n",
+    "html": "<p>My <img src=\"/path/to/train.jpg\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 579,
+    "start_line": 8603,
+    "end_line": 8607,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo](<url>)\n",
+    "html": "<p><img src=\"url\" alt=\"foo\" /></p>\n",
+    "example": 580,
+    "start_line": 8610,
+    "end_line": 8614,
+    "section": "Images"
+  },
+  {
+    "markdown": "![](/url)\n",
+    "html": "<p><img src=\"/url\" alt=\"\" /></p>\n",
+    "example": 581,
+    "start_line": 8617,
+    "end_line": 8621,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[bar]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 582,
+    "start_line": 8626,
+    "end_line": 8632,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][bar]\n\n[BAR]: /url\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" /></p>\n",
+    "example": 583,
+    "start_line": 8635,
+    "end_line": 8641,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 584,
+    "start_line": 8646,
+    "end_line": 8652,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar][]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 585,
+    "start_line": 8655,
+    "end_line": 8661,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo][]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 586,
+    "start_line": 8666,
+    "end_line": 8672,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo] \n[]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" />\n[]</p>\n",
+    "example": 587,
+    "start_line": 8678,
+    "end_line": 8686,
+    "section": "Images"
+  },
+  {
+    "markdown": "![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo\" title=\"title\" /></p>\n",
+    "example": 588,
+    "start_line": 8691,
+    "end_line": 8697,
+    "section": "Images"
+  },
+  {
+    "markdown": "![*foo* bar]\n\n[*foo* bar]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"foo bar\" title=\"title\" /></p>\n",
+    "example": 589,
+    "start_line": 8700,
+    "end_line": 8706,
+    "section": "Images"
+  },
+  {
+    "markdown": "![[foo]]\n\n[[foo]]: /url \"title\"\n",
+    "html": "<p>![[foo]]</p>\n<p>[[foo]]: /url &quot;title&quot;</p>\n",
+    "example": 590,
+    "start_line": 8711,
+    "end_line": 8718,
+    "section": "Images"
+  },
+  {
+    "markdown": "![Foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p><img src=\"/url\" alt=\"Foo\" title=\"title\" /></p>\n",
+    "example": 591,
+    "start_line": 8723,
+    "end_line": 8729,
+    "section": "Images"
+  },
+  {
+    "markdown": "!\\[foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>![foo]</p>\n",
+    "example": 592,
+    "start_line": 8735,
+    "end_line": 8741,
+    "section": "Images"
+  },
+  {
+    "markdown": "\\![foo]\n\n[foo]: /url \"title\"\n",
+    "html": "<p>!<a href=\"/url\" title=\"title\">foo</a></p>\n",
+    "example": 593,
+    "start_line": 8747,
+    "end_line": 8753,
+    "section": "Images"
+  },
+  {
+    "markdown": "<http://foo.bar.baz>\n",
+    "html": "<p><a href=\"http://foo.bar.baz\">http://foo.bar.baz</a></p>\n",
+    "example": 594,
+    "start_line": 8780,
+    "end_line": 8784,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<https://foo.bar.baz/test?q=hello&id=22&boolean>\n",
+    "html": "<p><a href=\"https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean\">https://foo.bar.baz/test?q=hello&amp;id=22&amp;boolean</a></p>\n",
+    "example": 595,
+    "start_line": 8787,
+    "end_line": 8791,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<irc://foo.bar:2233/baz>\n",
+    "html": "<p><a href=\"irc://foo.bar:2233/baz\">irc://foo.bar:2233/baz</a></p>\n",
+    "example": 596,
+    "start_line": 8794,
+    "end_line": 8798,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<MAILTO:FOO@BAR.BAZ>\n",
+    "html": "<p><a href=\"MAILTO:FOO@BAR.BAZ\">MAILTO:FOO@BAR.BAZ</a></p>\n",
+    "example": 597,
+    "start_line": 8803,
+    "end_line": 8807,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<a+b+c:d>\n",
+    "html": "<p><a href=\"a+b+c:d\">a+b+c:d</a></p>\n",
+    "example": 598,
+    "start_line": 8815,
+    "end_line": 8819,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<made-up-scheme://foo,bar>\n",
+    "html": "<p><a href=\"made-up-scheme://foo,bar\">made-up-scheme://foo,bar</a></p>\n",
+    "example": 599,
+    "start_line": 8822,
+    "end_line": 8826,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<https://../>\n",
+    "html": "<p><a href=\"https://../\">https://../</a></p>\n",
+    "example": 600,
+    "start_line": 8829,
+    "end_line": 8833,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<localhost:5001/foo>\n",
+    "html": "<p><a href=\"localhost:5001/foo\">localhost:5001/foo</a></p>\n",
+    "example": 601,
+    "start_line": 8836,
+    "end_line": 8840,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<https://foo.bar/baz bim>\n",
+    "html": "<p>&lt;https://foo.bar/baz bim&gt;</p>\n",
+    "example": 602,
+    "start_line": 8845,
+    "end_line": 8849,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<https://example.com/\\[\\>\n",
+    "html": "<p><a href=\"https://example.com/%5C%5B%5C\">https://example.com/\\[\\</a></p>\n",
+    "example": 603,
+    "start_line": 8854,
+    "end_line": 8858,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo@bar.example.com>\n",
+    "html": "<p><a href=\"mailto:foo@bar.example.com\">foo@bar.example.com</a></p>\n",
+    "example": 604,
+    "start_line": 8876,
+    "end_line": 8880,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo+special@Bar.baz-bar0.com>\n",
+    "html": "<p><a href=\"mailto:foo+special@Bar.baz-bar0.com\">foo+special@Bar.baz-bar0.com</a></p>\n",
+    "example": 605,
+    "start_line": 8883,
+    "end_line": 8887,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo\\+@bar.example.com>\n",
+    "html": "<p>&lt;foo+@bar.example.com&gt;</p>\n",
+    "example": 606,
+    "start_line": 8892,
+    "end_line": 8896,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<>\n",
+    "html": "<p>&lt;&gt;</p>\n",
+    "example": 607,
+    "start_line": 8901,
+    "end_line": 8905,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "< https://foo.bar >\n",
+    "html": "<p>&lt; https://foo.bar &gt;</p>\n",
+    "example": 608,
+    "start_line": 8908,
+    "end_line": 8912,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<m:abc>\n",
+    "html": "<p>&lt;m:abc&gt;</p>\n",
+    "example": 609,
+    "start_line": 8915,
+    "end_line": 8919,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<foo.bar.baz>\n",
+    "html": "<p>&lt;foo.bar.baz&gt;</p>\n",
+    "example": 610,
+    "start_line": 8922,
+    "end_line": 8926,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "https://example.com\n",
+    "html": "<p>https://example.com</p>\n",
+    "example": 611,
+    "start_line": 8929,
+    "end_line": 8933,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "foo@bar.example.com\n",
+    "html": "<p>foo@bar.example.com</p>\n",
+    "example": 612,
+    "start_line": 8936,
+    "end_line": 8940,
+    "section": "Autolinks"
+  },
+  {
+    "markdown": "<a><bab><c2c>\n",
+    "html": "<p><a><bab><c2c></p>\n",
+    "example": 613,
+    "start_line": 9016,
+    "end_line": 9020,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a/><b2/>\n",
+    "html": "<p><a/><b2/></p>\n",
+    "example": 614,
+    "start_line": 9025,
+    "end_line": 9029,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a  /><b2\ndata=\"foo\" >\n",
+    "html": "<p><a  /><b2\ndata=\"foo\" ></p>\n",
+    "example": 615,
+    "start_line": 9034,
+    "end_line": 9040,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 />\n",
+    "html": "<p><a foo=\"bar\" bam = 'baz <em>\"</em>'\n_boolean zoop:33=zoop:33 /></p>\n",
+    "example": 616,
+    "start_line": 9045,
+    "end_line": 9051,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "Foo <responsive-image src=\"foo.jpg\" />\n",
+    "html": "<p>Foo <responsive-image src=\"foo.jpg\" /></p>\n",
+    "example": 617,
+    "start_line": 9056,
+    "end_line": 9060,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<33> <__>\n",
+    "html": "<p>&lt;33&gt; &lt;__&gt;</p>\n",
+    "example": 618,
+    "start_line": 9065,
+    "end_line": 9069,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a h*#ref=\"hi\">\n",
+    "html": "<p>&lt;a h*#ref=&quot;hi&quot;&gt;</p>\n",
+    "example": 619,
+    "start_line": 9074,
+    "end_line": 9078,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"hi'> <a href=hi'>\n",
+    "html": "<p>&lt;a href=&quot;hi'&gt; &lt;a href=hi'&gt;</p>\n",
+    "example": 620,
+    "start_line": 9083,
+    "end_line": 9087,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "< a><\nfoo><bar/ >\n<foo bar=baz\nbim!bop />\n",
+    "html": "<p>&lt; a&gt;&lt;\nfoo&gt;&lt;bar/ &gt;\n&lt;foo bar=baz\nbim!bop /&gt;</p>\n",
+    "example": 621,
+    "start_line": 9092,
+    "end_line": 9102,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href='bar'title=title>\n",
+    "html": "<p>&lt;a href='bar'title=title&gt;</p>\n",
+    "example": 622,
+    "start_line": 9107,
+    "end_line": 9111,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a></foo >\n",
+    "html": "<p></a></foo ></p>\n",
+    "example": 623,
+    "start_line": 9116,
+    "end_line": 9120,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "</a href=\"foo\">\n",
+    "html": "<p>&lt;/a href=&quot;foo&quot;&gt;</p>\n",
+    "example": 624,
+    "start_line": 9125,
+    "end_line": 9129,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!-- this is a --\ncomment - with hyphens -->\n",
+    "html": "<p>foo <!-- this is a --\ncomment - with hyphens --></p>\n",
+    "example": 625,
+    "start_line": 9134,
+    "end_line": 9140,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!--> foo -->\n\nfoo <!---> foo -->\n",
+    "html": "<p>foo <!--> foo --&gt;</p>\n<p>foo <!---> foo --&gt;</p>\n",
+    "example": 626,
+    "start_line": 9142,
+    "end_line": 9149,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <?php echo $a; ?>\n",
+    "html": "<p>foo <?php echo $a; ?></p>\n",
+    "example": 627,
+    "start_line": 9154,
+    "end_line": 9158,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <!ELEMENT br EMPTY>\n",
+    "html": "<p>foo <!ELEMENT br EMPTY></p>\n",
+    "example": 628,
+    "start_line": 9163,
+    "end_line": 9167,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <![CDATA[>&<]]>\n",
+    "html": "<p>foo <![CDATA[>&<]]></p>\n",
+    "example": 629,
+    "start_line": 9172,
+    "end_line": 9176,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"&ouml;\">\n",
+    "html": "<p>foo <a href=\"&ouml;\"></p>\n",
+    "example": 630,
+    "start_line": 9182,
+    "end_line": 9186,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo <a href=\"\\*\">\n",
+    "html": "<p>foo <a href=\"\\*\"></p>\n",
+    "example": 631,
+    "start_line": 9191,
+    "end_line": 9195,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "<a href=\"\\\"\">\n",
+    "html": "<p>&lt;a href=&quot;&quot;&quot;&gt;</p>\n",
+    "example": 632,
+    "start_line": 9198,
+    "end_line": 9202,
+    "section": "Raw HTML"
+  },
+  {
+    "markdown": "foo  \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 633,
+    "start_line": 9212,
+    "end_line": 9218,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 634,
+    "start_line": 9224,
+    "end_line": 9230,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo       \nbaz\n",
+    "html": "<p>foo<br />\nbaz</p>\n",
+    "example": 635,
+    "start_line": 9235,
+    "end_line": 9241,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 636,
+    "start_line": 9246,
+    "end_line": 9252,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n     bar\n",
+    "html": "<p>foo<br />\nbar</p>\n",
+    "example": 637,
+    "start_line": 9255,
+    "end_line": 9261,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo  \nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 638,
+    "start_line": 9267,
+    "end_line": 9273,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "*foo\\\nbar*\n",
+    "html": "<p><em>foo<br />\nbar</em></p>\n",
+    "example": 639,
+    "start_line": 9276,
+    "end_line": 9282,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code  \nspan`\n",
+    "html": "<p><code>code   span</code></p>\n",
+    "example": 640,
+    "start_line": 9287,
+    "end_line": 9292,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "`code\\\nspan`\n",
+    "html": "<p><code>code\\ span</code></p>\n",
+    "example": 641,
+    "start_line": 9295,
+    "end_line": 9300,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo  \nbar\">\n",
+    "html": "<p><a href=\"foo  \nbar\"></p>\n",
+    "example": 642,
+    "start_line": 9305,
+    "end_line": 9311,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "<a href=\"foo\\\nbar\">\n",
+    "html": "<p><a href=\"foo\\\nbar\"></p>\n",
+    "example": 643,
+    "start_line": 9314,
+    "end_line": 9320,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\\\n",
+    "html": "<p>foo\\</p>\n",
+    "example": 644,
+    "start_line": 9327,
+    "end_line": 9331,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo  \n",
+    "html": "<p>foo</p>\n",
+    "example": 645,
+    "start_line": 9334,
+    "end_line": 9338,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo\\\n",
+    "html": "<h3>foo\\</h3>\n",
+    "example": 646,
+    "start_line": 9341,
+    "end_line": 9345,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "### foo  \n",
+    "html": "<h3>foo</h3>\n",
+    "example": 647,
+    "start_line": 9348,
+    "end_line": 9352,
+    "section": "Hard line breaks"
+  },
+  {
+    "markdown": "foo\nbaz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 648,
+    "start_line": 9363,
+    "end_line": 9369,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "foo \n baz\n",
+    "html": "<p>foo\nbaz</p>\n",
+    "example": 649,
+    "start_line": 9375,
+    "end_line": 9381,
+    "section": "Soft line breaks"
+  },
+  {
+    "markdown": "hello $.;'there\n",
+    "html": "<p>hello $.;'there</p>\n",
+    "example": 650,
+    "start_line": 9395,
+    "end_line": 9399,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Foo χρῆν\n",
+    "html": "<p>Foo χρῆν</p>\n",
+    "example": 651,
+    "start_line": 9402,
+    "end_line": 9406,
+    "section": "Textual content"
+  },
+  {
+    "markdown": "Multiple     spaces\n",
+    "html": "<p>Multiple     spaces</p>\n",
+    "example": 652,
+    "start_line": 9411,
+    "end_line": 9415,
+    "section": "Textual content"
+  }
+]

--- a/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
+++ b/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
@@ -9,8 +9,6 @@ RSpec.describe YARD::Templates::Helpers::Markup::HybridMarkdown, 'CommonMark 0.3
   # strict CommonMark, especially around indentation-sensitive block parsing,
   # nested list continuation, and YARD's bare-URL autolinking behavior.
   INTENTIONAL_DIVERGENCE_EXAMPLES = [
-    276, 280,
-    312,
     611 # we intentionally auto-link bare URLs.
   ].freeze
 

--- a/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
+++ b/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'json'
+
+RSpec.describe YARD::Templates::Helpers::Markup::HybridMarkdown, 'CommonMark 0.31.2 examples' do
+  # This suite runs the full upstream CommonMark corpus as a conformance signal.
+  # HybridMarkdown is intentionally a hybrid parser, so some failures are
+  # expected where YARD/RDoc-compatible behavior deliberately diverges from
+  # strict CommonMark, especially around indentation-sensitive block parsing,
+  # nested list continuation, and YARD's bare-URL autolinking behavior.
+  INTENTIONAL_DIVERGENCE_EXAMPLES = [
+    2, 5, 6, 7, 9,
+    49, 57, 60,
+    70,
+    81, 82, 85, 87, 88, 93, 94, 95, 99, 100,
+    113, 115,
+    128,
+    223,
+    237, 238, 242, 249, 252,
+    276, 280, 300,
+    307, 311, 312, 313, 318, 319,
+    611,
+    636, 637
+  ].freeze
+
+  fixture_path = File.dirname(__FILE__) + '/fixtures/commonmark_0.31.2.json'
+  all_examples = JSON.parse(File.read(fixture_path), :symbolize_names => true)
+  examples = all_examples.reject { |example| INTENTIONAL_DIVERGENCE_EXAMPLES.include?(example[:example]) }
+
+  it 'vendors the full upstream CommonMark corpus' do
+    expect(all_examples.length).to eq(652)
+  end
+
+  it 'documents the expected hybrid-parser divergences from strict CommonMark' do
+    expect(all_examples.count { |example| INTENTIONAL_DIVERGENCE_EXAMPLES.include?(example[:example]) }).to eq(INTENTIONAL_DIVERGENCE_EXAMPLES.length)
+  end
+
+  examples.group_by { |example| example[:section] }.sort.each do |section, section_examples|
+    describe section do
+      section_examples.each do |example|
+        it "matches example #{example[:example]} from lines #{example[:start_line]}-#{example[:end_line]}" do
+          actual = described_class.new(example[:markdown]).to_html
+          expected = example[:html].sub(/\n\z/, '')
+          expect(actual).to eq(expected)
+        end
+      end
+    end
+  end
+end

--- a/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
+++ b/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
@@ -10,11 +10,9 @@ RSpec.describe YARD::Templates::Helpers::Markup::HybridMarkdown, 'CommonMark 0.3
   # nested list continuation, and YARD's bare-URL autolinking behavior.
   INTENTIONAL_DIVERGENCE_EXAMPLES = [
     2, 5, 6, 7, 9,
-    88,
     276, 280,
-    307, 312, 318, 319,
-    611,
-    637
+    312,
+    611 # we intentionally auto-link bare URLs.
   ].freeze
 
   fixture_path = File.dirname(__FILE__) + '/fixtures/commonmark_0.31.2.json'

--- a/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
+++ b/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe YARD::Templates::Helpers::Markup::HybridMarkdown, 'CommonMark 0.3
   # strict CommonMark, especially around indentation-sensitive block parsing,
   # nested list continuation, and YARD's bare-URL autolinking behavior.
   INTENTIONAL_DIVERGENCE_EXAMPLES = [
-    2, 5, 6, 7, 9,
     276, 280,
     312,
     611 # we intentionally auto-link bare URLs.

--- a/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
+++ b/spec/templates/helpers/markup/hybrid_markdown_commonmark_spec.rb
@@ -10,17 +10,11 @@ RSpec.describe YARD::Templates::Helpers::Markup::HybridMarkdown, 'CommonMark 0.3
   # nested list continuation, and YARD's bare-URL autolinking behavior.
   INTENTIONAL_DIVERGENCE_EXAMPLES = [
     2, 5, 6, 7, 9,
-    49, 57, 60,
-    70,
-    81, 82, 85, 87, 88, 93, 94, 95, 99, 100,
-    113, 115,
-    128,
-    223,
-    237, 238, 242, 249, 252,
-    276, 280, 300,
-    307, 311, 312, 313, 318, 319,
+    88,
+    276, 280,
+    307, 312, 318, 319,
     611,
-    636, 637
+    637
   ].freeze
 
   fixture_path = File.dirname(__FILE__) + '/fixtures/commonmark_0.31.2.json'

--- a/spec/templates/helpers/markup/hybrid_markdown_spec.rb
+++ b/spec/templates/helpers/markup/hybrid_markdown_spec.rb
@@ -159,6 +159,12 @@ HTML
       )
     end
 
+    it "does not open emphasis around unicode currency symbols" do
+      expect(described_class.new("*$*alpha.\n\n*£*bravo.\n\n*€*charlie.\n").to_html).to eq(
+        "<p>*$*alpha.</p>\n<p>*£*bravo.</p>\n<p>*€*charlie.</p>"
+      )
+    end
+
     it "preserves markdown code spans" do
       expect(to_html('Use `puts 1` here')).to eq('<p>Use <code>puts 1</code> here</p>')
     end

--- a/spec/templates/helpers/markup/hybrid_markdown_spec.rb
+++ b/spec/templates/helpers/markup/hybrid_markdown_spec.rb
@@ -1,0 +1,227 @@
+# frozen_string_literal: true
+
+RSpec.describe YARD::Templates::Helpers::Markup::HybridMarkdown do
+  def to_html(text)
+    described_class.new(text).to_html.gsub(/\r?\n/, '')
+  end
+
+  describe "markdown block syntax" do
+    it "renders ATX headings" do
+      expect(to_html("## Heading")).to eq('<h2>Heading</h2>')
+    end
+
+    it "renders setext headings" do
+      expect(to_html("Heading\n---")).to eq('<h2>Heading</h2>')
+      expect(to_html("Heading\n===")).to eq('<h1>Heading</h1>')
+    end
+
+    it "renders thematic breaks" do
+      expect(to_html("---")).to eq('<hr />')
+      expect(to_html("* * *")).to eq('<hr />')
+    end
+
+    it "renders fenced code blocks" do
+      expect(to_html("```ruby\nputs 1\n```")).to eq('<pre><code class="ruby">puts 1</code></pre>')
+    end
+
+    it "keeps yard link syntax and macro placeholders literal inside fenced code blocks" do
+      html = described_class.new(<<-'MARKDOWN').to_html
+```ruby
+# @deprecated Use {#my_new_method}
+# @return [${-1}] value
+```
+MARKDOWN
+      expect(html).to eq(<<-'HTML'.chomp)
+<pre><code class="ruby"># @deprecated Use {#my_new_method}
+# @return [${-1}] value
+</code></pre>
+HTML
+    end
+
+    it "renders indented code blocks" do
+      expect(to_html("    puts 1\n    puts 2\n")).to eq('<pre><code>puts 1puts 2</code></pre>')
+    end
+
+    it "treats two-space indentation as an indented code block after a blank line" do
+      expect(to_html("intro\n\n  puts 1\n  puts 2\n")).to eq('<p>intro</p><pre><code>puts 1puts 2</code></pre>')
+    end
+
+    it "does not treat two-space indentation as an indented code block without a blank line" do
+      expect(to_html("intro\n  puts 1\n  puts 2\n")).to eq('<p>introputs 1puts 2</p>')
+    end
+
+    it "treats !!!LANG as the code language for indented blocks" do
+      expect(described_class.new("intro\n\n  !!!ruby\n  puts 1\n").to_html).to eq(
+        '<p>intro</p>' + "\n" + '<pre><code class="ruby">puts 1' + "\n" + '</code></pre>'
+      )
+    end
+
+    it "treats indented comment examples as code before heading parsing" do
+      html = described_class.new(<<-'MARKDOWN').to_html
+    # @deprecated Use {#my_new_method} instead of this method because
+    #   it uses a library that is no longer supported in Ruby 1.9.
+    #   The new method accepts the same parameters.
+MARKDOWN
+      expect(html).to eq(<<-'HTML'.chomp)
+<pre><code># @deprecated Use {#my_new_method} instead of this method because
+#   it uses a library that is no longer supported in Ruby 1.9.
+#   The new method accepts the same parameters.
+</code></pre>
+HTML
+    end
+
+    it "renders unordered lists" do
+      html = described_class.new("- one\n- two\n").to_html
+      expect(html).to include('<ul>')
+      expect(html).to include('<li>one</li>')
+      expect(html).to include('<li>two</li>')
+    end
+
+    it "renders ordered lists" do
+      html = described_class.new("1. one\n2. two\n").to_html
+      expect(html).to include('<ol>')
+      expect(html).to include('<li>one</li>')
+      expect(html).to include('<li>two</li>')
+    end
+
+    it "renders blockquotes" do
+      html = described_class.new("> quoted\n>\n> text\n").to_html.gsub(/\r?\n/, '')
+      expect(html).to include('<blockquote>')
+      expect(html).to include('<p>quoted</p>')
+      expect(html).to include('<p>text</p>')
+    end
+
+    it "renders tables with alignment" do
+      html = described_class.new("| a | b |\n|:--|--:|\n| 1 | 2 |\n").to_html
+      expect(html).to include('<table>')
+      expect(html).to include('<th align="left">a</th>')
+      expect(html).to include('<th align="right">b</th>')
+      expect(html).to include('<td align="right">2</td>')
+    end
+
+    it "passes through block HTML" do
+      expect(described_class.new("<div>block</div>\n").to_html).to eq('<div>block</div>')
+    end
+  end
+
+  describe "markdown inline syntax" do
+    it "autolinks bare URLs using the full URL as the label" do
+      expect(to_html('https://example.com')).to eq(
+        '<p><a href="https://example.com">https://example.com</a></p>'
+      )
+    end
+
+    it "renders inline links" do
+      expect(to_html('[YARD](https://yardoc.org)')).to eq(
+        '<p><a href="https://yardoc.org">YARD</a></p>'
+      )
+    end
+
+    it "renders inline images" do
+      expect(to_html('![Alt](https://example.com/a.png "Title")')).to eq(
+        '<p><img src="https://example.com/a.png" alt="Alt" title="Title" /></p>'
+      )
+    end
+
+    it "renders full reference-style links" do
+      expect(described_class.new("[x][1]\n\n[1]: https://example.com\n").to_html).to eq(
+        '<p><a href="https://example.com">x</a></p>'
+      )
+    end
+
+    it "renders collapsed reference-style links" do
+      expect(described_class.new("[x]\n\n[x]: https://example.com\n").to_html).to eq(
+        '<p><a href="https://example.com">x</a></p>'
+      )
+    end
+
+    it "matches reference labels using unicode case folding for greek text" do
+      expect(described_class.new("[ΑΓΩ]: /φου\n\n[αγω]\n").to_html).to eq(
+        '<p><a href="/%CF%86%CE%BF%CF%85">αγω</a></p>'
+      )
+    end
+
+    it "matches reference labels using unicode case folding for sharp s" do
+      expect(described_class.new("[ẞ]\n\n[SS]: /url\n").to_html).to eq(
+        '<p><a href="/url">ẞ</a></p>'
+      )
+    end
+
+    it "renders reference-style images" do
+      expect(described_class.new("![x][logo]\n\n[logo]: https://example.com/logo.png\n").to_html).to eq(
+        '<p><img src="https://example.com/logo.png" alt="x" /></p>'
+      )
+    end
+
+    it "renders strong, emphasis, and strikethrough" do
+      expect(to_html('**bold** _em_ ~~gone~~')).to eq(
+        '<p><strong>bold</strong> <em>em</em> <del>gone</del></p>'
+      )
+    end
+
+    it "preserves markdown code spans" do
+      expect(to_html('Use `puts 1` here')).to eq('<p>Use <code>puts 1</code> here</p>')
+    end
+
+    it "preserves yard link syntax before any markdown parsing" do
+      expect(to_html('{MyClass#foo *not bold*}')).to eq('<p>{MyClass#foo *not bold*}</p>')
+      expect(to_html('{https://example.com label}')).to eq('<p>{https://example.com label}</p>')
+    end
+
+    it "supports hard line breaks" do
+      expect(described_class.new("one\\\ntwo").to_html).to eq("<p>one<br />\ntwo</p>")
+    end
+
+    it "supports markdown backslash escapes" do
+      expect(to_html('\*literal\* \> quote')).to eq('<p>*literal* &gt; quote</p>')
+    end
+
+    it "preserves HTML tags inline" do
+      expect(to_html('Hello <em>world</em>')).to eq('<p>Hello <em>world</em></p>')
+    end
+
+    it "preserves pre-escaped entities" do
+      expect(to_html('&amp; &#169;')).to eq('<p>&amp; ©</p>')
+    end
+
+    it "escapes HTML-sensitive characters in regular text" do
+      expect(to_html('2 < 3 & "quoted"')).to eq('<p>2 &lt; 3 &amp; &quot;quoted&quot;</p>')
+    end
+  end
+
+  describe "rdoc compatibility" do
+    it "renders rdoc headings" do
+      expect(to_html("== Heading")).to eq('<h2>Heading</h2>')
+    end
+
+    it "renders rdoc typewriter spans" do
+      expect(to_html('Hello +<code>+')).to eq('<p>Hello <code>&lt;code&gt;</code></p>')
+    end
+
+    it "renders rdoc labeled lists with double colons" do
+      html = described_class.new("cat:: feline\ndog:: canine\n").to_html
+      expect(html).to include('<dt>cat</dt>')
+      expect(html).to include('<dd><p>feline</p></dd>')
+    end
+
+    it "does not treat namespace paths using :: as labeled lists" do
+      expect(to_html('{YARD::Verifier}')).to eq('<p>{YARD::Verifier}</p>')
+      expect(to_html('See YARD::Verifier for details.')).to eq('<p>See YARD::Verifier for details.</p>')
+    end
+
+    it "renders alphabetic ordered lists used by rdoc" do
+      html = described_class.new("a. first\nb. second\n").to_html
+      expect(html).to include('<ol>')
+      expect(html).to include('<li>first</li>')
+      expect(html).to include('<li>second</li>')
+    end
+
+    it "treats two-space indented verbatim text as a code block" do
+      expect(to_html("Paragraph\n\n  x = 1\n")).to eq('<p>Paragraph</p><pre><code>x = 1</code></pre>')
+    end
+
+    it "treats hyphen rules as horizontal rules" do
+      expect(to_html("----")).to eq('<hr />')
+    end
+  end
+end

--- a/spec/templates/helpers/markup/hybrid_markdown_spec.rb
+++ b/spec/templates/helpers/markup/hybrid_markdown_spec.rb
@@ -226,6 +226,32 @@ HTML
       expect(to_html("Paragraph\n\n  x = 1\n")).to eq('<p>Paragraph</p><pre><code>x = 1</code></pre>')
     end
 
+    it "treats verbatim text inside nested lists relative to the list indentation" do
+      html = described_class.new("- outer\n  - inner\n\n      code\n").to_html
+      expect(html).to eq(<<-'HTML'.chomp)
+<ul>
+<li>outer
+<ul>
+<li>
+<p>inner</p>
+<pre><code>code
+</code></pre>
+</li>
+</ul>
+</li>
+</ul>
+HTML
+    end
+
+    it "does not treat insufficiently indented text after a list as a verbatim block" do
+      expect(described_class.new("-    foo\n\n  bar\n").to_html).to eq(<<-'HTML'.chomp)
+<ul>
+<li>foo</li>
+</ul>
+<p>bar</p>
+HTML
+    end
+
     it "treats hyphen rules as horizontal rules" do
       expect(to_html("----")).to eq('<hr />')
     end

--- a/spec/templates/helpers/markup_helper_spec.rb
+++ b/spec/templates/helpers/markup_helper_spec.rb
@@ -35,32 +35,32 @@ RSpec.describe YARD::Templates::Helpers::MarkupHelper do
       expect(@gen.markup_class).to eq nil
     end
 
-    it "loads RDocMarkup if rdoc is specified and it is installed" do
+    it "loads HybridMarkdown if rdoc is specified and it is installed" do
       @gen.options.markup = :rdoc
       expect(@gen.load_markup_provider).to be true
-      expect(@gen.markup_class).to eq YARD::Templates::Helpers::Markup::RDocMarkup
+      expect(@gen.markup_class).to eq YARD::Templates::Helpers::Markup::HybridMarkdown
     end
 
     it "fails if RDoc cannot be loaded" do
       @gen.options.markup = :rdoc
+      expect(@gen).to receive(:require).with('yard').and_return(false)
+      expect(@gen).to receive(:eval).with('::YARD::Templates::Helpers::Markup::HybridMarkdown').and_raise(NameError)
+      expect(@gen).to receive(:require).with('rdoc').and_return(true)
       expect(@gen).to receive(:eval).with('::YARD::Templates::Helpers::Markup::RDocMarkup').and_raise(NameError)
       expect(@gen.load_markup_provider).to be false
       expect(@gen.markup_provider).to eq nil
     end
 
-    it "searches through available markup providers for the markup type if none is set" do
-      expect(@gen).to receive(:eval).with('::RedcarpetCompat').and_return(double(:bluecloth))
-      expect(@gen).to receive(:require).with('redcarpet').and_return(true)
-      expect(@gen).not_to receive(:require).with('maruku')
+    it "loads the builtin markdown provider first when none is set" do
       @gen.options.markup = :markdown
-      # this only raises an exception because we mock out require to avoid
-      # loading any libraries but our implementation tries to return the library
-      # name as a constant
       expect(@gen.load_markup_provider).to be true
-      expect(@gen.markup_provider).to eq :redcarpet
+      expect(@gen.markup_class).to eq YARD::Templates::Helpers::Markup::HybridMarkdown
+      expect(@gen.markup_provider).to eq :yard
     end
 
     it "continues searching if some of the providers are unavailable" do
+      expect(@gen).to receive(:eval).with('::YARD::Templates::Helpers::Markup::HybridMarkdown').and_raise(NameError)
+      expect(@gen).to receive(:require).with('yard').and_return(false)
       expect(@gen).to receive(:require).with('redcarpet').and_raise(LoadError)
       expect(@gen).to receive(:require).with('rdiscount').and_raise(LoadError)
       expect(@gen).to receive(:require).with('kramdown').and_raise(LoadError)
@@ -85,7 +85,11 @@ RSpec.describe YARD::Templates::Helpers::MarkupHelper do
     end
 
     it "fails if no provider is found" do
+      expect(@gen).to receive(:require).with('yard').and_return(false)
+      expect(@gen).to receive(:eval).with('::YARD::Templates::Helpers::Markup::HybridMarkdown').and_raise(NameError)
       YARD::Templates::Helpers::MarkupHelper::MARKUP_PROVIDERS[:markdown].each do |p|
+        next unless p[:lib]
+        next if p[:lib] == :yard
         expect(@gen).to receive(:require).with(p[:lib].to_s).and_raise(LoadError)
       end
       @gen.options.markup = :markdown

--- a/spec/templates/markup_processor_integrations/markdown_spec.rb
+++ b/spec/templates/markup_processor_integrations/markdown_spec.rb
@@ -96,4 +96,38 @@ MARKDOWN
       expect(rendered_document).to include("commonmark line break with<br />\na backslash")
     end
   end
+
+  describe 'HybridMarkdown' do
+    let(:markup) { :markdown }
+    let(:markup_provider) { :yard }
+
+    include_examples 'shared examples for markdown processors'
+
+
+    it 'renders level 2 header' do
+      expect(rendered_document).to match(header_regexp(2, 'Example code listings'))
+    end
+
+    it 'renders indented block of code, and applies Ruby syntax highlight' do
+      expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '1'))
+    end
+
+    it 'renders fenced block of code, and applies Ruby syntax highlight' do
+      expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '2'))
+    end
+
+    it 'renders fenced and annotated block of Ruby code, and applies syntax highlight' do
+      expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '3'))
+    end
+
+    it 'renders fenced and annotated block of non-Ruby code, and does not apply syntax highlight' do
+      expect(rendered_document).to match('x = 4')
+    end
+
+    it "autolinks URLs" do
+      expect(html_renderer.htmlify('https://example.com', :markdown).chomp.gsub('&#47;', '/')).to eq(
+        '<p><a href="https://example.com">https://example.com</a></p>'
+      )
+    end
+  end
 end

--- a/spec/templates/markup_processor_integrations/rdoc_spec.rb
+++ b/spec/templates/markup_processor_integrations/rdoc_spec.rb
@@ -4,13 +4,11 @@ require File.dirname(__FILE__) + '/integration_spec_helper'
 
 RSpec.describe 'RDoc integration' do
   include_context 'shared helpers for markup processor integration specs'
-  let(:markup) { :rdoc }
-  # Must be nil as this is how this provider is defined.
-  # See: https://github.com/lsegal/yard/commit/6634ae25878cd4fcb79.
-  let(:markup_provider) { nil }
 
-  let(:document) do
-    <<-RDOC
+  shared_examples 'shared examples for rdoc processors' do
+    let(:markup) { :rdoc }
+    let(:document) do
+      <<-RDOC
 == Example code listings
 
 Verbatim block of Ruby code:
@@ -22,18 +20,29 @@ Verbatim non-Ruby block:
   This has nothing to do with Ruby.
 
 RDOC
+    end
+
+    it 'renders level 2 header' do
+      expect(rendered_document).to match(header_regexp(2, 'Example code listings'))
+    end
+
+    it 'renders indented block of code, and applies Ruby syntax highlight' do
+      expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '1'))
+    end
+
+    it 'renders indented block of text which is not a piece of Ruby code, ' \
+      'and does not apply syntax highlight' do
+      expect(rendered_document).to match('This has nothing to do with Ruby.')
+    end
   end
 
-  it 'renders level 2 header' do
-    expect(rendered_document).to match(header_regexp(2, 'Example code listings'))
+  describe 'HybridMarkdown' do
+    let(:markup_provider) { :yard }
+    include_examples 'shared examples for rdoc processors'
   end
 
-  it 'renders indented block of code, and applies Ruby syntax highlight' do
-    expect(rendered_document).to match(highlighted_ruby_regexp('x', '=', '1'))
-  end
-
-  it 'renders indented block of text which is not a piece of Ruby code, ' \
-    'and does not apply syntax highlight' do
-    expect(rendered_document).to match('This has nothing to do with Ruby.')
+  describe 'RDocMarkup' do
+    let(:markup_provider) { :rdoc }
+    include_examples 'shared examples for rdoc processors'
   end
 end


### PR DESCRIPTION
YARD now ships with a built-in Markdown renderer (`YARD::Templates::Helpers::Markup::HybridMarkdown`)
that requires **no external gems**. It supports a practical subset of GitHub Flavored Markdown (GFM)
as well as common RDoc markup forms, including:

- Headings (`#`, `=`)
- Fenced code blocks (`` ``` `` and `~~~`) as well as RDoc formatted `+text+` blocks.
- Tables, blockquotes, and thematic breaks
- Ordered and unordered lists (including RDoc-style)
- Inline emphasis, code, links, and images
- HTML passthrough blocks

This renderer is the **default** for both the `rdoc` and `markdown` markup types—no gem
installation required. If an optional provider gem (e.g. `redcarpet`, `kramdown`,
`commonmarker`) is installed and selected, YARD will use it instead for extra features such
as custom extensions or stricter spec compliance.