### PR TITLE
Preserve default encodings when initializing Yardoc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # main
 
 - Fix duplicate "View source" links after client-side navigation in default HTML template
+- Stop changing Ruby's default encodings when initializing Yardoc
 
 # [0.9.45] - July 14th, 2026
 

--- a/lib/yard/cli/yardoc.rb
+++ b/lib/yard/cli/yardoc.rb
@@ -222,13 +222,6 @@ module YARD
         @save_yardoc = true
         @has_markup = false
         @fail_on_warning = false
-
-        if defined?(::Encoding) && ::Encoding.respond_to?(:default_external=)
-          utf8 = ::Encoding.find('utf-8')
-
-          ::Encoding.default_external = utf8 unless ::Encoding.default_external == utf8
-          ::Encoding.default_internal = utf8 unless ::Encoding.default_internal == utf8
-        end
       end
 
       def description

--- a/spec/cli/yardoc_spec.rb
+++ b/spec/cli/yardoc_spec.rb
@@ -82,6 +82,21 @@ RSpec.describe YARD::CLI::Yardoc do
     it "does not set any locale by default" do
       expect(@yardoc.options.locale).to be nil
     end
+
+    it "does not change Ruby's default encodings" do
+      internal = Encoding.default_internal
+      external = Encoding.default_external
+      Encoding.default_internal = nil
+      Encoding.default_external = Encoding::US_ASCII
+
+      CLI::Yardoc.new
+
+      expect(Encoding.default_internal).to be nil
+      expect(Encoding.default_external).to eq Encoding::US_ASCII
+    ensure
+      Encoding.default_internal = internal
+      Encoding.default_external = external
+    end if defined?(::Encoding)
   end
 
   describe "General options" do


### PR DESCRIPTION
# Description

`YARD::CLI::Yardoc.new` currently changes Ruby's process-wide default external and internal encodings to UTF-8. Ruby explicitly warns against changing these defaults at runtime, so constructing Yardoc with warnings enabled emits `warning: setting Encoding.default_internal`. It also unexpectedly overrides encoding defaults selected by the caller.

YARD source parsing already detects declared encodings and otherwise converts source to UTF-8 explicitly. This removes the initializer mutation while retaining `--charset` as the opt-in global encoding override. A regression spec verifies that Yardoc initialization preserves both defaults, and the changelog records the change.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally.

# Verification

- `ruby -w -Ilib -e "require 'yard'; internal = Encoding.default_internal; YARD::CLI::Yardoc.new; abort unless Encoding.default_internal == internal"`
- `bundle exec rspec spec/cli/yardoc_spec.rb`
- `bundle exec rake`

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md