### PR TITLE
Fix HTML generation for RBS constants without values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add compatibility with RDoc 8
 - Fix TypesExplainer parsing of types following Hash collections (#1688)
+- Fix HTML generation for RBS constants without source values (#1686)
 
 # [0.9.44] - May 25th, 2026
 

--- a/lib/yard/templates/helpers/method_helper.rb
+++ b/lib/yard/templates/helpers/method_helper.rb
@@ -66,6 +66,8 @@ module YARD
 
       # @return [String] formats source code of a constant value
       def format_constant(value)
+        return "" unless value
+
         # last can return nil, so default to empty string
         sp = value.split("\n").last || ""
         sp = sp[/^(\s+)/, 1]

--- a/spec/templates/helpers/method_helper_spec.rb
+++ b/spec/templates/helpers/method_helper_spec.rb
@@ -115,5 +115,11 @@ RSpec.describe YARD::Templates::Helpers::MethodHelper do
         expect(format_constant("")).to eq ""
       end
     end
+
+    context "when nil is passed as param" do
+      it "returns an empty string" do
+        expect(format_constant(nil)).to eq ""
+      end
+    end
   end
 end


### PR DESCRIPTION
## Root cause

RBS constant declarations define a type but do not include a Ruby source value. The default HTML constant summary passed that legitimate `nil` value to `format_constant`, which called `split` unconditionally and aborted generation of the containing class page.

## Change

- Return an empty formatted value when a constant has no source expression.
- Add a focused regression example for a `nil` constant value.
- Document the fix in the current changelog section.

## User impact

HTML documentation for classes containing RBS constant declarations is generated normally, with the constant listed and no fabricated source value.

## Testing

- Reproduced the missing `Foo.html` with `BAR: untyped` before the fix.
- Verified the same command creates `Foo.html` and includes `BAR` after the fix.
- `bundle exec rspec spec/templates/helpers/method_helper_spec.rb` (11 examples, 0 failures)
- `bundle exec rake` (2,785 examples, 0 failures; documentation build passed)

## Completed tasks

- [x] I have read the contributing guide.
- [x] The pull request is complete.
- [x] Git commits are clean.
- [x] I wrote tests and ran `bundle exec rake` locally.

Closes #1686