### PR TITLE
Fix parser method redefinition warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Add compatibility with RDoc 8
 - Fix TypesExplainer parsing of types following Hash collections (#1688)
+- Fix method redefinition warnings when loading YARD with Ruby warnings enabled (#1687)
 
 # [0.9.44] - May 25th, 2026
 

--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -379,6 +379,7 @@ module YARD
         # entries from corrupting source ranges of later hash literals and brace blocks.
         # Bare hash patterns (key: val without braces) fire no brace scanner events, so
         # we only clean up when @map[:rbrace] confirms a closing brace was scanned.
+        begin; undef on_hshptn; rescue NameError; end
         def on_hshptn(*args)
           if (@map[:rbrace] ||= []).any?
             (@map[:lbrace] ||= []).pop
@@ -443,6 +444,7 @@ module YARD
         # on_rbracket scanner events. The corresponding parser events are on_aryptn/on_fndptn
         # (not on_aref), so we must clean up the bracket maps to prevent stale entries from
         # corrupting source ranges of later array indexing expressions.
+        begin; undef on_aryptn; rescue NameError; end
         def on_aryptn(*args)
           (@map[:lbracket] ||= []).pop
           (@map[:aref] ||= []).shift
@@ -451,6 +453,7 @@ module YARD
           AstNode.new(:aryptn, args)
         end
 
+        begin; undef on_fndptn; rescue NameError; end
         def on_fndptn(*args)
           (@map[:lbracket] ||= []).pop
           (@map[:aref] ||= []).shift

--- a/spec/parser/ruby/ruby_parser_spec.rb
+++ b/spec/parser/ruby/ruby_parser_spec.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+require 'open3'
 
 RSpec.describe YARD::Parser::Ruby::RubyParser do
   def stmt(stmt)
@@ -11,6 +12,15 @@ RSpec.describe YARD::Parser::Ruby::RubyParser do
 
   def tokenize(stmt)
     YARD::Parser::Ruby::RubyParser.new(stmt, nil).parse.tokens
+  end
+
+  it "loads without redefining parser event methods" do
+    _stdout, stderr, status = Open3.capture3(
+      RbConfig.ruby, '-w', "-I#{YARD::ROOT}", '-e', "require 'yard'"
+    )
+
+    expect(status).to be_success
+    expect(stderr).not_to include('method redefined')
   end
 
   describe "#parse" do


### PR DESCRIPTION
## Summary

Ruby 4.0 warns when YARD loads because Ripper's parser event table generates default handlers for `on_hshptn`, `on_aryptn`, and `on_fndptn` before YARD replaces them with specialized pattern-matching handlers.

This change explicitly undefines each generated callback before defining its specialized implementation. Pattern-matching behavior remains unchanged, while loading YARD with Ruby warnings enabled no longer emits method-redefinition warnings.

The unreleased changelog now records the fix, and a subprocess regression spec loads YARD under `ruby -w` and verifies both a successful load and the absence of method-redefinition warnings.

## Tests

- `bundle exec rspec spec/parser/ruby/ruby_parser_spec.rb` (100 examples, 0 failures)
- `bundle exec rake` (2,785 examples, 0 failures; documentation generation passed)
- `ruby -w -Ilib -e "require 'yard'; YARD.parse"` (no parser method-redefinition warnings)

Closes #1687
