### PR TITLE
Fix quadratic parsing of files with very large literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fix duplicate "View source" links after client-side navigation in default HTML template
 - Fix duplicated character class range warning in HybridMarkdown
+- Fix quadratic parsing slowdown on source files containing very large literals
 
 # [0.9.45] - July 14th, 2026
 

--- a/lib/yard/parser/ruby/ast_node.rb
+++ b/lib/yard/parser/ruby/ast_node.rb
@@ -210,7 +210,8 @@ module YARD
           until nodes.empty?
             node = nodes.pop
             yield node
-            nodes += node.children.reverse unless node.children.empty?
+            children = node.children
+            nodes.concat(children.reverse) unless children.empty?
           end
         end
 

--- a/lib/yard/parser/ruby/ruby_parser.rb
+++ b/lib/yard/parser/ruby/ruby_parser.rb
@@ -709,16 +709,21 @@ module YARD
           # insert any lone unadded comments before node
           root.traverse do |node|
             next if node.type == :list || node.parent.type != :list
-            @comments.keys.each do |line|
-              next unless node.line_range.include?(line)
-              pick = nil
-              node.traverse do |subnode|
-                next unless subnode.type == :list
-                pick ||= subnode
-                next unless subnode.line_range.include?(line)
-                pick = subnode
+            lines = @comments.keys.select {|line| node.line_range.include?(line) }
+            next if lines.empty?
+
+            # Collect the list subnodes once rather than re-traversing the
+            # whole subtree for every comment.
+            sublists = []
+            node.traverse {|subnode| sublists << subnode if subnode.type == :list }
+            next if sublists.empty?
+
+            lines.each do |line|
+              pick = sublists.first
+              sublists.each do |subnode|
+                pick = subnode if subnode.line_range.include?(line)
               end
-              add_comment(line, nil, pick, true) if pick
+              add_comment(line, nil, pick, true)
             end
           end unless @comments.empty?
 


### PR DESCRIPTION
# Description

Parsing the uts58 gem never finished inside 600 seconds. Its constants
file is 138,233 lines holding two generated hash literals, which come
out as 691,342 AST nodes. The widest node is a hash with 138,157 direct
children. The gem now parses in 3.3 seconds and a full yard doc run
takes 7.3 seconds.

Two things were quadratic.

AstNode#traverse grew its pending queue with `nodes +=
node.children.reverse`, which allocates a new array and copies the whole
queue every time it visits a node that has children. The wide hash node
pushes 138,157 children at once, and each of those has children of its
own, so the loop copies a queue tens of thousands of entries long once
per child. concat appends in place instead.

RipperParser#insert_comments walked a node's entire subtree once per
comment to choose the :list node to attach that comment to. It takes the
last :list in traversal order whose line range covers the comment, and
falls back to the first :list it saw. That set cannot change while
comments are being attached, because add_comment only ever inserts
:comment nodes, so collect it once per candidate node and reuse it.

Both changes are needed. Alone, the traversal fix leaves the gem at 21
seconds and the comment fix leaves it at 155. Parse time is now linear
in file size: 10k, 20k, 40k and 80k line excerpts take 0.18s, 0.31s,
0.64s and 1.29s.

The full suite passes, 2793 examples, 0 failures. Dumping every code
object, docstring and tag from YARD's own lib and spec trees before and
after gives the same output apart from line numbers inside the two
edited files.

# Completed Tasks

- [x] I have read the [Contributing Guide][contrib].
- [x] The pull request is complete (implemented / written).
- [x] Git commits have been cleaned up (squash WIP / revert commits).
- [x] I wrote tests and ran `bundle exec rake` locally (if code is attached to PR).

[contrib]: https://github.com/lsegal/yard/blob/main/CONTRIBUTING.md
