### PR TITLE
Add intersection ("A & B") and union ("A | B" / "[A | B]") type syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # main
 
+- Add support for intersection (`Foo & Bar`) types: a value must satisfy
+  every type listed, rather than any one of them, reading as "both a Foo
+  and a Bar" (or "all of a Foo, a Bar, and a Baz" for 3+) to avoid reading
+  like two separate values (closes #1644)
+- Add `|` as a union operator (`Foo | Bar` means an object that's either a
+  Foo or a Bar). Type lists that already mean a union - the top level, a
+  hash's key/value lists, `Array<...>`/`Set<...>` - read `,` and `|` the
+  same way; elsewhere, where a comma-separated list means distinct type
+  parameters or tuple slots (`Array(...)`, or `<...>` for a name other
+  than `Array`/`Set`), `|` groups a union within a single one of them
+  (closes #1699)
+- Add `[...]`, used the same way parentheses are in algebra: to override
+  the default order of operations, e.g. to use a union as one conjunct of
+  an intersection (closes #1699)
+- Document the existing anonymous `<A>`, `(A)`, and `{A=>B}` shorthand forms
+- Stop assuming `Foo<A, B>` always means "A or B": only `Array`/`Set` (known
+  homogeneous collections) keep that implicit-union reading; any other
+  name with 2+ type parameters now reads neutrally as "with type
+  parameters (A, B)", since `<...>` is also conventionally used for a
+  class's distinct type parameters (e.g. `Result<Success, Failure>`).
+  `Hash<KeyType, ValueType>` gets its own dedicated positional rendering,
+  matching `Hash{KeyType=>ValueType}`
 - Fix duplicate "View source" links after client-side navigation in default HTML template
 
 # [0.9.45] - July 14th, 2026

--- a/docs/Tags.md
+++ b/docs/Tags.md
@@ -169,18 +169,29 @@ Note that one extra type that is accepted by convention is the `Boolean` type,
 which represents both the `TrueClass` and `FalseClass` types. This type does not
 exist in Ruby, however.
 
-#### Parametrized Types
+#### Parameterized Types
 
 In addition to basic types (like String or Array), YARD conventions allow for
-a "generics" like syntax to specify container objects or other parametrized types.
+a "generics" like syntax to specify container objects or other parameterized types.
 The syntax is `Type<SubType, OtherSubType, ...>`. For instance, an Array might
 contain only String objects, in which case the type specification would be
-`Array<String>`. Multiple parametrized types can be listed, separated by commas.
+`Array<String>`. Multiple type parameters can be listed, separated by commas:
+`Array<String, Fixnum>` can contain any amount of Strings or Fixnums, in any
+order - `Array` and `Set` both treat their type parameters as an implicit
+union, meaning "any of these".
 
-Note that parametrized types are typically not order-dependent, in other words,
-a list of parametrized types can occur in any order inside of a type. An array
-specified as `Array<String, Fixnum>` can contain any amount of Strings or Fixnums,
-in any order. When the order matters, use "order-dependent lists", described below.
+The type name before `<...>` can be omitted, in which case it defaults to
+`Array`: `<String, Fixnum>` means the same thing as `Array<String, Fixnum>`.
+
+Not every type uses its parameters this way, though: `Result<Success, Failure>`
+uses `Success` and `Failure` as two distinct type parameters, not "either of
+these". A type with a single parameter is unambiguous either way. For a name
+that isn't specifically known to mean a union, YARD describes its
+parameters neutrally, without asserting either reading:
+`Result<Success, Failure>` reads as "a Result with type parameters (a
+Success, a Failure)". `Hash<KeyType, ValueType>` is a special case with its
+own dedicated positional rendering (slot 1 is the key type, slot 2 is the
+value type), matching the `Hash{KeyType=>ValueType}` syntax described below.
 
 #### Duck-Types
 
@@ -194,9 +205,24 @@ that responds to the "read" method:
     # @param io [#read] the input object to read from
     def read(io) io.read end
 
+#### Intersection Types
+
+Types joined with `&` describe an intersection: a value that satisfies every
+type listed, rather than any one of them (which is what a union - the `|`
+operator - already means). For instance, an argument that must both
+inherit from `Foo` and respond to `#bar` would be listed as `Foo & #bar`.
+
+    # Accepts any Comparable string.
+    # @param value [String & Comparable] the value to accept
+    def accept(value) end
+
+`&` is legal in every position a type can appear, and always binds tighter
+than any union or slot separator around it - see
+[Operator Precedence](#Operator_Precedence) below.
+
 #### Hashes
 
-Hashes can be specified either via the parametrized type discussed above,
+Hashes can be specified either via the parameterized type discussed above,
 in the form `Hash<KeyType, ValueType>`, or using the hash specific syntax:
 `Hash{KeyTypes=>ValueTypes}`. In the latter case, KeyTypes or ValueTypes can
 also be a list of types separated by commas.
@@ -222,12 +248,73 @@ Keys in the hash-specific syntax are commonly [literal values](#Literals) such
 as symbols (`:key`) or strings (`'key'`, `"key"`), but any type listed in the
 [type conventions](#Type_List_Conventions) is allowed.
 
+The type name before `{...}` can be omitted, in which case it defaults to
+`Hash`: `{K=>V}` means the same thing as `Hash{K=>V}`.
+
 #### Order-Dependent Lists
 
 An order dependent list is a set of types surrounded by "()" and separated by
 commas. This list must contain exactly those types in exactly the order specified.
 For instance, an Array containing a String, Fixnum and Hash in that order (and
 having exactly those 3 elements) would be listed as: `Array(String, Fixnum, Hash)`.
+
+The type name before `(...)` can be omitted, in which case it defaults to
+`Array`: `(String, Fixnum, Hash)` means the same thing as
+`Array(String, Fixnum, Hash)`.
+
+A single slot can itself be a union: `Array(Integer | String, Symbol)` is a
+2-element Array whose first element is an Integer or a String - see
+[Union Operator](#Union_Operator) below.
+
+#### Union Operator
+
+`|` marks a union: a value matching any of the listed types.
+`Integer | String` means an Integer or a String.
+
+Some type lists already mean a union without `|` - a plain comma-separated
+list at the top level, a hash's key or value list, inside `[...]`
+(described below), and inside `Array<...>`/`Set<...>`. In those places `,`
+and `|` come to the same thing, so use whichever reads better:
+`Integer, String` and `Integer | String` describe the same type.
+
+Elsewhere, each comma-separated item is a distinct, positional type
+parameter instead - a fixed-order list like `Array(...)`, or `<...>` for a
+type other than `Array`/`Set` (see
+[Parameterized Types](#Parameterized_Types) above). There, use `|` within a
+single item to say it can be any of several types:
+`Array(Integer | String, Symbol)` is a 2-element Array whose first element
+is an Integer or a String, and `Result<Success | Failure, Other>` is a
+Result whose first type parameter is a Success or a Failure.
+
+#### Operator Precedence
+
+`&`, `,`, and `|` can all appear in the same type, and `&` always binds
+tighter than the union or slot separator around it: `Foo & Bar, Baz` means
+either both a Foo and a Bar, or a Baz - not `Foo`, unioned with `Bar & Baz`.
+
+#### Overriding the Order of Operations
+
+Square brackets `[...]` are used the same way parentheses are in algebra:
+to override the order of operations described above. Types inside `[...]`
+are combined first; hence `[Foo | Bar] & Baz` describes a value that's
+either a Foo or a Bar, and also a Baz - not `Foo`, unioned with
+`Bar & Baz`. Without the brackets, `&` binds tighter than the union
+around it, so `Foo | Bar & Baz` means the latter.
+
+Inside `[...]`, `,` and `|` both mean a union, so `[Foo, Bar]` and
+`[Foo | Bar]` describe the same type.
+
+<p class="note">
+  While you can treat them the same in practice, this <code>[...]</code> is
+  not the same thing as the <code>[Types]</code> brackets that delimit a
+  tag's whole <a href="#Types_Specifier_List">types specifier list</a> -
+  that outer bracket is tag punctuation, not part of any individual type.
+</p>
+
+`[...]` never takes a preceding type name - `[Integer | String]` alone
+just means "an Integer or a String," identical in meaning to the plain
+top-level list `Integer, String`, just usable in more places. It can nest
+inside itself (`[[Foo | Bar] | Baz]`).
 
 #### Literals
 

--- a/lib/yard/tags/types_explainer.rb
+++ b/lib/yard/tags/types_explainer.rb
@@ -35,7 +35,7 @@ module YARD
 
         def to_s(singular = true)
           if name[0, 1] =~ /[A-Z]/
-            singular ? "a#{name[0, 1] =~ /[aeiou]/i ? 'n' : ''} " + name : "#{name}#{name[-1, 1] =~ /[A-Z]/ ? "'" : ''}s"
+            singular ? "#{indefinite_article(name)} " + name : "#{name}#{name[-1, 1] =~ /[A-Z]/ ? "'" : ''}s"
           else
             name
           end
@@ -52,6 +52,11 @@ module YARD
             index += 1
             acc
           end
+        end
+
+        # @return ["a", "an"] whichever indefinite article precedes `word`
+        def indefinite_article(word)
+          word[0, 1] =~ /[aeiou]/i ? "an" : "a"
         end
       end
 
@@ -70,8 +75,71 @@ module YARD
       end
 
       # @private
+      class IntersectionType < Type
+        attr_accessor :types
+
+        def initialize(types)
+          @types = types
+        end
+
+        def to_s(singular = true)
+          # A leading "both"/"all of" disambiguates a single value
+          # satisfying every listed type from what "a Foo and a Bar" alone
+          # could otherwise read as - two separate things.
+          prefix = types.size == 2 ? "both " : "all of "
+          prefix + list_join(types.map {|t| t.to_s(singular) }, with: "and")
+        end
+      end
+
+      # @private
+      class GroupType < Type
+        attr_accessor :types
+
+        def initialize(types)
+          @types = types
+        end
+
+        def to_s(singular = true)
+          "(" + list_join(types.map {|t| disambiguate(t, singular) }) + ")"
+        end
+
+        private
+
+        # {IntersectionType} and a multi-method {DuckType} (`#foo & #bar`)
+        # both render as a bare "X and Y", with no punctuation of their own
+        # to mark where they end. Sitting next to a sibling in this group's
+        # own "or"-joined list, that reads ambiguously (e.g. "a Foo and a
+        # Bar or a Baz" doesn't show whether the "and" or the "or" binds
+        # tighter) even though the parse itself is unambiguous. Wrap those
+        # two cases in their own parens so the group's members are visually
+        # self-delimiting; every other {Type} already is (a bare name, or
+        # something with its own bracketing like {GroupType} itself).
+        def disambiguate(type, singular)
+          rendered = type.to_s(singular)
+          needs_parens = type.is_a?(IntersectionType) ||
+                         (type.is_a?(DuckType) && type.name.include?('&'))
+          needs_parens ? "(#{rendered})" : rendered
+        end
+      end
+
+      # @private
+      #
+      # `<...>`'s type parameters are conventionally used two ways - as a
+      # homogeneous collection's implicit union of element type(s), or as
+      # a class's distinct, positional type parameters, e.g.
+      # `Result<Success, Failure>` - and this class renders either way,
+      # chosen per instance by {#union?}. This keeps that choice entirely
+      # out of the parser: every `<...>` becomes one of these, regardless
+      # of name.
       class CollectionType < Type
         attr_accessor :types
+
+        # Type names known in advance to be genuinely homogeneous
+        # collections, where `<...>`'s type parameters really do mean
+        # "any one of these". Fixed and not user-configurable - YARD has
+        # no syntax for a class to declare its own `<...>` convention, so
+        # this can only ever be a hardcoded, conservative list.
+        UNION_COLLECTION_NAMES = %w[Array Set].freeze
 
         def initialize(name, types)
           @name = name
@@ -79,14 +147,39 @@ module YARD
         end
 
         def to_s(_singular = true)
-          "a#{name[0, 1] =~ /[aeiou]/i ? 'n' : ''} #{name} of (" + list_join(types.map {|t| t.to_s(false) }) + ")"
+          if union?
+            "#{indefinite_article(name)} #{name} of (" + list_join(flattened_types.map {|t| t.to_s(false) }) + ")"
+          else
+            "#{indefinite_article(name)} #{name} with type parameters (" +
+              types.map {|t| t.to_s(true) }.join(", ") + ")"
+          end
+        end
+
+        private
+
+        # A single type parameter is never ambiguous (there's nothing to
+        # distinguish a union from a positional type parameter when
+        # there's only one), so it's read as a union regardless of name;
+        # otherwise, only the known homogeneous-collection names are.
+        def union?
+          types.size <= 1 || UNION_COLLECTION_NAMES.include?(name)
+        end
+
+        # A parsed type parameter that's itself a union (from `Foo | Bar`
+        # in e.g. `Array<Foo | Bar, Baz>`) is a {GroupType}. Since this
+        # whole parameter list is already read as one flat union, absorb
+        # such a parameter's own members into that same list instead of
+        # rendering it as a nested, parenthesized sub-union - the two mean
+        # the same thing here.
+        def flattened_types
+          types.flat_map {|t| t.is_a?(GroupType) ? t.types : [t] }
         end
       end
 
       # @private
       class FixedCollectionType < CollectionType
         def to_s(_singular = true)
-          "a#{name[0, 1] =~ /[aeiou]/i ? 'n' : ''} #{name} containing (" + types.map(&:to_s).join(" followed by ") + ")"
+          "#{indefinite_article(name)} #{name} containing (" + types.map(&:to_s).join(" followed by ") + ")"
         end
       end
 
@@ -134,9 +227,9 @@ module YARD
         end
 
         def to_s(_singular = true)
-          return "a#{name[0, 1] =~ /[aeiou]/i ? 'n' : ''} #{name}" if @key_value_pairs.empty?
+          return "#{indefinite_article(name)} #{name}" if @key_value_pairs.empty?
 
-          result = "a#{name[0, 1] =~ /[aeiou]/i ? 'n' : ''} #{name} with "
+          result = "#{indefinite_article(name)} #{name} with "
           parts = @key_value_pairs.map do |keys, values|
             "keys made of (" + list_join(keys.map {|t| t.to_s(false) }) +
             ") and values of (" + list_join(values.map {|t| t.to_s(false) }) + ")"
@@ -154,9 +247,13 @@ module YARD
           :collection_end => />/,
           :fixed_collection_start => /\(/,
           :fixed_collection_end => /\)/,
+          :group_start => /\[/,
+          :group_end => /\]/,
           :type_name => /#{ISEP}#{METHODNAMEMATCH}|#{NAMESPACEMATCH}|#{LITERALMATCH}|\w+/,
           :symbol => /:#{METHODNAMEMATCH}/,
           :type_next => /[,]/,
+          :intersect => /&/,
+          :union => /\|/,
           :whitespace => /\s+/,
           :hash_collection_start => /\{/,
           :hash_collection_value => /=>/,
@@ -181,34 +278,115 @@ module YARD
 
         private
 
-        def parse_until(until_tokens)
+        # @param slot_pipe [Boolean] whether `,` separates positional type
+        #   parameters/slots (a fixed tuple's `(...)`, or a parameterized
+        #   type's `<...>`), in which case a bare `|` groups alternatives
+        #   within a single one of them instead of adding another
+        #   top-level item. False for containers whose whole
+        #   comma-separated list already means "any of these" (the top
+        #   level, `{...}`, and `[...]`) - there, `,` and `|` both just add
+        #   another alternative to that same list.
+        #
+        # `&` (intersection) is legal anywhere a type is expected (it never
+        #   needs this distinction), accumulated via
+        #   `intersection_conjuncts`/{#finish_intersection}, and always
+        #   binds tighter than whichever separator is active: `A & B, C` is
+        #   `(A & B), C` everywhere, and `Array(A & B | C, D)` is
+        #   `Array((A & B) | C, D)` - a 2-slot tuple whose first slot is
+        #   `(A & B) or C`.
+        #
+        # `[...]` groups a union (spelled with either `,` or `|`) into a
+        #   single type usable as one conjunct of an intersection at the
+        #   top level, where a bare union would otherwise just add another
+        #   independent top-level item instead: `[A | B] & C` groups `A`
+        #   and `B` before intersecting with `C`, where `A | B & C` would
+        #   parse as the two top-level items `A` and `B & C`.
+        # @return [Array(Array<Type>, Symbol)] the parsed types and the
+        #   token that ended the list
+        def parse_until(until_tokens, slot_pipe: false)
           current_parsed_types = []
           type = nil
           name = nil
           finished = false
           end_token = nil
+          intersection_conjuncts = []
+          slot_conjuncts = []
           types = parse_with_handlers do |token_type, token|
             case token_type
             when *until_tokens
               raise SyntaxError, "expecting name, got '#{token}'" if name.nil?
               type = create_type(name) unless type
-              current_parsed_types << type
+              slot = finish_intersection(intersection_conjuncts, type)
+              slot = finish_group(slot_conjuncts, slot) if slot_pipe
+              current_parsed_types << slot
+              intersection_conjuncts = []
+              slot_conjuncts = []
               finished = true
               end_token = token_type
             when :type_name
               raise SyntaxError, "expecting END, got name '#{token}'" if name
               name = token
+            when :intersect
+              raise SyntaxError, "expecting name, got '&' at #{@scanner.pos}" if name.nil?
+              type = create_type(name) unless type
+              intersection_conjuncts << type
+              name = nil
+              type = nil
             when :type_next
               raise SyntaxError, "expecting name, got '#{token}' at #{@scanner.pos}" if name.nil?
               type = create_type(name) unless type
-              current_parsed_types << type
+              slot = finish_intersection(intersection_conjuncts, type)
+              slot = finish_group(slot_conjuncts, slot) if slot_pipe
+              current_parsed_types << slot
+              intersection_conjuncts = []
+              slot_conjuncts = []
+              name = nil
+              type = nil
+            when :union
+              raise SyntaxError, "expecting name, got '|' at #{@scanner.pos}" if name.nil?
+              type = create_type(name) unless type
+              combined = finish_intersection(intersection_conjuncts, type)
+              intersection_conjuncts = []
+              if slot_pipe
+                slot_conjuncts << combined
+              else
+                current_parsed_types << combined
+              end
               name = nil
               type = nil
             when :fixed_collection_start, :collection_start
+              is_fixed = token_type == :fixed_collection_start
               name ||= "Array"
-              klass = token_type == :collection_start ? CollectionType : FixedCollectionType
-              nested_types, = parse_until([:fixed_collection_end, :collection_end, :parse_end])
-              type = klass.new(name, nested_types)
+              # Both a fixed tuple's `(...)` and a parameterized type's
+              # `<...>` treat `,` as separating positional type parameters,
+              # and a bare `|` as grouping alternatives within just one of
+              # them (`finish_group`) - parsing doesn't need to know
+              # whether `name` means an implicit union. Whether a name's
+              # type parameters get described as a union (Array, Set) or
+              # neutrally (everything else) is purely a rendering choice,
+              # made below.
+              nested_types, = parse_until(
+                [:fixed_collection_end, :collection_end, :parse_end], slot_pipe: true
+              )
+              type = if is_fixed
+                FixedCollectionType.new(name, nested_types)
+              elsif name == "Hash" && nested_types.size == 2
+                # `Hash<KeyType, ValueType>` is documented as positional
+                # (slot 0 = key type, slot 1 = value type), matching the
+                # dedicated `Hash{K=>V}` syntax - not an implicit union.
+                HashCollectionType.new(name, [nested_types[0]], [nested_types[1]])
+              else
+                # Whether these type parameters get described as a union
+                # (Array, Set) or neutrally (everything else) doesn't
+                # affect parsing, so it's not decided here - see
+                # {CollectionType#union?}.
+                CollectionType.new(name, nested_types)
+              end
+            when :group_start
+              raise SyntaxError, "'[' cannot follow a type name" if name
+              nested_types, = parse_until([:group_end, :parse_end])
+              type = GroupType.new(nested_types)
+              name = "Group"
             when :hash_collection_start
               name ||= "Hash"
               type = parse_hash_collection(name)
@@ -241,17 +419,42 @@ module YARD
         def parse_hash_collection(name)
           key_value_pairs = []
           current_keys = []
+          key_name = nil
+          key_type = nil
+          intersection_conjuncts = []
           finished = false
+
+          # Finalizes whatever key is pending (if any) into `current_keys`,
+          # the same way `parse_until` finalizes a union member - `&` binds
+          # tighter than the `,`/`|` (synonyms here, as everywhere outside
+          # `(...)`) that separates keys.
+          finalize_key = lambda do
+            next if key_name.nil?
+            key_type = create_type(key_name) unless key_type
+            current_keys << finish_intersection(intersection_conjuncts, key_type)
+            intersection_conjuncts = []
+            key_name = nil
+            key_type = nil
+          end
 
           parse_with_handlers do |token_type, token|
             case token_type
             when :type_name
-              current_keys << create_type(token)
-            when :type_next
-              # Comma - continue collecting keys unless we just processed a value
-              # In that case, start a new key group
+              raise SyntaxError, "expecting END, got name '#{token}'" if key_name
+              key_name = token
+            when :intersect
+              raise SyntaxError, "expecting name, got '&' at #{@scanner.pos}" if key_name.nil?
+              key_type = create_type(key_name) unless key_type
+              intersection_conjuncts << key_type
+              key_name = nil
+              key_type = nil
+            when :type_next, :union
+              # ',' and '|' are synonyms here, as everywhere outside '(...)'
+              raise SyntaxError, "expecting name, got '#{token}' at #{@scanner.pos}" if key_name.nil?
+              finalize_key.call
             when :hash_collection_value
               # => - current keys map to the next value(s)
+              finalize_key.call
               raise SyntaxError, "no keys before =>" if current_keys.empty?
               values, end_token = parse_until([:hash_collection_value_end, :hash_collection_end, :parse_end])
               key_value_pairs << [current_keys, values]
@@ -269,6 +472,39 @@ module YARD
         end
 
         private
+
+        # Combines the conjuncts of an `A & B & ...` intersection with the
+        # final type in the chain. Consecutive duck-types (`#foo & #bar`)
+        # collapse into a single {DuckType} listing all of the methods, to
+        # match the pre-existing duck-type convention; any other mix of
+        # types becomes an {IntersectionType}.
+        #
+        # @param conjuncts [Array<Type>] the conjuncts seen so far (may be empty)
+        # @param last_type [Type] the final conjunct in the chain
+        # @return [Type] the combined type for this union slot
+        def finish_intersection(conjuncts, last_type)
+          return last_type if conjuncts.empty?
+          all_types = conjuncts + [last_type]
+          if all_types.all? {|t| t.is_a?(DuckType) }
+            DuckType.new(all_types.map(&:name).join(' & '))
+          else
+            IntersectionType.new(all_types)
+          end
+        end
+
+        # Combines the `|`-separated conjuncts of one order-dependent-list
+        # slot (`A | B` in `Array(A | B, C)`) with the slot's final type
+        # into a single {GroupType}, the same representation `[...]`
+        # produces - so `Array(A | B, C)` and `Array([A | B], C)` describe
+        # the same type.
+        #
+        # @param conjuncts [Array<Type>] the conjuncts seen so far (may be empty)
+        # @param last_type [Type] the final conjunct in the slot
+        # @return [Type] the combined type for this slot
+        def finish_group(conjuncts, last_type)
+          return last_type if conjuncts.empty?
+          GroupType.new(conjuncts + [last_type])
+        end
 
         def create_type(name)
           if name[0, 1] == ":" || (name[0, 1] =~ /['"]/ && name[-1, 1] =~ /['"]/)

--- a/spec/tags/types_explainer_spec.rb
+++ b/spec/tags/types_explainer_spec.rb
@@ -72,6 +72,50 @@ RSpec.describe YARD::Tags::TypesExplainer do
     end
   end
 
+  describe YARD::Tags::TypesExplainer::IntersectionType, '#to_s' do
+    it "works for two types" do
+      intersection = described_class.new([type("Foo"), type("Bar")])
+      expect(intersection.to_s).to eq "both a Foo and a Bar"
+      expect(intersection.to_s(false)).to eq "both Foos and Bars"
+    end
+
+    it "works for more than two types" do
+      intersection = described_class.new([type("Foo"), type("Bar"), type("Baz")])
+      expect(intersection.to_s).to eq "all of a Foo, a Bar and a Baz"
+    end
+  end
+
+  describe YARD::Tags::TypesExplainer::GroupType, '#to_s' do
+    it "works for two types" do
+      group = described_class.new([type("Foo"), type("Bar")])
+      expect(group.to_s).to eq "(a Foo or a Bar)"
+      expect(group.to_s(false)).to eq "(Foos or Bars)"
+    end
+
+    it "works for more than two types" do
+      group = described_class.new([type("Foo"), type("Bar"), type("Baz")])
+      expect(group.to_s).to eq "(a Foo, a Bar or a Baz)"
+    end
+
+    it "adds defensive parens around an IntersectionType member" do
+      intersection = YARD::Tags::TypesExplainer::IntersectionType.new([type("Foo"), type("Bar")])
+      group = described_class.new([intersection, type("Baz")])
+      expect(group.to_s).to eq "((both a Foo and a Bar) or a Baz)"
+    end
+
+    it "adds defensive parens around a multi-method DuckType member" do
+      duck = YARD::Tags::TypesExplainer::DuckType.new("#foo & #bar")
+      group = described_class.new([duck, type("Baz")])
+      expect(group.to_s).to eq "((an object that responds to #foo and #bar) or a Baz)"
+    end
+
+    it "does not add extra parens around a single-method DuckType member" do
+      duck = YARD::Tags::TypesExplainer::DuckType.new("#foo")
+      group = described_class.new([duck, type("Baz")])
+      expect(group.to_s).to eq "(an object that responds to #foo or a Baz)"
+    end
+  end
+
   describe YARD::Tags::TypesExplainer::LiteralType, '#to_s' do
     it "works for literal values" do
       [':symbol', "'5'"].each do |name|
@@ -98,6 +142,17 @@ RSpec.describe YARD::Tags::TypesExplainer do
     it "can contain nested collections" do
       @t.types = [described_class.new("List", [type("Object")])]
       expect(@t.to_s).to eq "an Array of (a List of (Objects))"
+    end
+
+    it "flattens a GroupType member into its own union list" do
+      group = YARD::Tags::TypesExplainer::GroupType.new([type("Foo"), type("Bar")])
+      @t.types = [group, type("Baz")]
+      expect(@t.to_s).to eq "an Array of (Foos, Bars or Bazs)"
+    end
+
+    it "lists a non-allow-listed name's 2+ type parameters without pluralizing or asserting union/order" do
+      result = described_class.new("Result", [type("Success"), type("Failure")])
+      expect(result.to_s).to eq "a Result with type parameters (a Success, a Failure)"
     end
   end
 
@@ -193,6 +248,75 @@ RSpec.describe YARD::Tags::TypesExplainer do
       expect(type.first.types.first.name).to eq "String"
     end
 
+    it "keeps the implicit-union CollectionType for a single type parameter, regardless of name" do
+      type = parse("MyBox<Contents>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+    end
+
+    it "keeps the implicit-union CollectionType for allow-listed names with 2+ parameters" do
+      type = parse("Array<Foo, Bar>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+      type = parse("Set<Foo, Bar>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+    end
+
+    it "renders a non-allow-listed name's 2+ parameters neutrally" do
+      type = parse("Result<Success, Failure>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+      expect(type.first.name).to eq "Result"
+      expect(type.first.types.map(&:name)).to eq ["Success", "Failure"]
+      expect(type.first.to_s).to eq "a Result with type parameters (a Success, a Failure)"
+    end
+
+    it "special-cases Hash<KeyType, ValueType> to match Hash{K=>V}'s key/value rendering" do
+      by_angle_brackets = parse("Hash<KeyType, ValueType>")
+      by_braces = parse("Hash{KeyType => ValueType}")
+      expect(by_angle_brackets.first).to be_a(YARD::Tags::TypesExplainer::HashCollectionType)
+      expect(by_angle_brackets.first.key_types.map(&:name)).to eq by_braces.first.key_types.map(&:name)
+      expect(by_angle_brackets.first.value_types.map(&:name)).to eq by_braces.first.value_types.map(&:name)
+    end
+
+    it "falls back to a neutral CollectionType for Hash<...> with the wrong number of parameters" do
+      type = parse("Hash<A, B, C>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+      expect(type.first.to_s).to eq "a Hash with type parameters (an A, a B, a C)"
+      type = parse("Hash<A>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+      expect(type.first.to_s).to eq "a Hash of (A's)"
+    end
+
+    it "groups '|' within a single slot of a non-allow-listed <...>, since its slots are positional" do
+      type = parse("Result<Success | Failure, Other>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+      expect(type.first.types.size).to eq 2
+      expect(type.first.types.first).to be_a(YARD::Tags::TypesExplainer::GroupType)
+      expect(type.first.types.first.types.map(&:name)).to eq ["Success", "Failure"]
+      expect(type.first.types.last.name).to eq "Other"
+    end
+
+    it "groups '|' within a slot of Hash<KeyType, ValueType>, since its slots are positional" do
+      type = parse("Hash<KeyType | OtherKeyType, ValueType>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::HashCollectionType)
+      expect(type.first.key_types.size).to eq 1
+      expect(type.first.key_types.first).to be_a(YARD::Tags::TypesExplainer::GroupType)
+      expect(type.first.key_types.first.types.map(&:name)).to eq ["KeyType", "OtherKeyType"]
+    end
+
+    it "parses '|' within a slot of an allow-listed <...>, mixed with ','" do
+      type = parse("Array<Foo | Bar, Baz>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+      expect(type.first.types.size).to eq 2
+      expect(type.first.types.first).to be_a(YARD::Tags::TypesExplainer::GroupType)
+      expect(type.first.types.first.types.map(&:name)).to eq ["Foo", "Bar"]
+      expect(type.first.types.last.name).to eq "Baz"
+    end
+
+    it "still renders '|' as a flat alternative inside allow-listed <...>, where the whole list is a union" do
+      by_comma = YARD::Tags::TypesExplainer.explain("Array<Foo, Bar>")
+      by_pipe = YARD::Tags::TypesExplainer.explain("Array<Foo | Bar>")
+      expect(by_pipe).to eq by_comma
+    end
+
     it "allows a collection type without a name" do
       type = parse("<String>")
       expect(type.first.name).to eq "Array"
@@ -201,6 +325,58 @@ RSpec.describe YARD::Tags::TypesExplainer do
     it "allows a fixed collection type without a name" do
       type = parse("(String)")
       expect(type.first.name).to eq "Array"
+    end
+
+    it "parses a grouped union inside square brackets as a GroupType" do
+      type = parse("[String | Symbol]")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::GroupType)
+      expect(type.first.types.map(&:name)).to eq ["String", "Symbol"]
+    end
+
+    it "treats ',' and '|' as synonyms inside square brackets" do
+      by_comma = parse("[String, Symbol]")
+      by_pipe = parse("[String | Symbol]")
+      expect(by_comma.first).to be_a(YARD::Tags::TypesExplainer::GroupType)
+      expect(by_comma.first.types.map(&:name)).to eq by_pipe.first.types.map(&:name)
+    end
+
+    it "treats '|' as a synonym for ',' at the top level" do
+      by_comma = parse("String, Symbol")
+      by_pipe = parse("String | Symbol")
+      expect(by_pipe.map(&:name)).to eq by_comma.map(&:name)
+    end
+
+    it "treats '|' as a synonym for ',' inside a collection type" do
+      type = parse("Array<String | Symbol>")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+      expect(type.first.to_s).to eq "an Array of (Strings or Symbols)"
+    end
+
+    it "allows a grouped union as a fixed-tuple slot via square brackets" do
+      type = parse("Array([String | Symbol], Integer)")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::FixedCollectionType)
+      expect(type.first.types.first).to be_a(YARD::Tags::TypesExplainer::GroupType)
+      expect(type.first.types.first.types.map(&:name)).to eq ["String", "Symbol"]
+      expect(type.first.types.last.name).to eq "Integer"
+    end
+
+    it "allows a grouped union as a fixed-tuple slot via a bare '|', equivalent to square brackets" do
+      bare = parse("Array(String | Symbol, Integer)")
+      bracketed = parse("Array([String | Symbol], Integer)")
+      expect(bare.first).to be_a(YARD::Tags::TypesExplainer::FixedCollectionType)
+      expect(bare.first.types.first).to be_a(YARD::Tags::TypesExplainer::GroupType)
+      expect(bare.first.types.first.types.map(&:name)).to eq ["String", "Symbol"]
+      expect(bare.first.types.last.name).to eq "Integer"
+      expect(bare.first.types.first.types.map(&:name)).to eq bracketed.first.types.first.types.map(&:name)
+    end
+
+    it "does not allow a dangling '|' inside a fixed-tuple slot" do
+      parse_fail "Array(String |, Integer)"
+      parse_fail "Array(| String, Integer)"
+    end
+
+    it "does not allow '[' to follow a type name" do
+      parse_fail "Foo[String]"
     end
 
     it "allows a hash collection type without a name" do
@@ -221,6 +397,23 @@ RSpec.describe YARD::Tags::TypesExplainer do
     it "parses constant values" do
       type = parse("false, true, nil, 4, :foo")
       expect(type.map(&:name)).to eq ['false', 'true', 'nil', '4', ':foo']
+    end
+
+    it "combines '&'-joined hash keys into an IntersectionType" do
+      type = parse("Hash{Foo & Bar => String}")
+      expect(type.first.key_types.size).to eq 1
+      expect(type.first.key_types.first).to be_a(YARD::Tags::TypesExplainer::IntersectionType)
+      expect(type.first.key_types.first.types.map(&:name)).to eq ["Foo", "Bar"]
+    end
+
+    it "treats ',' and '|' as synonyms for hash keys" do
+      by_comma = parse("Hash{Foo, Bar => String}")
+      by_pipe = parse("Hash{Foo | Bar => String}")
+      expect(by_comma.first.key_types.map(&:name)).to eq by_pipe.first.key_types.map(&:name)
+    end
+
+    it "does not silently accept two hash keys with no separator between them" do
+      parse_fail "Hash{Foo Bar => String}"
     end
 
     it "does not accept two commas in a row" do
@@ -271,6 +464,148 @@ RSpec.describe YARD::Tags::TypesExplainer do
         explain = YARD::Tags::TypesExplainer.explain(input)
         expect(explain).to eq expected.delete("\n").squeeze(' ')
       end
+    end
+
+    it "parses intersection types (`&`)" do
+      expect = {
+        "Foo & Bar" => "both a Foo and a Bar",
+        "Foo & Bar & Baz" => "all of a Foo, a Bar and a Baz",
+        "Array<Foo & Bar>" => "an Array of (both Foos and Bars)",
+        # `&` binds tighter than `,`, matching RBS's `A & B | C` == `(A & B) | C`
+        "Foo & Bar, Baz & Qux" => "both a Foo and a Bar; both a Baz and a Qux",
+        "Foo, Bar & Baz" => "a Foo; both a Bar and a Baz",
+        # consecutive duck-types joined by `&` collapse into a single duck-type,
+        # matching the pre-existing "#method_one & #method_two" convention
+        "#read & #write" => "an object that responds to #read and #write",
+        "#read&#write&#close" => "an object that responds to #read, #write and #close",
+        # a duck-type intersected with a real type stays a full intersection
+        "Foo & #read" => "both a Foo and an object that responds to #read"
+      }
+      expect.each do |input, expected|
+        explain = YARD::Tags::TypesExplainer.explain(input)
+        expect(explain).to eq expected.delete("\n").squeeze(' ')
+      end
+    end
+
+    it "parses grouped unions (`[A | B]`)" do
+      expect = {
+        # standalone, redundant with a plain top-level union, but legal
+        "[Integer | String]" => "(an Integer or a String)",
+        # the motivating case: a union in a fixed-tuple slot, which `,`
+        # can't express there since it already means "next slot"
+        "Array([Integer | String], Symbol)" =>
+          "an Array containing ((an Integer or a String) followed by a Symbol)",
+        "Hash{String => [Integer | Symbol]}" =>
+          "a Hash with keys made of (Strings) and values of ((Integers or Symbols))"
+      }
+      expect.each do |input, expected|
+        explain = YARD::Tags::TypesExplainer.explain(input)
+        expect(explain).to eq expected.delete("\n").squeeze(' ')
+      end
+    end
+
+    it "composes `&` and `[A | B]` together, with `&` binding tighter than `|`" do
+      expect = {
+        # a group used as one conjunct of an intersection
+        "[Integer | String] & Comparable" => "both (an Integer or a String) and a Comparable",
+        "Comparable & [Integer | String]" => "both a Comparable and (an Integer or a String)",
+        # `&` binds tighter than `|` *inside* a group too, matching how it
+        # already binds tighter than `,` everywhere else: `A & B | C` inside
+        # `[...]` groups parses as `(A & B) | C`, not `A & (B | C)`. The
+        # `&`-joined conjunct has no punctuation of its own to mark where it
+        # ends, so the group adds defensive parens around it (only) to keep
+        # the English rendering unambiguous, matching the real parse tree.
+        "[Foo & Bar | Baz]" => "((both a Foo and a Bar) or a Baz)",
+        "[Foo | Bar & Baz]" => "(a Foo or (both a Bar and a Baz))",
+        # duck-types inside a group are NOT collapsed the way `&`-joined ones
+        # are - grouping is a real alternative ("either responds to #foo, or
+        # responds to #bar"), not the same method-list convention. But a
+        # multi-method duck-type (already `&`-collapsed before the `|` is
+        # seen) gets the same defensive-parens treatment as `&` above.
+        "[#foo | #bar]" => "(an object that responds to #foo or an object that responds to #bar)",
+        "[#foo & #bar | #baz]" =>
+          "((an object that responds to #foo and #bar) or an object that responds to #baz)",
+        # a group nested inside another group's slot - GroupType always
+        # parenthesizes itself, so no extra disambiguation is needed here
+        "Array([[Integer | String] | Symbol], Number)" =>
+          "an Array containing (((an Integer or a String) or a Symbol) followed by a Number)"
+      }
+      expect.each do |input, expected|
+        explain = YARD::Tags::TypesExplainer.explain(input)
+        expect(explain).to eq expected.delete("\n").squeeze(' ')
+      end
+    end
+
+    it "treats '|' as a synonym for ',' everywhere a union is legal" do
+      # '&' never needs '[...]' - it's legal (and binds tightest) everywhere
+      expect(YARD::Tags::TypesExplainer.explain("Array<Foo & Bar, Baz>")).to eq(
+        "an Array of (both Foos and Bars or Bazs)"
+      )
+      # a bare '|' at the top level is just another spelling of ','
+      expect(YARD::Tags::TypesExplainer.explain("Foo & Bar | Baz")).to eq(
+        YARD::Tags::TypesExplainer.explain("Foo & Bar, Baz")
+      )
+      # and ',' is likewise accepted as a synonym for '|' inside '[...]'
+      expect(YARD::Tags::TypesExplainer.explain("[Foo & Bar, Baz]")).to eq(
+        YARD::Tags::TypesExplainer.explain("[Foo & Bar | Baz]")
+      )
+    end
+
+    it "lets '|' group a fixed-tuple slot directly, equivalent to wrapping that slot in '[...]'" do
+      expect(YARD::Tags::TypesExplainer.explain("Array(Foo | Bar, Baz)")).to eq(
+        YARD::Tags::TypesExplainer.explain("Array([Foo | Bar], Baz)")
+      )
+      expect(YARD::Tags::TypesExplainer.explain("Array(Foo | Bar, Baz)")).to eq(
+        "an Array containing ((a Foo or a Bar) followed by a Baz)"
+      )
+      # '&' still binds tighter than '|' inside a fixed-tuple slot, exactly
+      # as it does everywhere else
+      expect(YARD::Tags::TypesExplainer.explain("Array(Foo & Bar | Baz, Qux)")).to eq(
+        "an Array containing (((both a Foo and a Bar) or a Baz) followed by a Qux)"
+      )
+      expect(YARD::Tags::TypesExplainer.explain("Array(Foo | Bar & Baz, Qux)")).to eq(
+        "an Array containing ((a Foo or (both a Bar and a Baz)) followed by a Qux)"
+      )
+    end
+
+    it "still needs '[...]' to group a union used as one conjunct of a top-level intersection" do
+      # without brackets, '|' at the top level is just ',' - so this is two
+      # independent top-level items, NOT one intersection
+      expect(YARD::Tags::TypesExplainer.explain("Foo | Bar & Baz")).to eq(
+        "a Foo; both a Bar and a Baz"
+      )
+      # '[...]' raises the union's precedence above '&' to get the other reading
+      expect(YARD::Tags::TypesExplainer.explain("[Foo | Bar] & Baz")).to eq(
+        "both (a Foo or a Bar) and a Baz"
+      )
+    end
+
+    it "does not assume <...> always means union, for names that aren't known collections" do
+      expect = {
+        # allow-listed names keep the implicit-union reading
+        "Array<Foo, Bar>" => "an Array of (Foos or Bars)",
+        "Set<Foo, Bar>" => "a Set of (Foos or Bars)",
+        # Hash<KeyType, ValueType> is documented as positional (key, then
+        # value), matching Hash{K=>V} - not "KeyTypes or ValueTypes"
+        "Hash<Symbol, String>" => "a Hash with keys made of (Symbols) and values of (Strings)",
+        # a single parameter is never ambiguous, so it's unaffected
+        # regardless of the name
+        "Box<Contents>" => "a Box of (Contentss)",
+        # an unrecognized name with 2+ parameters doesn't assert union -
+        # RBS-style positional generics like Result<Success, Failure> are
+        # exactly the case this protects
+        "Result<Success, Failure>" => "a Result with type parameters (a Success, a Failure)"
+      }
+      expect.each do |input, expected|
+        explain = YARD::Tags::TypesExplainer.explain(input)
+        expect(explain).to eq expected.delete("\n").squeeze(' ')
+      end
+    end
+
+    it "groups '|' within a slot of a non-implicit-union '<...>', instead of unioning the whole list" do
+      expect(YARD::Tags::TypesExplainer.explain("Result<Success | Failure, Other>")).to eq(
+        "a Result with type parameters ((a Success or a Failure), an Other)"
+      )
     end
   end
 end


### PR DESCRIPTION
## Summary

Adds three related type-tag syntax elements:

- **`&` (intersection, closes #1644)**: `Foo & Bar` means a value must
  satisfy both `Foo` and `Bar`, matching Solargraph's syntax
  (castwide/solargraph#1231). Legal in every position a type can appear,
  and always binds tighter than the union or slot separator around it,
  matching RBS's documented precedence. Renders as "both a Foo and a
  Bar" (or "all of a Foo, a Bar, and a Baz" for 3+), to avoid reading
  like two separate values.
- **`|` (union, closes #1699)**: marks a union - a value matching any of
  the listed types. Some type lists already mean a union without it (the
  top level, a hash's key/value lists, `[...]`, and
  `Array<...>`/`Set<...>`), so `,` and `|` land on the same result there.
  Elsewhere, each comma-separated item is a distinct, positional type
  parameter instead (a fixed-order list like `Array(...)`, or `<...>` for
  a name other than `Array`/`Set`) - there, `|` groups alternatives
  within a single one of them: `Array(Foo | Bar, Baz)` is a 2-element
  Array whose first element is a Foo or a Bar, and
  `Result<Success | Failure, Other>` is a Result whose first type
  parameter is a Success or a Failure.
- **`[...]` (closes #1699)**: used the same way parentheses are in
  algebra, to override the default order of operations - e.g. to use a
  union as one conjunct of an intersection, which otherwise has no way to
  mark where the union ends: `[Foo | Bar] & Baz`.

Also documents three pre-existing but previously undocumented anonymous
shorthand forms - `<A>`, `(A)`, `{A=>B}` - where the leading type name can
be omitted and defaults to `Array`/`Hash` (see #1701), and stops
`Foo<A, B>` from always being read as a union: `<...>`'s type parameters
are conventionally used both ways - a homogeneous collection's implicit
union of element type(s) (`Array<String, Symbol>`), or a class's
distinct, positional type parameters (`Result<Success, Failure>`).
`Array`/`Set` (and any name with a single type parameter) keep the union
reading; `Hash<K, V>` gets its own dedicated key/value rendering matching
`Hash{K=>V}`; anything else with 2+ parameters reads neutrally ("a Result
with type parameters (a Success, a Failure)"). This choice is made
entirely at render time (`CollectionType#to_s`) - the parser always
treats `<...>` the same way it already treats `(...)`, with no
name-specific knowledge at all.

Full rules and examples are in the new "Operator Precedence" and
"Overriding the Order of Operations" sections of `docs/Tags.md`, and the
rewritten "Parameterized Types"/"Union Operator" sections.

## Test plan

- [x] `bundle exec rspec spec/tags/types_explainer_spec.rb` - specs for
  `IntersectionType`/`GroupType`/`CollectionType#to_s`, parser-level
  precedence/error cases, and end-to-end `.explain` examples.
- [x] `bundle exec rspec` - full suite green (2830 examples, 0 failures).
