### PR TITLE
Fix TypesExplainer parsing of nested collections in hash key position

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # main
 
+- Fix TypesExplainer parsing of nested collection types in Hash key position
 - Fix duplicate "View source" links after client-side navigation in default HTML template
 - Fix duplicated character class range warning in HybridMarkdown
 

--- a/lib/yard/tags/types_explainer.rb
+++ b/lib/yard/tags/types_explainer.rb
@@ -250,6 +250,14 @@ module YARD
             when :type_next
               # Comma - continue collecting keys unless we just processed a value
               # In that case, start a new key group
+            when :fixed_collection_start, :collection_start
+              klass = token_type == :collection_start ? CollectionType : FixedCollectionType
+              nested_types, = parse_until([:fixed_collection_end, :collection_end, :parse_end])
+              key_name = current_keys.last.instance_of?(Type) ? current_keys.pop.name : "Array"
+              current_keys << klass.new(key_name, nested_types)
+            when :hash_collection_start
+              key_name = current_keys.last.instance_of?(Type) ? current_keys.pop.name : "Hash"
+              current_keys << parse_hash_collection(key_name)
             when :hash_collection_value
               # => - current keys map to the next value(s)
               raise SyntaxError, "no keys before =>" if current_keys.empty?

--- a/spec/tags/types_explainer_spec.rb
+++ b/spec/tags/types_explainer_spec.rb
@@ -218,6 +218,34 @@ RSpec.describe YARD::Tags::TypesExplainer do
       expect(types.last.name).to eq "nil"
     end
 
+    it "parses a collection type in hash key position" do
+      types = parse("Hash{Array<Symbol> => Proc}")
+
+      expect(types.size).to eq 1
+      expect(types.first).to be_a(YARD::Tags::TypesExplainer::HashCollectionType)
+      expect(types.first.key_types.size).to eq 1
+      expect(types.first.key_types.first).to be_a(YARD::Tags::TypesExplainer::CollectionType)
+      expect(types.first.key_types.first.name).to eq "Array"
+      expect(types.first.key_types.first.types.map(&:name)).to eq ["Symbol"]
+      expect(types.first.value_types.map(&:name)).to eq ["Proc"]
+    end
+
+    it "parses fixed collection and hash types in hash key position" do
+      types = parse("Hash{(String, Integer) => Proc; Hash{Symbol => String}, Symbol => Object}")
+
+      expect(types.size).to eq 1
+      pairs = types.first.key_value_pairs
+      expect(pairs.size).to eq 2
+      expect(pairs[0][0].first).to be_a(YARD::Tags::TypesExplainer::FixedCollectionType)
+      expect(pairs[0][0].first.types.map(&:name)).to eq ["String", "Integer"]
+      expect(pairs[0][1].map(&:name)).to eq ["Proc"]
+      expect(pairs[1][0].first).to be_a(YARD::Tags::TypesExplainer::HashCollectionType)
+      expect(pairs[1][0].first.key_types.map(&:name)).to eq ["Symbol"]
+      expect(pairs[1][0].first.value_types.map(&:name)).to eq ["String"]
+      expect(pairs[1][0].last.name).to eq "Symbol"
+      expect(pairs[1][1].map(&:name)).to eq ["Object"]
+    end
+
     it "parses constant values" do
       type = parse("false, true, nil, 4, :foo")
       expect(type.map(&:name)).to eq ['false', 'true', 'nil', '4', ':foo']
@@ -265,7 +293,8 @@ RSpec.describe YARD::Tags::TypesExplainer do
         ":symbol, 'string'" => "a literal value :symbol; a literal value 'string'",
         "Hash{:key_one, :key_two => String; :key_three => Symbol}" => "a Hash with keys made of (a literal value :key_one or a literal value :key_two) and values of (Strings) and keys made of (a literal value :key_three) and values of (Symbols)",
         "Hash{:key_one, :key_two => String; :key_three => Symbol; :key_four => Hash{:sub_key_one => String}}" => "a Hash with keys made of (a literal value :key_one or a literal value :key_two) and values of (Strings) and keys made of (a literal value :key_three) and values of (Symbols) and keys made of (a literal value :key_four) and values of (a Hash with keys made of (a literal value :sub_key_one) and values of (Strings))",
-        "Hash{:key_one => String, Number; :key_two => String}" => "a Hash with keys made of (a literal value :key_one) and values of (Strings or Numbers) and keys made of (a literal value :key_two) and values of (Strings)"
+        "Hash{:key_one => String, Number; :key_two => String}" => "a Hash with keys made of (a literal value :key_one) and values of (Strings or Numbers) and keys made of (a literal value :key_two) and values of (Strings)",
+        "Hash{Array<Symbol> => Proc}" => "a Hash with keys made of (an Array of (Symbols)) and values of (Procs)"
       }
       expect.each do |input, expected|
         explain = YARD::Tags::TypesExplainer.explain(input)


### PR DESCRIPTION
# Description

`TypesExplainer::Parser#parse_hash_collection` only handles bare `:type_name` tokens on the key side of a `Hash{...}` type, so a nested collection in key position falls apart into flat key types: `Hash{Array<Symbol> => Proc}` parses as two keys (`Array`, `Symbol`) and the generic is silently dropped. The value side already handles this correctly because it goes through `parse_until`, which knows about `:collection_start` / `:fixed_collection_start` / `:hash_collection_start`. The gap dates back to #1630, which introduced `parse_hash_collection` with nested type support on the value side only.

```ruby
YARD::Tags::TypesExplainer.explain!("Hash{Array<Symbol> => Proc}")
# before: "a Hash with keys made of (Arrays or Symbols) and values of (Procs)"
# after:  "a Hash with keys made of (an Array of (Symbols)) and values of (Procs)"
```

Downstream this produces false positives in tools that round-trip the parsed types back to strings, e.g. rubocop-yard's `YARD/CollectionStyle` flags `Hash{Array<Symbol> => Proc}` and autocorrects it to a factually different type.

The fix adds the two missing token branches to the key side, dispatching to the existing nested parsing (`parse_until` for `<...>` and `(...)`, recursive `parse_hash_collection` for `{...}`) and wrapping the just-collected key name into the resulting collection type, the same way `parse_until` does. Behaviour for previously working inputs (multiple keys, literal keys, `;` separated pairs, nested hashes in value position) is unchanged; the full spec suite passes. The unreleased changelog records the fix.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
