### PR TITLE
Support class Foo < Data.define(:a, :b) as a documented superclass

### DIFF
--- a/lib/yard/handlers/ruby/class_handler.rb
+++ b/lib/yard/handlers/ruby/class_handler.rb
@@ -21,6 +21,8 @@ class YARD::Handlers::Ruby::ClassHandler < YARD::Handlers::Ruby::Base
       end
       if is_a_struct
         parse_struct_superclass(klass, statement[1])
+      elsif superclass == "Data"
+        parse_data_superclass(klass, statement[1])
       elsif klass
         create_attributes(klass, members_from_tags(klass))
       end
@@ -95,6 +97,11 @@ class YARD::Handlers::Ruby::ClassHandler < YARD::Handlers::Ruby::Base
     create_attributes(klass, members)
   end
 
+  def parse_data_superclass(klass, superclass)
+    return unless superclass.call? && superclass.parameters
+    create_readers(klass, extract_parameters(superclass))
+  end
+
   def parse_superclass(superclass)
     return nil unless superclass
 
@@ -113,6 +120,7 @@ class YARD::Handlers::Ruby::ClassHandler < YARD::Handlers::Ruby::Base
       if cname =~ /^O?Struct$/ && superclass.method_name(true) == :new
         return cname
       end
+      return cname if cname == "Data" && superclass.method_name(true) == :define
     end
     nil
   end

--- a/lib/yard/handlers/ruby/constant_handler.rb
+++ b/lib/yard/handlers/ruby/constant_handler.rb
@@ -48,11 +48,7 @@ class YARD::Handlers::Ruby::ConstantHandler < YARD::Handlers::Ruby::Base
     lhs = statement[0]
     if (lhs.type == :var_field && lhs[0].type == :const) || lhs.type == :const_path_field
       klass = create_class(lhs.source, P(:Data))
-      extract_parameters(statement[1]).each do |member|
-        next if klass.attributes[:instance][member]
-        klass.attributes[:instance][member] = SymbolHash[:read => nil, :write => nil]
-        create_reader(klass, member)
-      end
+      create_readers(klass, extract_parameters(statement[1]))
       parse_block(statement[1].block[1], :namespace => klass) unless statement[1].block.nil?
     else
       raise YARD::Parser::UndocumentableError, "Data assignment to #{lhs.source}"

--- a/lib/yard/handlers/ruby/legacy/class_handler.rb
+++ b/lib/yard/handlers/ruby/legacy/class_handler.rb
@@ -103,6 +103,7 @@ class YARD::Handlers::Ruby::Legacy::ClassHandler < YARD::Handlers::Ruby::Legacy:
     case superclass
     when /\A(#{NAMESPACEMATCH})(?:\s|\Z)/,
          /\A(Struct|OStruct)\.new/,
+         /\A(Data)\.define/,
          /\ADelegateClass\((.+?)\)\s*\Z/,
          /\A(#{NAMESPACEMATCH})\(/
       $1

--- a/lib/yard/handlers/ruby/struct_handler_methods.rb
+++ b/lib/yard/handlers/ruby/struct_handler_methods.rb
@@ -161,6 +161,19 @@ module YARD::Handlers::Ruby::StructHandlerMethods
     end
   end
 
+  # Creates reader-only member methods and attaches them to the given
+  # ClassObject. Used for Data classes, whose members are immutable.
+  #
+  # @param [ClassObject] klass the class to generate readers for
+  # @param [Array<String>] members a list of member names
+  def create_readers(klass, members)
+    members.each do |member|
+      next if klass.attributes[:instance][member]
+      klass.attributes[:instance][member] = SymbolHash[:read => nil, :write => nil]
+      create_reader klass, member
+    end
+  end
+
   # Registers an auto-generated member method without reapplying the class's
   # docstring to it. The generated reader or writer receives its own docstring
   # and tags immediately after registration.

--- a/spec/handlers/class_handler_spec.rb
+++ b/spec/handlers/class_handler_spec.rb
@@ -244,4 +244,37 @@ RSpec.describe "YARD::Handlers::Ruby::#{LEGACY_PARSER ? "Legacy::" : ""}ClassHan
   it "handles inheritance from 'self'" do
     expect(Registry.at('Outer1::Inner1').superclass).to eq Registry.at('Outer1')
   end
+
+  it "sets Data as superclass of 'class Const < Data.define(:sym)'" do
+    expect(Registry.at('DataPoint').superclass).to eq P(:Data)
+    expect(Registry.at('EmptyDataClass').superclass).to eq P(:Data)
+    expect(Registry.at('DoccedData').superclass).to eq P(:Data)
+  end
+
+  it "creates no attributes for 'class Const < Data.define' without members" do
+    expect(Registry.at('EmptyDataClass').attributes[:instance]).to be_empty
+  end
+
+  it "lets an explicit method definition override a generated Data reader" do
+    expect(Registry.at('DataClassWithMethods#a').docstring).to eq 'Overridden reader.'
+    expect(Registry.at('DataClassWithMethods#double_a')).not_to be nil
+  end
+
+  it "turns 'class Const < Data.define(:sym)' into class Const with attr reader :sym" do
+    obj = Registry.at('DataPoint')
+    expect(obj).to be_kind_of(CodeObjects::ClassObject)
+    attrs = obj.attributes[:instance]
+    [:x, :y].each do |key|
+      expect(attrs).to have_key(key)
+      expect(attrs[key][:read]).not_to be nil
+      expect(attrs[key][:write]).to be nil
+    end
+  end unless LEGACY_PARSER
+
+  it "uses @attr tags for Data member readers without creating writers" do
+    obj = Registry.at('DoccedData#name')
+    expect(obj.docstring).to eq 'the name of the person'
+    expect(obj.tag(:return).types).to eq ['String']
+    expect(Registry.at('DoccedData').attributes[:instance][:name][:write]).to be nil
+  end unless LEGACY_PARSER
 end

--- a/spec/handlers/examples/class_handler_001.rb.txt
+++ b/spec/handlers/examples/class_handler_001.rb.txt
@@ -118,3 +118,24 @@ class NotAStruct; end
 class Outer1
   class Inner1 < self; end
 end
+
+class DataPoint < Data.define(:x, :y)
+end
+
+class EmptyDataClass < Data.define
+end
+
+# @attr [String] name the name of the person
+class DoccedData < Data.define(:name)
+end
+
+class DataClassWithMethods < Data.define(:a)
+  # Overridden reader.
+  def a
+    super
+  end
+
+  def double_a
+    a * 2
+  end
+end


### PR DESCRIPTION
# Description

`class Foo < Data.define(:a, :b)` currently registers with no superclass. The parser logs `[warn]: in YARD::Handlers::Ruby::ClassHandler: Undocumentable superclass (class was added without superclass)`, and the rendered docs claim the class inherits `Object`. #1533 reports this exact case. #1600 added the constant form `Foo = Data.define(:a, :b)` and invited this change:

> Note: the support of the `class Foo < Data.define(:a, :b)` form was not added by intention because I don't want to encourage this style of programming and it does not appear in the `Data` documentation. If one has a strong opinion that this style must be supported, they're free to do it in a separate PR.

Here is that separate PR. The strong opinion: current tooling forces the inheritance form on some projects, whatever style one prefers.

- ruby-lsp reads `.rb` and never `sig/`, so hover docs on members need a documented reader per member: `def a = super`. That reader works only in the inheritance form. In the block form, `Data.define(:a) do def a = super end` raises `NoMethodError: super: no superclass method 'a'` at runtime, because the block runs on the same class that defines the reader.
- Steep type-checks only the inheritance form. In the block form it attributes the methods to `::Object` (soutaro/steep#963), and the rbs guide `docs/data_and_struct.md` records the same preference for inheriting.
- The `Data` documentation not showing the form also holds for `class Foo < Struct.new(...)`, which YARD has long supported.

Changes:

- `ClassHandler#parse_superclass` resolves `Data.define(...)` to `Data`, next to the existing `Struct.new` branch. The warning is gone and the ancestry renders correctly.
- Members become read-only attributes through the path the constant form already uses. The loop from `ConstantHandler#process_dataclass` moved to `StructHandlerMethods#create_readers`, and both handlers call it.
- The legacy parser resolves the superclass through one added regex alternative. Member specs are gated to the Ripper parser, as #1600's specs are.

Verified against a real tree: a gem that generates 361 such classes from the Telegram Bot API spec. Before: 361 warnings. After: zero warnings, every class renders `Data` ancestry with read-only member attributes, and explicitly documented readers in class bodies keep their own docstrings.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
