### PR TITLE
"[A | B]" grouped-union syntax for type tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # main
 
+- Add `[A | B]` grouped-union syntax for type tags (closes #1699); document the
+  existing anonymous `<A>`, `(A)`, and `{A=>B}` shorthand forms
 - Fix duplicate "View source" links after client-side navigation in default HTML template
 
 # [0.9.45] - July 14th, 2026

--- a/docs/Tags.md
+++ b/docs/Tags.md
@@ -182,6 +182,9 @@ a list of parametrized types can occur in any order inside of a type. An array
 specified as `Array<String, Fixnum>` can contain any amount of Strings or Fixnums,
 in any order. When the order matters, use "order-dependent lists", described below.
 
+The type name before `<...>` can be omitted, in which case it defaults to
+`Array`: `<String, Fixnum>` means the same thing as `Array<String, Fixnum>`.
+
 #### Duck-Types
 
 Duck-types are allowed in type specifier lists, and are identified by method
@@ -222,12 +225,39 @@ Keys in the hash-specific syntax are commonly [literal values](#Literals) such
 as symbols (`:key`) or strings (`'key'`, `"key"`), but any type listed in the
 [type conventions](#Type_List_Conventions) is allowed.
 
+The type name before `{...}` can be omitted, in which case it defaults to
+`Hash`: `{K=>V}` means the same thing as `Hash{K=>V}`.
+
 #### Order-Dependent Lists
 
 An order dependent list is a set of types surrounded by "()" and separated by
 commas. This list must contain exactly those types in exactly the order specified.
 For instance, an Array containing a String, Fixnum and Hash in that order (and
 having exactly those 3 elements) would be listed as: `Array(String, Fixnum, Hash)`.
+
+The type name before `(...)` can be omitted, in which case it defaults to
+`Array`: `(String, Fixnum, Hash)` means the same thing as
+`Array(String, Fixnum, Hash)`.
+
+#### Grouped Unions
+
+A comma inside an order-dependent list already means "next slot," so there's no
+way to write "a slot that can be either of two types" using a comma there - and
+the same problem applies to any other position where `,` already has a
+different meaning. Wrapping a `|`-separated list in square brackets (`[...]`)
+groups it into a single union type that can be used anywhere a type is
+expected, including as one slot of an order-dependent list:
+`Array([Integer | String], Symbol)` describes a 2-element Array whose first
+element is an `Integer` or a `String`, followed by a `Symbol`.
+
+`[...]` is dedicated entirely to this grouping; unlike `<...>`, `(...)`, and
+`{...}`, it never takes a preceding type name and is never itself a
+collection - `[Integer | String]` alone just means "an Integer or a String",
+identical in meaning to the plain top-level list `Integer, String`, just
+usable in more places. `|` is only meaningful inside `[...]`, and a plain `,`
+is not allowed inside `[...]` - a top-level type list already uses `,` for
+the same "either of these" meaning, so there is no need for two spellings of
+it in the same position.
 
 #### Literals
 

--- a/lib/yard/tags/types_explainer.rb
+++ b/lib/yard/tags/types_explainer.rb
@@ -70,6 +70,19 @@ module YARD
       end
 
       # @private
+      class GroupType < Type
+        attr_accessor :types
+
+        def initialize(types)
+          @types = types
+        end
+
+        def to_s(singular = true)
+          "(" + list_join(types.map {|t| t.to_s(singular) }) + ")"
+        end
+      end
+
+      # @private
       class CollectionType < Type
         attr_accessor :types
 
@@ -154,9 +167,12 @@ module YARD
           :collection_end => />/,
           :fixed_collection_start => /\(/,
           :fixed_collection_end => /\)/,
+          :group_start => /\[/,
+          :group_end => /\]/,
           :type_name => /#{ISEP}#{METHODNAMEMATCH}|#{NAMESPACEMATCH}|#{LITERALMATCH}|\w+/,
           :symbol => /:#{METHODNAMEMATCH}/,
           :type_next => /[,]/,
+          :union_sep => /\|/,
           :whitespace => /\s+/,
           :hash_collection_start => /\{/,
           :hash_collection_value => /=>/,
@@ -181,7 +197,19 @@ module YARD
 
         private
 
-        def parse_until(until_tokens)
+        # @param allow_pipe [Boolean] whether a bare `|` is a legal separator
+        #   in this scope. Only true directly inside `[...]`, YARD's grouping
+        #   syntax: it lets a union be nested as a single type wherever a
+        #   type is expected, including inside constructs where `,` already
+        #   has a different meaning (an order-dependent list's positional
+        #   slots). `,` is not allowed inside `[...]` (and `|` is not allowed
+        #   anywhere else) - the two are never legal in the same scope, so
+        #   there is nothing to disambiguate between them.
+        # @param allow_comma [Boolean] whether a bare `,` is a legal separator
+        #   in this scope. False only directly inside `[...]`.
+        # @return [Array(Array<Type>, Symbol)] the parsed types and the
+        #   token that ended the list
+        def parse_until(until_tokens, allow_pipe: false, allow_comma: true)
           current_parsed_types = []
           type = nil
           name = nil
@@ -199,7 +227,15 @@ module YARD
               raise SyntaxError, "expecting END, got name '#{token}'" if name
               name = token
             when :type_next
+              raise SyntaxError, "',' is not allowed inside '[...]' groups" unless allow_comma
               raise SyntaxError, "expecting name, got '#{token}' at #{@scanner.pos}" if name.nil?
+              type = create_type(name) unless type
+              current_parsed_types << type
+              name = nil
+              type = nil
+            when :union_sep
+              raise SyntaxError, "'|' is only allowed inside '[...]' groups" unless allow_pipe
+              raise SyntaxError, "expecting name, got '|' at #{@scanner.pos}" if name.nil?
               type = create_type(name) unless type
               current_parsed_types << type
               name = nil
@@ -209,6 +245,11 @@ module YARD
               klass = token_type == :collection_start ? CollectionType : FixedCollectionType
               nested_types, = parse_until([:fixed_collection_end, :collection_end, :parse_end])
               type = klass.new(name, nested_types)
+            when :group_start
+              raise SyntaxError, "'[' cannot follow a type name" if name
+              nested_types, = parse_until([:group_end, :parse_end], allow_pipe: true, allow_comma: false)
+              type = GroupType.new(nested_types)
+              name = "Group"
             when :hash_collection_start
               name ||= "Hash"
               type = parse_hash_collection(name)

--- a/spec/tags/types_explainer_spec.rb
+++ b/spec/tags/types_explainer_spec.rb
@@ -72,6 +72,19 @@ RSpec.describe YARD::Tags::TypesExplainer do
     end
   end
 
+  describe YARD::Tags::TypesExplainer::GroupType, '#to_s' do
+    it "works for two types" do
+      group = described_class.new([type("Foo"), type("Bar")])
+      expect(group.to_s).to eq "(a Foo or a Bar)"
+      expect(group.to_s(false)).to eq "(Foos or Bars)"
+    end
+
+    it "works for more than two types" do
+      group = described_class.new([type("Foo"), type("Bar"), type("Baz")])
+      expect(group.to_s).to eq "(a Foo, a Bar or a Baz)"
+    end
+  end
+
   describe YARD::Tags::TypesExplainer::LiteralType, '#to_s' do
     it "works for literal values" do
       [':symbol', "'5'"].each do |name|
@@ -203,6 +216,36 @@ RSpec.describe YARD::Tags::TypesExplainer do
       expect(type.first.name).to eq "Array"
     end
 
+    it "parses a grouped union inside square brackets as a GroupType" do
+      type = parse("[String | Symbol]")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::GroupType)
+      expect(type.first.types.map(&:name)).to eq ["String", "Symbol"]
+    end
+
+    it "allows a grouped union as a fixed-tuple slot" do
+      type = parse("Array([String | Symbol], Integer)")
+      expect(type.first).to be_a(YARD::Tags::TypesExplainer::FixedCollectionType)
+      expect(type.first.types.first).to be_a(YARD::Tags::TypesExplainer::GroupType)
+      expect(type.first.types.first.types.map(&:name)).to eq ["String", "Symbol"]
+      expect(type.first.types.last.name).to eq "Integer"
+    end
+
+    it "does not allow '|' outside of square brackets" do
+      parse_fail "String | Symbol"
+    end
+
+    it "does not allow '|' inside a collection type" do
+      parse_fail "Array<String | Symbol>"
+    end
+
+    it "does not allow ',' inside square brackets" do
+      parse_fail "[String, Symbol]"
+    end
+
+    it "does not allow '[' to follow a type name" do
+      parse_fail "Foo[String]"
+    end
+
     it "allows a hash collection type without a name" do
       type = parse("{K=>V}")
       expect(type.first.name).to eq "Hash"
@@ -266,6 +309,23 @@ RSpec.describe YARD::Tags::TypesExplainer do
         "Hash{:key_one, :key_two => String; :key_three => Symbol}" => "a Hash with keys made of (a literal value :key_one or a literal value :key_two) and values of (Strings) and keys made of (a literal value :key_three) and values of (Symbols)",
         "Hash{:key_one, :key_two => String; :key_three => Symbol; :key_four => Hash{:sub_key_one => String}}" => "a Hash with keys made of (a literal value :key_one or a literal value :key_two) and values of (Strings) and keys made of (a literal value :key_three) and values of (Symbols) and keys made of (a literal value :key_four) and values of (a Hash with keys made of (a literal value :sub_key_one) and values of (Strings))",
         "Hash{:key_one => String, Number; :key_two => String}" => "a Hash with keys made of (a literal value :key_one) and values of (Strings or Numbers) and keys made of (a literal value :key_two) and values of (Strings)"
+      }
+      expect.each do |input, expected|
+        explain = YARD::Tags::TypesExplainer.explain(input)
+        expect(explain).to eq expected.delete("\n").squeeze(' ')
+      end
+    end
+
+    it "parses grouped unions (`[A | B]`)" do
+      expect = {
+        # standalone, redundant with a plain top-level union, but legal
+        "[Integer | String]" => "(an Integer or a String)",
+        # the motivating case: a union in a fixed-tuple slot, which `,`
+        # can't express there since it already means "next slot"
+        "Array([Integer | String], Symbol)" =>
+          "an Array containing ((an Integer or a String) followed by a Symbol)",
+        "Hash{String => [Integer | Symbol]}" =>
+          "a Hash with keys made of (Strings) and values of ((Integers or Symbols))"
       }
       expect.each do |input, expected|
         explain = YARD::Tags::TypesExplainer.explain(input)


### PR DESCRIPTION
## Summary

Closes #1699. There was no way to nest a union inside a position where `,`
already means something else - most concretely, an order-dependent list's
positional slots (`Array(A, B)` already means "2 slots", so `,` can't also
mean "alternative for this slot" there).

`[...]` is a new, dedicated grouping construct - unlike `<...>`, `(...)`,
and `{...}`, it never takes a preceding type name and never means a
collection; `[A | B]` alone just means "A or B", exactly like the plain
top-level list `A, B`, but usable anywhere a type is expected. `|` is only
meaningful inside `[...]`, and `,` is not allowed inside `[...]` - the two
never compete for the same position, so there's nothing to disambiguate
(no need for a "cannot mix `,` and `|`" rule, or extra nested parens).

This resolves the motivating example from the issue directly:
`Array([Integer | String], Symbol)` is a 2-element tuple whose first
element is an `Integer` or a `String`, followed by a `Symbol` - no extra
nesting required.

## Why `[]` and not `()` or reusing `,`

- `()` already has an established meaning (`Array(A, B)`, an
  order-dependent tuple) that this repo isn't changing here, to leave that
  syntax free for a possible future use.
- `[` has no meaning at all today in `YARD::Tags::TypesExplainer::Parser`
  (only `<`, `(`, `{` are wired up as bracket-openers there), even though
  the outer tag-value tokenizer (`DefaultFactory::TYPELIST_OPENING_CHARS`)
  already balances it generically - so it's free to claim without any
  parsing-level conflict.
- Reusing the existing `,`-for-union convention *inside* the grouping
  brackets was considered and rejected: it would make `[A, B]` and
  `[A | B]` two spellings of the same thing, and (worse) invites
  misreading `[A, B]` as an array/tuple literal by analogy with other
  ecosystems, rather than as a plain 2-way alternative. `|` avoids both.

## What else changed

Also documents three pre-existing (but previously undocumented in
`docs/Tags.md`) anonymous shorthand forms - `<A>`, `(A)`, and `{A=>B}` -
where the leading type name can be omitted and defaults to `Array` or
`Hash` respectively. These were already implemented and spec-tested, and
documented externally at https://yardoc.org/types.html, but absent from
this repo's own docs; see #1701.

## Test plan

- [x] `bundle exec rspec spec/tags/types_explainer_spec.rb` - added specs
  for `GroupType#to_s`, parser-level grouping/error cases, and end-to-end
  `.explain` examples.
- [x] `bundle exec rspec` - full suite green (2802 examples, 0 failures).
