### PR TITLE
Add source_code_uri to gem metadata

### DIFF
--- a/yard.gemspec
+++ b/yard.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.8.7' if s.respond_to?(:required_ruby_version=)
   s.metadata['yard.run'] = 'yri'
   s.metadata['changelog_uri'] = 'https://rubydoc.info/gems/yard/file/CHANGELOG.md'
+  s.metadata['source_code_uri'] = 'https://github.com/lsegal/yard'
 end


### PR DESCRIPTION
# Description

Point the gem's metadata at the canonical GitHub repository so RubyGems links to the source code (as [documented here](https://guides.rubygems.org/specification-reference/)).

# Completed Tasks

- [X] I have read the [Contributing Guide][contrib].
- [X] The pull request is complete (implemented / written).
- [X] Git commits have been cleaned up (squash WIP / revert commits).
- [X] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
