### PR TITLE
html: don't resolve links within code block

### DIFF
--- a/lib/yard/templates/helpers/html_helper.rb
+++ b/lib/yard/templates/helpers/html_helper.rb
@@ -233,47 +233,13 @@ module YARD
       # @param [String] text the text to resolve links in
       # @return [String] HTML with linkified references
       def resolve_links(text)
-        code_tags = 0
-        text.gsub(%r{<(/)?(pre|code|tt)|(\\|!)?\{(?!\})(\S+?)(?:\s([^\}]*?\S))?\}(?=\W|.+</|$)}m) do |str|
-          closed = $1
-          tag = $2
-          escape = $3
-          name = $4
-          title = $5
-          match = $&
-          if tag
-            code_tags += (closed ? -1 : 1)
-            next str
-          end
-          next str unless code_tags == 0
-
-          next(match[1..-1]) if escape
-
-          next(match) if name[0, 1] == '|'
-
-          if name == '<a' && title =~ %r{href=["'](.+?)["'].*>.*</a>\s*(.*)\Z}
-            name = $1
-            title = $2
-            title = nil if title.empty?
-          end
-
-          name = CGI.unescapeHTML(name)
-
-          if object.is_a?(String)
-            object
+        text.split(%r{(^[ \t]{0,3}(?:`{3,}|~{3,})[^\n]*\n.*?^[ \t]{0,3}(?:`{3,}|~{3,})[ \t]*(?:\n|\z))}m).map do |part|
+          if part =~ %r{\A[ \t]{0,3}(?:`{3,}|~{3,})}m
+            part
           else
-            link = linkify(name, title)
-            if (link == name || link == title) && (name + ' ' + link !~ /\A<a\s.*>/)
-              match = /(.+)?(\{#{Regexp.quote name}(?:\s.*?)?\})(.+)?/.match(text)
-              file = (defined?(@file) && @file ? @file.filename : object.file) || '(unknown)'
-              line = (defined?(@file) && @file ? 1 : (object.docstring.line_range ? object.docstring.line_range.first : 1)) + (match ? $`.count("\n") : 0)
-              log.warn "In file `#{file}':#{line}: Cannot resolve link to #{name} from text" + (match ? ":" : ".") +
-                       "\n\t" + (match[1] ? '...' : '') + match[2].delete("\n") + (match[3] ? '...' : '') if match
-            end
-
-            link
+            resolve_links_in_text(part)
           end
-        end
+        end.join
       end
 
       # (see BaseHelper#link_file)
@@ -605,6 +571,50 @@ module YARD
       # @endgroup
 
       private
+
+      def resolve_links_in_text(text)
+        code_tags = 0
+        text.gsub(%r{<(/)?(pre|code|tt)|(\\|!)?\{(?!\})(\S+?)(?:\s([^\}]*?\S))?\}(?=\W|.+</|$)}m) do |str|
+          closed = $1
+          tag = $2
+          escape = $3
+          name = $4
+          title = $5
+          match = $&
+          if tag
+            code_tags += (closed ? -1 : 1)
+            next str
+          end
+          next str unless code_tags == 0
+
+          next(match[1..-1]) if escape
+
+          next(match) if name[0, 1] == '|'
+
+          if name == '<a' && title =~ %r{href=["'](.+?)["'].*>.*</a>\s*(.*)\Z}
+            name = $1
+            title = $2
+            title = nil if title.empty?
+          end
+
+          name = CGI.unescapeHTML(name)
+
+          if object.is_a?(String)
+            object
+          else
+            link = linkify(name, title)
+            if (link == name || link == title) && (name + ' ' + link !~ /\A<a\s.*>/)
+              match = /(.+)?(\{#{Regexp.quote name}(?:\s.*?)?\})(.+)?/.match(text)
+              file = (defined?(@file) && @file ? @file.filename : object.file) || '(unknown)'
+              line = (defined?(@file) && @file ? 1 : (object.docstring.line_range ? object.docstring.line_range.first : 1)) + (match ? $`.count("\n") : 0)
+              log.warn "In file `#{file}':#{line}: Cannot resolve link to #{name} from text" + (match ? ":" : ".") +
+                       "\n\t" + (match[1] ? '...' : '') + match[2].delete("\n") + (match[3] ? '...' : '') if match
+            end
+
+            link
+          end
+        end
+      end
 
       # Converts a set of hash options into HTML attributes for a tag
       #

--- a/spec/templates/helpers/html_helper_spec.rb
+++ b/spec/templates/helpers/html_helper_spec.rb
@@ -175,6 +175,31 @@ RSpec.describe YARD::Templates::Helpers::HtmlHelper do
       expect(html).to match %r{^<p>Introduction:</p>.*<code class="ruby">}m
     end
 
+    it "does not resolve braces in fenced code inside an HTML block" do
+      markdown = <<-MARKDOWN
+<details>
+<summary>Example</summary>
+```ruby
+{contents: File.read(path)}
+{body}
+{city: "Paris", temperature: 15.0, conditions: "Cloudy"}
+{keep: 64}
+```
+</details>
+      MARKDOWN
+      markup_options = options
+      markup_options.markup = :markdown
+      markup_options.markup_provider = :redcarpet
+      allow(self).to receive(:options).and_return(markup_options)
+      allow(self).to receive(:object).and_return(Registry.root)
+      markup_helper = YARD::Templates::Helpers::MarkupHelper
+      markup_helper.clear_markup_cache
+
+      expect(log).not_to receive(:warn)
+      htmlify(markdown, :markdown)
+      markup_helper.clear_markup_cache
+    end
+
     it "sets env and env-yard attributes (AsciiDoc specific)" do
       skip "Missing asciidoctor gem" if markup_class(:asciidoc).nil?
 


### PR DESCRIPTION
# Description

This patch fixes a bug where a markdown file parsed by yardoc 
(with the redcarpet provider) would emit a warning because yard 
tries to parse Ruby code for doc references (eg "see {Foo}").

The bug requires that `<details><summary>..</summary></details>`
is used alongside a GitHub-flavored markdown codeblock. The 
redcarpet renderer might also be relevant, and the new test 
depends on it.

The diff is a bit noisy because I moved the previous `resolve_links` 
implementation into a private method. The actual new changes in 
lib/ are probably 3 lines, though.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
