### PR TITLE
Fix duplicate "View source" links after client-side navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+- Fix duplicate "View source" links after client-side navigation in default HTML template
+
 # [0.9.45] - July 14th, 2026
 
 [0.9.45]: https://github.com/lsegal/yard/compare/v0.9.44...v0.9.45

--- a/templates/default/fulldoc/html/js/app.js
+++ b/templates/default/fulldoc/html/js/app.js
@@ -144,6 +144,9 @@
 
 	function createSourceLinks() {
 		queryAll(".method_details_list .source_code").forEach((sourceCode) => {
+			if (sourceCode.previousElementSibling?.classList.contains("showSource"))
+				return;
+
 			const toggleWrapper = document.createElement("span");
 			const link = document.createElement("a");
 


### PR DESCRIPTION
createSourceLinks() adds a [ View source ] toggle in front of every
.source_code table, but never checks if one's already there. The default
template's instant-nav feature (since 0.9.38) reruns the whole
window.__app() setup — including createSourceLinks() — every time it
swaps new content into #main, and if that fires without #main actually
being replaced first, you get two toggles per source block instead of
one.

I hit this on a site that serves YARD's static HTML output directly, with
no `yard server` in front — that reinit path ends up being the only
navigation mechanism in play there. Confirmed it with a small jsdom test:
loading a page once gives the expected one toggle per source_code table,
and calling window.__app() a second time without touching #main doubles
them.

Fix is a one-line guard: skip a source_code table if its previous sibling
already has the showSource class.