### PR TITLE
Fix HTML generation for RBS constants without values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add compatibility with RDoc 8
 - Fix TypesExplainer parsing of types following Hash collections (#1688)
+- Fix HTML generation for RBS constants without source values (#1686)
 
 # [0.9.44] - May 25th, 2026
 

--- a/lib/yard/templates/helpers/method_helper.rb
+++ b/lib/yard/templates/helpers/method_helper.rb
@@ -64,8 +64,11 @@ module YARD
         end.join("\n")
       end
 
+      # @param [String, nil] value the source code of a constant value
       # @return [String] formats source code of a constant value
       def format_constant(value)
+        return "" if value.nil?
+
         # last can return nil, so default to empty string
         sp = value.split("\n").last || ""
         sp = sp[/^(\s+)/, 1]

--- a/spec/templates/helpers/method_helper_spec.rb
+++ b/spec/templates/helpers/method_helper_spec.rb
@@ -115,5 +115,11 @@ RSpec.describe YARD::Templates::Helpers::MethodHelper do
         expect(format_constant("")).to eq ""
       end
     end
+
+    context "when nil is passed as param" do
+      it "returns an empty string" do
+        expect(format_constant(nil)).to eq ""
+      end
+    end
   end
 end

--- a/spec/templates/module_spec.rb
+++ b/spec/templates/module_spec.rb
@@ -201,6 +201,19 @@ RSpec.describe YARD::Templates::Engine.template(:default, :module) do
     html_equals(Registry.at('A').format(html_options), :module005)
   end
 
+  it "renders RBS constants without source values in html" do
+    Registry.clear
+    YARD::Parser::SourceParser.parse_string <<-'RBS', :rbs
+class Foo
+  BAR: untyped
+end
+    RBS
+
+    html = Registry.at('Foo').format(html_options)
+    expect(html).to include('id="BAR-constant"')
+    expect(html).to include('<pre class="code"></pre>')
+  end
+
   it "shows inherited methods from matching groups in the group section, not in flat inherited section" do
     Registry.clear
     YARD.parse_string <<-'eof'


### PR DESCRIPTION
# Description

Fixes #1686.

RBS constant declarations carry a type but no Ruby source value. Render a missing constant value as empty content so the default module template can generate the class page instead of raising `NoMethodError`.

This includes direct helper coverage, a template-level RBS regression, and the main changelog entry.

# Validation

- `bundle exec rspec spec/handlers/rbs/constant_handler_spec.rb spec/templates/helpers/method_helper_spec.rb spec/templates/module_spec.rb` — 26 examples, 0 failures
- `bundle exec rake` — 2,786 examples, 0 failures; documentation check passed
- Exact CLI reproduction generated `Foo.html` with `BAR` and an empty source-value block
- `npx --yes @biomejs/biome format` — passed
- `npx --yes @biomejs/biome lint` — passed with four existing warnings in unchanged JavaScript files
- Ruby syntax checks and `git diff --check` — passed

# Completed Tasks

- [x] I have read the Contributing Guide.
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).
