### PR TITLE
Fix duplicated range warning in HybridMarkdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # main
 
 - Fix duplicate "View source" links after client-side navigation in default HTML template
+- Fix duplicated character class range warning in HybridMarkdown
 
 # [0.9.45] - July 14th, 2026
 

--- a/lib/yard/templates/helpers/markup/hybrid_markdown.rb
+++ b/lib/yard/templates/helpers/markup/hybrid_markdown.rb
@@ -555,7 +555,7 @@ module YARD
               index += 1
             end
 
-            output.gsub(/(^|[\s>])\+([^\s+\n](?:[^+\n]*?[^\s+\n])?)\+(?=$|[\s<.,;:!?)]|\z)/) do
+            output.gsub(/(^|[\s>])\+([^\s+](?:[^+\n]*?[^\s+])?)\+(?=$|[\s<.,;:!?)]|\z)/) do
               prefix = $1
               prefix + store_placeholder(placeholders, "<code>#{h(restore_placeholders($2, placeholders))}</code>")
             end


### PR DESCRIPTION
HybridMarkdown fires off a warning.

Ruby 3.4, YARD 0.9.45

```bash
ruby -w -ryard -e 'YARD::Templates::Helpers::Markup::HybridMarkdown.new("+code+").to_html'
```

This results in:
`/home/sk/.local/share/mise/installs/ruby/4.0.6/lib/ruby/gems/4.0.0/gems/yard-0.9.45/lib/yard/templates/helpers/markup/hybrid_markdown.rb:558: warning: character class has duplicated range`

# Proposed solution
Ruby's `\s` character class already includes newlines, so this removes the redundant `\n` exclusions without changing matching behavior.

The existing HybridMarkdown typewriter span spec covers the affected rendering behavior, and the changelog records the compatibility fix.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] Existing tests cover the behavior and I ran `bundle exec rake` locally.

# Verification

- `ruby -w -Ilib -e "require 'yard'; abort unless YARD::Templates::Helpers::Markup::HybridMarkdown.new('+code+').to_html == '<p><code>code</code></p>'"`
- `bundle exec rspec spec/templates/helpers/markup/hybrid_markdown_spec.rb`
- `bundle exec rake`

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md