### PR TITLE
Fix TypesExplainer folding trailing types into a preceding Hash{...}

### DIFF
--- a/lib/yard/tags/types_explainer.rb
+++ b/lib/yard/tags/types_explainer.rb
@@ -186,6 +186,7 @@ module YARD
               raise SyntaxError, "expecting name, got '#{token}'" if name.nil?
               type = create_type(name) unless type
               current_parsed_types << type
+              @terminator_token = token_type
               finished = true
             when :type_name
               raise SyntaxError, "expecting END, got name '#{token}'" if name
@@ -245,9 +246,12 @@ module YARD
             when :hash_collection_value
               # => - current keys map to the next value(s)
               raise SyntaxError, "no keys before =>" if current_keys.empty?
-              values = parse(until_tokens: [:hash_collection_value_end, :parse_end])
+              values = parse(until_tokens: [:hash_collection_value_end, :hash_collection_end, :parse_end])
               key_value_pairs << [current_keys, values]
               current_keys = []
+              # The value parse consumes its terminator_token. A closing '}' (or end of input)
+              # ends the hash; ';' continues to the next key group.
+              finished = true if @terminator_token == :hash_collection_end || @terminator_token == :parse_end
             when :hash_collection_end, :parse_end
               # End of hash
               finished = true

--- a/spec/tags/types_explainer_spec.rb
+++ b/spec/tags/types_explainer_spec.rb
@@ -213,6 +213,16 @@ RSpec.describe YARD::Tags::TypesExplainer do
       expect(type.map(&:name)).to eq ['false', 'true', 'nil', '4', ':foo']
     end
 
+    it "parses a type following a closed hash collection as a sibling" do
+      type = parse("Hash{Symbol => String}, nil")
+      expect(type.size).to eq 2
+      expect(type[0]).to be_a(YARD::Tags::TypesExplainer::HashCollectionType)
+      expect(type[0].key_types.map(&:name)).to eq ["Symbol"]
+      expect(type[0].value_types.map(&:name)).to eq ["String"]
+      expect(type[1]).to be_a(YARD::Tags::TypesExplainer::Type)
+      expect(type[1].name).to eq "nil"
+    end
+
     it "does not accept two commas in a row" do
       parse_fail "A,,B"
     end
@@ -255,7 +265,8 @@ RSpec.describe YARD::Tags::TypesExplainer do
         ":symbol, 'string'" => "a literal value :symbol; a literal value 'string'",
         "Hash{:key_one, :key_two => String; :key_three => Symbol}" => "a Hash with keys made of (a literal value :key_one or a literal value :key_two) and values of (Strings) and keys made of (a literal value :key_three) and values of (Symbols)",
         "Hash{:key_one, :key_two => String; :key_three => Symbol; :key_four => Hash{:sub_key_one => String}}" => "a Hash with keys made of (a literal value :key_one or a literal value :key_two) and values of (Strings) and keys made of (a literal value :key_three) and values of (Symbols) and keys made of (a literal value :key_four) and values of (a Hash with keys made of (a literal value :sub_key_one) and values of (Strings))",
-        "Hash{:key_one => String, Number; :key_two => String}" => "a Hash with keys made of (a literal value :key_one) and values of (Strings or Numbers) and keys made of (a literal value :key_two) and values of (Strings)"
+        "Hash{:key_one => String, Number; :key_two => String}" => "a Hash with keys made of (a literal value :key_one) and values of (Strings or Numbers) and keys made of (a literal value :key_two) and values of (Strings)",
+        "Hash{Symbol => String}, nil" => "a Hash with keys made of (Symbols) and values of (Strings); nil"
       }
       expect.each do |input, expected|
         explain = YARD::Tags::TypesExplainer.explain(input)


### PR DESCRIPTION
# Description

Fixes #1688.

`YARD::Tags::TypesExplainer::Parser.parse` absorbed types that follow a closed `Hash{...}` collection into that hash's value list, instead of treating them as sibling top-level types — diverging from `DocstringParser`, which splits the same text correctly:

```ruby
# Before
YARD::Tags::TypesExplainer::Parser.parse("Hash{Symbol => String}, nil").size # => 1 (wrong)
# After
YARD::Tags::TypesExplainer::Parser.parse("Hash{Symbol => String}, nil").size # => 2
YARD::DocstringParser.new.parse("@return [Hash{Symbol => String}, nil]").tags.first.types
# => ["Hash{Symbol => String}", "nil"]
```

This was a regression from #1630 (which moved hash parsing into its own nested loop).

## Root cause

In `parse_hash_collection`, the value sub-parse did **not** stop on the hash's closing `}` (`:hash_collection_end`). Since the main `parse` case statement also doesn't handle that token, the `}` was silently consumed and the value parse kept going, swallowing the trailing `, nil`. It only surfaced when a type followed the `}` — `Array<...>, nil` works because collection parsing is inlined in `parse` and returns control to the same loop, whereas the hash runs in its own nested loop.

## Fix

- Stop the value sub-parse on `:hash_collection_end` (in addition to `;` and end-of-input).
- Track the terminating token in `parse`; finish the hash when the value parse ended on `}` or end-of-input, returning control to the parent `parse` loop (which then reads the sibling `, nil`). A `;` terminator still continues to the next key group.

Multi-pair (`;`), nested-hash, and hash-as-last-type cases are unchanged (covered by existing specs). Added regression specs for the sibling-after-hash case.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran the suite locally (`bundle exec rspec spec/tags/ spec/docstring_parser_spec.rb` — 181 examples, 0 failures).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)